### PR TITLE
[DO NOT MERGE] Bash completion proof of concept

### DIFF
--- a/lib/autocomplete/autocomplete.js
+++ b/lib/autocomplete/autocomplete.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+/**
+ * This module contains the bash autocomplete functionality for `git-meta`
+ */
+
+const co 	   = require('co');
+const omelette = require('omelette');
+
+const branch     = require("./../metac/metac_branch");
+const checkout   = require("./../metac/metac_checkout");
+const cherryPick = require("./../metac/metac_cherrypick");
+const close      = require("./../metac/metac_close");
+const commit     = require("./../metac/metac_commit");
+const include    = require("./../metac/metac_include");
+const merge      = require("./../metac/metac_merge");
+const open       = require("./../metac/metac_open");
+const pull       = require("./../metac/metac_pull");
+const push       = require("./../metac/metac_push");
+const rebase     = require("./../metac/metac_rebase");
+const status     = require("./../metac/metac_status");
+const version    = require("./../metac/metac_version");
+
+const GitUtil    = require("./../metau/metau_gitutil");
+
+
+const isOption = function(arg) {
+	return arg.indexOf("-") == 0;
+}
+
+exports.isCompletion = function() {
+	const completionArg = "--compgen";
+	const configArg = "--completion";
+	return process.argv.indexOf(completionArg) > -1
+		|| process.argv.indexOf(configArg) > -1;
+}
+
+exports.autocomplete = co.wrap(function *() {
+	const meta = omelette('git-meta');
+	const parser = require('./parser');
+
+	var metac = [branch, checkout, cherryPick, close, commit, include, merge, open, pull, push, rebase, status, version];
+
+	for (var i = 0; i < 13; ++i) {
+		// TODO (edy): don't set commandName
+		parser.commandName = metac[i].command;
+		metac[i].configureParser(parser);
+	}
+
+	// Complete event is emitted by omelette when it detects a tab completion
+
+	meta.on("complete", co.wrap(function *(frag, word, line) {
+		const args = line.split(" ");
+	
+		let currentCommand = parser.completers, currentOption, currentCompleter;
+
+		// Ignore first argument as it will be `git-meta`
+		// continue to parse arguments to predict how to complete
+
+		for (let i = 1; i < args.length - 1; ++i) {
+			const arg = args[i];
+
+			// If there is an active completer, it has been fulfilled since there
+			// is a next argument
+			if (currentCompleter) {
+				currentCompleter = null;
+				continue;
+			}
+
+			currentCompleter = null;
+			currentOption = null;
+
+			// If the argument being parsed is an option, then search the current 
+			// command for that option
+
+			if (isOption(arg)) {
+				if (arg in currentCommand.options) {
+					currentOption = currentCommand.options[arg];
+					currentCompleter = currentOption.completer;
+				}
+			}
+
+			// Else if the argument is not an option, then it could be a nested command
+
+			else if (currentCommand.commands && arg in currentCommand.commands) {
+				currentCommand = currentCommand.commands[arg];
+			} 
+
+			// Otherwise, assume it to be a positional argument. If there are no possible 
+			// arguments, simply return no possibilites
+
+			else {
+				if (!currentCommand.positionals || currentCommand.positionals.length == 0) {
+					return this.reply([]);
+				}
+				currentCommand.positionals.shift();
+			}
+		}
+
+		// At this point:
+		// currentCommand will point to a obj with possibly options or positional arguments.
+		// currentOption will be either null or point to a selected option
+		// currentCompleter will be either null or point to a completer
+
+		const lastArg = args[args.length - 1];
+
+		// If there is a completer, return the values generated by the completer
+
+		if (currentCompleter) {
+			return yield currentCompleter(lastArg);
+		} 
+
+		// Else if its an option (--), return possible completions
+		else if (isOption(lastArg)) {
+			return this.reply(Object.keys(currentCommand.options).filter(opt => opt.indexOf(lastArg) > -1));
+		}
+
+		// Then match subcommands
+		else if (currentCommand.commands) {
+			return this.reply(Object.keys(currentCommand.commands).filter(cmd => cmd.indexOf(lastArg) > -1));
+		}
+
+		// Ensure there are no positionals left
+		else if (currentCommand.positionals.length > 0) {
+			const posi = currentCommand.positionals.shift();
+			if (posi.completer) {
+				const options = yield posi.completer(lastArg);
+				return this.reply(options);
+			} else {
+				return this.reply([posi.defaultValue]);
+			}
+		}
+
+		// Finally, give up and return no possible values
+		return this.reply([]);
+
+	}));
+
+	meta.init();
+});

--- a/lib/autocomplete/completers.js
+++ b/lib/autocomplete/completers.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+/**
+ * This module contains default completers for common use cases such as 
+ * branch names.
+ */
+
+const assert  = require("chai").assert;
+const co      = require("co");
+const NodeGit = require("nodegit");
+
+const GitUtil    = require("./../metau/metau_gitutil");
+const TestUtil   = require("./../metau/metau_testutil");
+
+/**
+ * Each completer will take in the current repo, prefix (what has been 
+ * entered so far) and return an array of possible results.
+ * 
+ * @async
+ * @param {String}             prefix
+ * @return {String []}
+ */
+exports.branch = co.wrap(function *(prefix) {
+    const repo = yield GitUtil.getCurrentRepo();
+	const refs = yield repo.getReferenceNames(NodeGit.Reference.TYPE.LISTALL);
+	const options = [];
+	for (let i = 0; i < refs.length; ++i) {
+        const refName = refs[i];
+        const ref = yield NodeGit.Reference.lookup(repo, refName);
+        if (ref.isBranch()) {
+        	options.push(ref.shorthand());
+        }
+    }
+	return options.filter(name => name.indexOf(prefix) > -1);
+});

--- a/lib/autocomplete/parser.js
+++ b/lib/autocomplete/parser.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+/**
+ * This submodule provides parsing of completers for use in bash completion
+ */
+
+module.exports = {
+	completers: { commands: {}, options: {} },
+
+	commandName: "",
+
+	// TODO (edy): comments
+	// args can be name or flag or [name] or [flags...] as per argparse
+	addArgument: function (args, params) {
+		// TODO (edy): don't modify args
+		if (!Array.isArray(args)) {
+			args = [args];
+		}
+
+		if (!(this.commandName in this.completers.commands))
+			this.completers.commands[this.commandName] = { options: {}, positionals: [] };
+		
+		for (let i in args) {
+			const arg = args[i];
+
+			// being a flag implies no positional significance
+
+			if (arg.indexOf("-") == 0) {
+				this.completers.commands[this.commandName].options[arg] = params;
+			} 
+
+			// not having a flag means positional significance
+
+			else {
+				this.completers.commands[this.commandName].positionals.push(params);
+			}
+		}
+	}
+};

--- a/lib/git-meta.js
+++ b/lib/git-meta.js
@@ -37,6 +37,7 @@
 
 const ArgumentParser = require("argparse").ArgumentParser;
 
+const autocomplete = require("./autocomplete/autocomplete.js");
 const branch     = require("./metac/metac_branch");
 const checkout   = require("./metac/metac_checkout");
 const cherryPick = require("./metac/metac_cherrypick");
@@ -119,6 +120,9 @@ configureSubcommand(subParser, rebase);
 configureSubcommand(subParser, status);
 configureSubcommand(subParser, version);
 
-const args = parser.parseArgs();
-
-args.func(args);
+if (autocomplete.isCompletion()) {
+    autocomplete.autocomplete();
+} else {
+    const args = parser.parseArgs();
+    args.func(args);
+}

--- a/lib/git-meta.js
+++ b/lib/git-meta.js
@@ -54,17 +54,17 @@ const version    = require("./metac/metac_version");
 const UserError  = require("./metau/metau_usererror");
 
 /**
- * Configure the specified `parser` to include the command having the specified
- * `commandName` implemented in the specified `module`.
+ * Configure the specified `parser` to include the command 
+ * implemented in the specified `module`.
  *
  * @param {ArgumentParser} parser
- * @param {String}         commandName
  * @param {Object}         module
  * @param {Function}       module.configureParser
  * @param {Function}       module.executeableSubcommand
  * @param {String}         module.helpText
  */
-function configureSubcommand(parser, commandName, module) {
+function configureSubcommand(parser, module) {
+    const commandName = module.command;
     const subParser = parser.addParser(commandName, {
         help: module.helpText,
         description: module.description,
@@ -105,19 +105,19 @@ const parser = new ArgumentParser({
 
 const subParser = parser.addSubparsers({});
 
-configureSubcommand(subParser, "branch", branch);
-configureSubcommand(subParser, "checkout", checkout);
-configureSubcommand(subParser, "cherry-pick", cherryPick);
-configureSubcommand(subParser, "close", close);
-configureSubcommand(subParser, "commit", commit);
-configureSubcommand(subParser, "include", include);
-configureSubcommand(subParser, "merge", merge);
-configureSubcommand(subParser, "open", open);
-configureSubcommand(subParser, "pull", pull);
-configureSubcommand(subParser, "push", push);
-configureSubcommand(subParser, "rebase", rebase);
-configureSubcommand(subParser, "status", status);
-configureSubcommand(subParser, "version", version);
+configureSubcommand(subParser, branch);
+configureSubcommand(subParser, checkout);
+configureSubcommand(subParser, cherryPick);
+configureSubcommand(subParser, close);
+configureSubcommand(subParser, commit);
+configureSubcommand(subParser, include);
+configureSubcommand(subParser, merge);
+configureSubcommand(subParser, open);
+configureSubcommand(subParser, pull);
+configureSubcommand(subParser, push);
+configureSubcommand(subParser, rebase);
+configureSubcommand(subParser, status);
+configureSubcommand(subParser, version);
 
 const args = parser.parseArgs();
 

--- a/lib/metac/metac_branch.js
+++ b/lib/metac/metac_branch.js
@@ -37,6 +37,12 @@ const co      = require("co");
  */
 
 /**
+ * name of the `branch` command
+ * @property {String}
+ */
+exports.command = `branch`;
+
+/**
  * help text for the `branch` command
  * @property {String}
  */

--- a/lib/metac/metac_checkout.js
+++ b/lib/metac/metac_checkout.js
@@ -35,6 +35,12 @@ const co = require("co");
  * This module contains the entrypoint for the `checkout` command.
  */
 
+/**
+ * name of the `checkout` command
+ * @property {String}
+ */
+exports.command = `checkout`;
+
 exports.helpText = `Check out a branch in the meta-repository and each
 (visible) sub-repository.`;
 

--- a/lib/metac/metac_checkout.js
+++ b/lib/metac/metac_checkout.js
@@ -51,9 +51,12 @@ exports.helpText = `Check out a branch in the meta-repository and each
  */
 exports.configureParser = function (parser) {
 
+    const completers = require('./../autocomplete/completers');
+    
     parser.addArgument(["branchname"], {
         type: "string",
         help: "name of the branch",
+        completer: completers.branch,
     });
 
     parser.addArgument(["-c", "--create"], {

--- a/lib/metac/metac_cherrypick.js
+++ b/lib/metac/metac_cherrypick.js
@@ -37,6 +37,12 @@ const co = require("co");
  */
 
 /**
+ * name of the `cherry-pick` command
+ * @property {String}
+ */
+exports.command = `cherry-pick`;
+
+/**
  * help text for the `cherry-pick` command
  * @property {String}
  */

--- a/lib/metac/metac_close.js
+++ b/lib/metac/metac_close.js
@@ -36,6 +36,12 @@ const co = require("co");
  */
 
 /**
+ * name of the `close` command
+ * @property {String}
+ */
+exports.command = `close`;
+
+/**
  * help text associated with the `close` command.
  *
  * @property {String}

--- a/lib/metac/metac_commit.js
+++ b/lib/metac/metac_commit.js
@@ -34,6 +34,12 @@
  */
 
 /**
+ * name of the `commit` command
+ * @property {String}
+ */
+exports.command = `commit`;
+
+/**
  * help text for the `commit` command
  *
  * @property {String}

--- a/lib/metac/metac_include.js
+++ b/lib/metac/metac_include.js
@@ -37,6 +37,12 @@
 const co = require("co");
 
 /**
+ * name of the `commit` command
+ * @property {String}
+ */
+exports.command = `commit`;
+
+/**
  * help text for the `include` command
  *
  * @property {String}

--- a/lib/metac/metac_merge.js
+++ b/lib/metac/metac_merge.js
@@ -36,6 +36,12 @@ const co = require("co");
  */
 
 /**
+ * name of the `merge` command
+ * @property {String}
+ */
+exports.command = `merge`;
+
+/**
  * help text for the `merge` command
  * @property {String}
  */

--- a/lib/metac/metac_open.js
+++ b/lib/metac/metac_open.js
@@ -36,6 +36,12 @@
 const co = require("co");
 
 /**
+ * name of the `open` command
+ * @property {String}
+ */
+exports.command = `open`;
+
+/**
  * help text for the `open` command
  *
  * @property {String}

--- a/lib/metac/metac_pull.js
+++ b/lib/metac/metac_pull.js
@@ -37,6 +37,12 @@ const co = require("co");
  */
 
 /**
+ * name of the `pull` command
+ * @property {String}
+ */
+exports.command = `pull`;
+
+/**
  * help text for the `pull` command
  * @property {String}
  */

--- a/lib/metac/metac_push.js
+++ b/lib/metac/metac_push.js
@@ -37,6 +37,12 @@ const co = require("co");
  */
 
 /**
+ * name of the `push` command
+ * @property {String}
+ */
+exports.command = `push`;
+
+/**
  * help text for the `push` command
  * @property {String}
  */

--- a/lib/metac/metac_rebase.js
+++ b/lib/metac/metac_rebase.js
@@ -36,6 +36,12 @@ const co = require("co");
  */
 
 /**
+ * name of the `rebase` command
+ * @property {String}
+ */
+exports.command = `rebase`;
+
+/**
  * help text for the `rebase` command
  * @property {String}
  */

--- a/lib/metac/metac_status.js
+++ b/lib/metac/metac_status.js
@@ -38,6 +38,12 @@ const colors = require("colors/safe");
  */
 
 /**
+ * name of the `status` command
+ * @property {String}
+ */
+exports.command = `status`;
+
+/**
  * help text for the `pull` command
  * @property {String}
  */

--- a/lib/metac/metac_version.js
+++ b/lib/metac/metac_version.js
@@ -35,6 +35,12 @@
  */
 
 /**
+ * name of the `version` command
+ * @property {String}
+ */
+exports.command = `version`;
+
+/**
  * help text for the `version` command
  * @property {String}
  */

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "test": "mocha test"
   },
-  "directories": {
-  },
+  "directories": {},
   "bin": {
     "git-meta": "./lib/git-meta.js"
   },
@@ -27,18 +26,19 @@
   "preferGlobal": true,
   "homepage": "https://github.com/twosigma/git-meta#readme",
   "dependencies": {
-      "argparse": "",
-      "chai": "",
-      "child-process-promise": "",
-      "nodegit": "",
-      "co": "",
-      "fs-promise": "",
-      "rimraf": "",
-      "colors": ""
+    "argparse": "",
+    "chai": "",
+    "child-process-promise": "",
+    "co": "",
+    "colors": "",
+    "fs-promise": "",
+    "nodegit": "",
+    "omelette": "^0.3.1",
+    "rimraf": ""
   },
   "devDependencies": {
-      "mocha": "",
-      "mocha-jshint": "",
-      "temp": ""
+    "mocha": "",
+    "mocha-jshint": "",
+    "temp": ""
   }
 }


### PR DESCRIPTION
This is a first iteration of #5 for proof of concept

Implementation details:
- Run `git-meta --completion` to generate the bash script. Source this (this can be automated simply by saving it to `/usr/local/etc/bash_completion.d/` later)
- In `node_modules/omelette/src/omelette.js`, comment out line 58 (`return process.exit();`). Reason: since bash completion must occur before other codepaths are run (or to be exact, should be run instead of other codepaths), omelette was written in a way that emits the events, then force calls process.exit. However, since our code uses promises, the process.exit may be called before our promise is fulfilled in the event loop. 

Some terminology I use:

- option - flag that starts with - or --
- completer - method that is called to "complete" based on a given prefix
- command - command or sub-command
- positional - positional argument 
