### PR TITLE
add -q option to `git fetch`

### DIFF
--- a/lib/util/gitutil.js
+++ b/lib/util/gitutil.js
@@ -291,7 +291,7 @@ exports.fetch = co.wrap(function *(repo, remoteName) {
 
     const execString = `\
 cd '${repo.workdir()}'
-git fetch '${remoteName}'
+git fetch -q '${remoteName}'
 `;
     try {
         return yield exec(execString);


### PR DESCRIPTION
we don't output result anyway, and non-silent version causes buffer overrun
