### PR TITLE
Fix rebase to detect same commit is up-to-date.

### DIFF
--- a/lib/slmu/slmu_rebase.js
+++ b/lib/slmu/slmu_rebase.js
@@ -398,10 +398,15 @@ exports.rebase = co.wrap(function *(metaRepo, commit) {
     // First, see if 'commit' already exists in the current history.  If so, we
     // can exit immediately.
 
-    const isFF =
+    let upToDate = currentCommitId.equal(commitId);
+
+    if (!upToDate) {
+        upToDate =
          yield NodeGit.Graph.descendantOf(metaRepo, currentCommitId, commitId);
-    if (isFF) {
-        console.log(`${colors.green(currentBranch.shorthand())} is uptodate.`);
+    }
+    if (upToDate) {
+        console.log(`${colors.green(currentBranch.shorthand())} is \
+up-to-date.`);
         return;                                                       // RETURN
     }
 


### PR DESCRIPTION
I recently changed it to use `Graph.descendantOf` instead of some custom
algorithm I had written, but the behaviors differed in an important way --
mine considered (probably wrongly) a commit to be a descendant of itself.
