### PR TITLE
fix 'ensureClean' to find wrong submodule commits

### DIFF
--- a/lib/slmu/slmu_status.js
+++ b/lib/slmu/slmu_status.js
@@ -630,11 +630,17 @@ exports.ensureClean = co.wrap(function *(metaRepo) {
     }
 
     const submodules = yield SubmoduleUtil.getSubmoduleRepos(metaRepo);
+    const submoduleNames = submodules.map(sub => sub.name);
+    const head = yield metaRepo.getHeadCommit();
+    const expectedShas = yield SubmoduleUtil.getSubmoduleShasForCommit(
+                                                                metaRepo,
+                                                                submoduleNames,
+                                                                head);
     let allGood = true;
     const checkers = submodules.map(sub => co(function *() {
         const repo = sub.repo;
         const stat = yield getRepoStatus(repo);
-        if (!stat.isClean()) {
+        if (expectedShas[sub.name] !== stat.headCommit || !stat.isClean()) {
             console.error(`Sub-repo ${colors.blue(sub.name)} is not \
 clean.`);
             allGood = false;


### PR DESCRIPTION
Previously, it was not checking to see if the submodule was on the commit
expected in the meta-repo.
