### PR TITLE
submodule support for AST/shorthand

### DIFF
--- a/lib/util/repoast.js
+++ b/lib/util/repoast.js
@@ -39,6 +39,45 @@ const assert   = require("chai").assert;
 const deepCopy = require("deepcopy");
 
 /**
+ * @class {Submodule}
+ *
+ * This class represents the definition of a submodule in a repository.
+ */
+class Submodule {
+
+    /**
+     * Create a `Submodule` having the specified `url` and `sha`.
+     *
+     * @constructor
+     * @param {String} url
+     * @param {String} sha
+     */
+    constructor(url, sha) {
+        assert.isString(url);
+        assert.isString(sha);
+        this.d_url = url;
+        this.d_sha = sha;
+        Object.freeze(this);
+    }
+
+    /**
+     * @property {String} url upstream location of submodule
+     */
+    get url() {
+        return this.d_url;
+    }
+
+    get sha() {
+        return this.d_sha;
+    }
+}
+
+Submodule.prototype.toString = function () {
+    return `Submodule(url=${this.d_url}, sha=${this.d_sha})`;
+};
+
+
+/**
  * This module provides the RepoAST class and associated classes.  Supported
  * configurations will be added (and documented here) as they are added.
 
@@ -76,7 +115,10 @@ class Commit {
             assert.isObject(args.changes);
             for (let path in args.changes) {
                 const content = args.changes[path];
-                assert.isString(content, path);
+
+                if (null !== content && !(content instanceof Submodule)) {
+                    assert.isString(content, path);
+                }
                 this.d_changes[path] = content;
             }
         }
@@ -93,10 +135,17 @@ class Commit {
     /**
      * @property {Object} changes map from path to new (string) value
      *
-     * an entry mapped to null indicates a deletion
+     * changes may be:
+     * 1. string -- raw data for the path
+     * 2. null   -- indicates deletion of file at path
+     * 3. Submodule -- indicates addition/change of submodule at path
      */
     get changes() {
-        return deepCopy(this.d_changes);
+        let result = {};
+        for (let key in this.d_changes) {
+            result[key] = this.d_changes[key];
+        }
+        return result;
     }
 }
 
@@ -167,7 +216,9 @@ class AST {
      * `branch` or by `head`, that is, it is pointed to by a reference or is a
      * direct or indirect ancestor of a commit that is.  The behavior is
      * undefined if `currentBranchName` is set but `head` is not null and does
-     * not indicate the same branch as the current branch.
+     * not indicate the same branch as the current branch.  The behavior is
+     * undefined unless every deletion described by a commit references a path
+     * that would have existed.
      *
      * @param {Object}      args
      * @param {Object}      [args.commits]
@@ -329,6 +380,62 @@ class AST {
     }
 
     /**
+     * Return a map from path to change reflecting the state of the repository
+     * that would be expected were the commit with the specified `commitId`
+     * checked out -- basically, accumulating changes from root to `commit`,
+     * referencing commits in the specified `commitMap`.  The behavior is
+     * undefined unless `commitId` refers to a `Commit` object in `commitMap`
+     * and the commits are consistent as described in the constructor of `AST`.
+     * Use the specified `cache` to store intermediate (and final) results; if
+     * `commitId` already exists in `cache` return the value stored in `cache`.
+     *
+     * Note that this method is needed on `AST` because it will be used to
+     * validate preconditions in the constructor.
+     *
+     * @param {Object} cache
+     * @param {Object} commitMap
+     * @param {String} commitId
+     * @return {Object} maps from path to change
+     */
+    static renderCommit(cache, commitMap, commitId) {
+        assert.isObject(cache);
+        assert.isObject(commitMap);
+        assert.isString(commitId);
+
+        if (commitId in cache) {
+            return cache[commitId];
+        }
+
+        assert.property(commitMap, commitId);
+
+        const commit = commitMap[commitId];
+        let result = {};
+
+        if (0 !== commit.parents.length) {
+            // We need traverse only the left-most parent.  Changes are against
+            // the left parent.
+
+            Object.assign(
+                        result,
+                        AST.renderCommit(cache, commitMap, commit.parents[0]));
+        }
+
+        for (let path in commit.changes) {
+            const change = commit.changes[path];
+
+            if (null === change) {
+                assert.property(result, path);
+                delete result[path];
+            }
+            else {
+                result[path] = change;
+            }
+        }
+        cache[commitId] = result;
+        return result;
+    }
+
+    /**
      * Return a copy of this object replacing the properties in the specified
      * `args`.
      *
@@ -357,4 +464,5 @@ class AST {
 
 AST.Commit = Commit;
 AST.Remote = Remote;
+AST.Submodule = Submodule;
 module.exports = AST;

--- a/lib/util/repoastioutil.js
+++ b/lib/util/repoastioutil.js
@@ -39,107 +39,44 @@
 
 const assert   = require("chai").assert;
 const co       = require("co");
-const fs       = require("fs-promise");
+const exec     = require("child-process-promise").exec;
 const NodeGit  = require("nodegit");
-const path     = require("path");
 
-const RepoAST      = require("../util/repoast");
-const RepoASTUtil  = require("../util/repoastutil");
-const TestUtil     = require("../util/testutil");
+const RepoAST             = require("../util/repoast");
+const RepoASTUtil         = require("../util/repoastutil");
+const SubmoduleConfigUtil = require("../util/submodule_config_util");
+const TestUtil            = require("../util/testutil");
 
                          // Begin module-local methods
 
 /**
- * Write the specified `commit` to the specified `repo` and return its id.
- *
- * @private
+ * Exec the specified `string` and return the result, omitting the "\n" at the
+ * end.
  * @async
- * @param {NodeGit.Repository} repo
- * @param {RepoAST.Commit}     commit
- * @return {NodeGit.Oid}
+ * @private
+ * @param {String} string
+ * @return {String}
  */
-const writeRootCommit = co.wrap(function *(repo, commit) {
-    assert.instanceOf(repo, NodeGit.Repository);
-    assert.instanceOf(commit, RepoAST.Commit);
-    assert.equal(commit.parents.length, 0);
-
-    const sig = repo.defaultSignature();
-    const odb = yield repo.odb();
-    const treeBuilder = yield NodeGit.Treebuilder.create(repo, null);
-
-    // Now we need to create a blob for each changed file and write to the
-    // tree.
-
-    for (let path in commit.changes) {
-        const data = commit.changes[path];
-        const blobId = yield odb.write(data,
-                                       data.length,
-        NodeGit.Object.TYPE.BLOB);
-        yield treeBuilder.insert(path,
-                                 blobId,
-                                 NodeGit.TreeEntry.FILEMODE.BLOB);
-    }
-
-    const treeId = treeBuilder.write();
-    const tree = yield NodeGit.Tree.lookup(repo, treeId);
-
-    // Now create the commit.
-
-    const newCommitId = NodeGit.Commit.create(repo,
-                                              null,
-                                              sig,
-                                              sig,
-                                              null,
-                                              "a commit message",
-                                              tree,
-                                              0,
-                                              []);
-    return newCommitId;
+const doExec = co.wrap(function *(string) {
+    const result = yield exec(string);
+    return result.stdout.split("\n")[0];
 });
 
 /**
- * Write the specified `commit` in the specified `repo` having the specified
- * `parent` commits.
+ * Write the specified `data` to the specified `repo` and return its hash
+ * value.
  *
- * @private
  * @async
+ * @private
  * @param {NodeGit.Repository} repo
- * @param {RepoAST.Commit}     commit
- * @param {NodeGit.Oid []}     parents
+ * @param {String}             data
+ * @return {String}
  */
-const writeChildCommit = co.wrap(function *(repo, commit, parents) {
-    assert.instanceOf(repo, NodeGit.Repository);
-    assert.instanceOf(commit, RepoAST.Commit);
-    assert.isArray(parents);
-    parents.forEach(id => assert.instanceOf(id, NodeGit.Oid));
-    assert(1 === parents.length);  // for now, just support single parent
-
-    // Put the parent on HEAD
-
-    const parentId = parents[0];
-    repo.setHeadDetached(parentId);
-    const parentCommit = yield repo.getCommit(parentId);
-    yield NodeGit.Reset.reset(repo, parentCommit, NodeGit.Reset.TYPE.HARD);
-
-    // Write files.
-
-    const workdir = repo.workdir();
-    let changedFiles = [];
-    for (let fileName in commit.changes) {
-        changedFiles.push(fileName);
-        let absPath = path.join(workdir, fileName);
-        yield fs.writeFile(absPath, commit.changes[fileName]);
-    }
-
-    // Make commit.
-
-    const sig = repo.defaultSignature();
-
-    const id = yield repo.createCommitOnHead(changedFiles,
-                                             sig,
-                                             sig,
-                                             "a commit");
-    return id;
+const hashObject = co.wrap(function *(repo, data) {
+    const db = yield repo.odb();
+    const BLOB = 3;
+    const res = yield db.write(data, data.length, BLOB);
+    return res.tostrS();
 });
 
 /**
@@ -157,49 +94,96 @@ const writeChildCommit = co.wrap(function *(repo, commit, parents) {
 const writeCommits = co.wrap(function *(repo, commits) {
     let oldCommitMap = {};  // from old to new sha
     let newCommitMap = {};  // from new to old sha
+    let renderCache = {};   // used to render commits
     const writeCommit = co.wrap(function *(sha) {
+        // TODO: extend libgit2 and nodegit to allow submoduel manipulations to
+        // `TreeBuilder`.  For now, we will do this ourselves using the `git`
+        // commandline tool.
+        //
+        // - First, we calculate the tree describred by the commit at `sha`.
+        // - Then, we build a string that describes that as if it were output
+        //   by `ls-tree`.
+        // - Next, we invoke `git-mktree` to create a tree id
+        // - finally, we invoke `git-commit-tree` to create the commit.
+
+        // Bail out if already written.
 
         if (sha in oldCommitMap) {
             return oldCommitMap[sha];
         }
 
-        const commitInfo = commits[sha];
-        const parents = commitInfo.parents;
+        // Recursively get commit ids for parents.
 
-        assert(1 >= parents.length, "TODO: merge commits");
+        const commit = commits[sha];
+        const parents = commit.parents;
 
-        // NOTE: in theory, the method of creating trees and not touching the
-        // working directory could be used to write all commits, but it seems
-        // to be triggering undefined behavior (fails and sometimes segfaults).
-        // As this functionality is currently non-critical (i.e., just used for
-        // testing), I'm going to work around it rather than attempting to
-        // debug libgit2.  For now, we will write root commits without touching
-        // the workdir (via `writeRootCommit`) and all others by working in the
-        // workdir.
-
-        let newCommitId = null;
-        if (0 === parents.length) {
-            newCommitId = yield writeRootCommit(repo, commitInfo);
+        let newParents = [];  // Array of commit IDs
+        for (let i = 0; i < parents.length; ++i) {
+            let parentSha = yield writeCommit(parents[i]);
+            newParents.push(NodeGit.Oid.fromString(parentSha));
         }
-        else {
-            // Recursively process parents; can't write this commit until
-            // parents are done.
 
-            let newParents = [];  // Array of commit IDs
-            for (let i = 0; i < parents.length; ++i) {
-                let parentSha = yield writeCommit(parents[i]);
-                newParents.push(NodeGit.Oid.fromString(parentSha));
+        // Calculate the tree.
+        // `tree` describes the directory tree specified by the commit at
+        // `sha`.
+
+        const tree = RepoAST.renderCommit(renderCache, commits, sha);
+
+        // Build the tree file; build the `.gitmodules` file as submodules are
+        // seen.
+
+        let gitModulesData = "";
+        let treeData = "";
+
+        function addToTree(fileType, dataType, id, path) {
+            if ("" !== treeData) {
+                treeData += "\n";
             }
-
-            newCommitId = yield writeChildCommit(repo, commitInfo, newParents);
+            treeData += `${fileType} ${dataType} ${id}\t${path}`;
         }
 
-        // Record the commit information in relevant maps.
+        const addFile = co.wrap(function *(path, data) {
+            const id = yield hashObject(repo, data);
+            addToTree("100644", "blob", id, path);
+        });
 
-        const newSha = newCommitId.tostrS();
-        oldCommitMap[sha] = newSha;
-        newCommitMap[newSha] = sha;
-        return newSha;
+        for (let path in tree) {
+            const change = tree[path];
+            if (change instanceof RepoAST.Submodule) {
+                const modulesStr = `\
+[submodule "${path}"]
+\tpath = ${path}
+\turl = ${change.url}
+`;
+                const newSha = yield writeCommit(change.sha);
+                gitModulesData += modulesStr;
+                addToTree("160000", "commit", newSha, path);
+            }
+            else {
+                yield addFile(path, change);
+            }
+        }
+
+        if ("" !== gitModulesData) {
+            yield addFile(SubmoduleConfigUtil.modulesFileName, gitModulesData);
+        }
+
+        const makeTreeExecString = `\
+cd ${repo.path()}
+echo '${treeData}' | git mktree
+`;
+        const treeId = yield doExec(makeTreeExecString);
+
+        let makeCommitString = `\
+cd ${repo.path()}
+git commit-tree -m commit ${treeId}`;
+        if (0 !== newParents.length) {
+            makeCommitString += ` -p ${newParents[0]}`;
+        }
+        const commitId = yield doExec(makeCommitString);
+        oldCommitMap[sha] = commitId;
+        newCommitMap[commitId] = sha;
+        return commitId;
     });
 
     for (let sha in commits) {
@@ -234,17 +218,6 @@ const configureRepo = co.wrap(function *(repo, ast, commitMap) {
     let newHeadSha = null;
     if (null !== ast.head) {
         newHeadSha = commitMap[ast.head];
-        const headCommit = yield repo.getCommit(newHeadSha);
-        yield NodeGit.Reset.reset(repo, headCommit, NodeGit.Reset.TYPE.HARD);
-        repo.detachHead();
-    }
-
-    // Make sure any existing branches are gone.
-
-    const existingBranches = yield repo.getReferences(
-                                               NodeGit.Reference.TYPE.LISTALL);
-    for (let i = 0; i < existingBranches.length; ++i) {
-        NodeGit.Branch.delete(existingBranches[i]);
     }
 
     // Then create the branches we want.
@@ -270,30 +243,48 @@ const configureRepo = co.wrap(function *(repo, ast, commitMap) {
     // Deal with bare repos.
 
     if (null === ast.head) {
-        const oldPath = repo.workdir();
-        const temp = yield TestUtil.makeTempDir();
-        yield fs.rename(oldPath, temp);
-        const newPlaceRepo = yield NodeGit.Repository.open(temp);
-        const bareRepo = yield TestUtil.makeBareCopy(newPlaceRepo, oldPath);
         if (null !== ast.currentBranchName) {
-            bareRepo.setHead("refs/heads/" + ast.currentBranchName);
+            repo.setHead("refs/heads/" + ast.currentBranchName);
         }
-        return bareRepo;
     }
-
-    // Set head or current branch for non-remotes.
-
-    if (null !== ast.currentBranchName) {
+    else if (null !== ast.currentBranchName) {
         const currentBranch =
                    yield repo.getBranch("refs/heads/" + ast.currentBranchName);
         yield repo.checkoutBranch(currentBranch);
     }
     else {
+        const headCommit = yield repo.getCommit(newHeadSha);
         repo.setHeadDetached(newHeadSha);
+        yield NodeGit.Reset.reset(repo, headCommit, NodeGit.Reset.TYPE.HARD);
     }
 
-
     return repo;
+});
+
+
+/**
+ * Return a map from submodule name to url at the specified `commit` in the
+ * specified `repo`.
+ *
+ * @private
+ * @async
+ * @param {NodeGit.Commit} commit
+ * @return {Object} map from name to url
+ */
+const getSubmodules = co.wrap(function *(repo, commit) {
+    const tree = yield commit.getTree();
+    let entry;
+    try {
+        entry = yield tree.entryByPath(SubmoduleConfigUtil.modulesFileName);
+    }
+    catch (e) {
+        // No modules file.
+        return {};
+    }
+    const oid = entry.oid();
+    const blob = yield repo.getBlob(oid);
+    const data = blob.toString();
+    return  SubmoduleConfigUtil.parseSubmoduleConfig(data);
 });
 
                           // End modue-local methods
@@ -346,18 +337,41 @@ exports.readRAST = co.wrap(function *(repo) {
             commits[commitStr] = true;
 
             // Loop through all the diffs for the commit and read the value of
-            // each changed file.
+            // each changed file.  Special action must be taken for submodules.
+            // We will first load up a list of them from the `.gitmodules` file
+            // in the specified commit (if it exists) and that is how we will
+            // be able to identify changed paths as being submodules.
 
             const commit = yield repo.getCommit(commitId);
+            const submodules = yield getSubmodules(repo, commit);
             const diffs = yield commit.getDiff();
             const differs = diffs.map(co.wrap(function *(diff) {
                 for (let i = 0; i < diff.numDeltas(); ++i) {
                     const delta = diff.getDelta(i);
-                    // TODO: handle deleted files
-                    let path = delta.newFile().path();
-                    let entry = yield commit.getEntry(path);
-                    let blob = yield entry.getBlob();
-                    changes[path] = blob.toString();
+                    const path = delta.newFile().path();
+
+                    // We ignore the `.gitmodules` file.  Changes to it are an
+                    // implementation detail and will be reflected in changes
+                    // to submodule paths.
+
+                    if (SubmoduleConfigUtil.modulesFileName === path) {
+                        continue;
+                    }
+                    const DELETED = 2;
+                    if (DELETED === delta.status()) {
+                        changes[path] = null;
+                    }
+                    else if (path in submodules) {
+                        const url = submodules[path];
+                        const entry = yield commit.getEntry(path);
+                        const sha = entry.sha();
+                        changes[path] = new RepoAST.Submodule(url, sha);
+                    }
+                    else {
+                        const entry = yield commit.getEntry(path);
+                        const blob = yield entry.getBlob();
+                        changes[path] = blob.toString();
+                    }
                 }
             }));
             yield differs;
@@ -444,7 +458,8 @@ exports.writeRAST = co.wrap(function *(ast, path) {
     assert.instanceOf(ast, RepoAST);
     assert.isString(path);
 
-    const repo = yield NodeGit.Repository.init(path, 0);
+    const repo = yield NodeGit.Repository.init(path,
+                                               null === ast.head ? 1 : 0);
 
     const commits = yield writeCommits(repo, ast.commits);
     const resultRepo = yield configureRepo(repo, ast, commits.oldToNew);
@@ -479,6 +494,8 @@ exports.writeMultiRAST = co.wrap(function *(repos) {
 
     assert.isObject(repos);
 
+    repos = Object.assign({}, repos);  // make a copy
+
     // create a path for each repo
 
     let repoPaths = {};
@@ -487,6 +504,13 @@ exports.writeMultiRAST = co.wrap(function *(repos) {
         const path = yield TestUtil.makeTempDir();
         repoPaths[repoName] = path;
         urlMap[path] = repoName;
+    }
+
+    // Now, rewrite all the repo ASTs to have the right urls.
+    for (let repoName in repos) {
+        const repoAST = repos[repoName];
+        repos[repoName] =
+                         RepoASTUtil.mapCommitsAndUrls(repoAST, {}, repoPaths);
     }
 
     // First, collect all the commits:
@@ -517,12 +541,10 @@ exports.writeMultiRAST = co.wrap(function *(repos) {
     let resultRepos = {};
     for (let repoName in repos) {
 
-        // Rewrite Remote URLS from logical to physical name.
-
-        let repoAST = repos[repoName];
-        repoAST = RepoASTUtil.mapCommitsAndUrls(repoAST, {}, repoPaths);
         const path = repoPaths[repoName];
-        const repo = yield NodeGit.Clone.clone(commitRepo.workdir(), path);
+        const repo = yield NodeGit.Clone.clone(commitRepo.workdir(), path, {
+            bare: (null === repos[repoName].head) ? 1 : 0
+        });
 
         // Now we should have all the commits from `commitRepo` so delete it
         // and all associated refs.  We have to detach the head or it keeps
@@ -538,7 +560,7 @@ exports.writeMultiRAST = co.wrap(function *(repos) {
 
         // Then set up the rest of the repository.
         const resultRepo = yield configureRepo(repo,
-                                               repoAST,
+                                               repos[repoName],
                                                commitMaps.oldToNew);
         resultRepos[repoName] = resultRepo;
     }

--- a/lib/util/repoastutil.js
+++ b/lib/util/repoastutil.js
@@ -37,7 +37,6 @@
 
 const assert   = require("chai").assert;
 const colors   = require("colors");
-const deepCopy = require("deepcopy");
 const deeper   = require("deeper");
 
 const RepoAST  = require("../util/repoast");
@@ -145,10 +144,19 @@ ${colorAct(actual.parents)}`
         result.push(`unexpected change to ${colorBad(path)}`);
     }
     function compare(path) {
-        if (actual.changes[path] !== expected.changes[path]) {
+        const actualChange = actual.changes[path];
+        const expectedChange = expected.changes[path];
+        let different = actualChange !== expectedChange;
+        if (different &&
+            actualChange instanceof RepoAST.Submodule &&
+            expectedChange instanceof RepoAST.Submodule) {
+            different = actualChange.url !== expectedChange.url ||
+                actualChange.sha !== expectedChange.sha;
+        }
+        if (different) {
             result.push(`\
-for path ${colorBad(path)} expected ${colorExp(expected.changes[path])} but \
-got ${colorAct(actual.changes[path])}`
+for path ${colorBad(path)} expected ${colorExp(expectedChange)} but \
+got ${colorAct(actualChange)}`
                        );
         }
     }
@@ -425,13 +433,27 @@ exports.mapCommitsAndUrls = function (ast, commitMap, urlMap) {
     function mapCommit(commit) {
         assert.instanceOf(commit, RepoAST.Commit);
         const parents = commit.parents.map(mapCommitId);
-        const changes = deepCopy(commit.changes);
+        let changes = {};
+        for (let path in commit.changes) {
+            let change = commit.changes[path];
+            if (change instanceof RepoAST.Submodule) {
+                let url = change.url;
+                if (url in urlMap) {
+                    url = urlMap[url];
+                }
+                let sha = change.sha;
+                if (sha in commitMap) {
+                    sha = commitMap[sha];
+                }
+                change = new RepoAST.Submodule(url, sha);
+            }
+            changes[path] = change;
+        }
         return new RepoAST.Commit({
             parents: parents,
             changes: changes,
         });
     }
-
 
     // Copy and transform commit map.  Have to transform the key (commit id)
     // and the commits themselves which also contain commit ids.

--- a/lib/util/shorthandparserutil.js
+++ b/lib/util/shorthandparserutil.js
@@ -63,8 +63,9 @@ const RepoASTUtil  = require("../util/repoastutil");
  * branch         = 'B'<name>'='<commit>|<nothing>     nothing deletes branch
  * current branch = '*='<commit>
  * new commit     = 'C'<commit>'-'<commit>[' '<change>(','<change>*)]
- * change         = path '=' data
+ * change         = path '=' <submodule> | <data>
  * path           = (<alpha numeric>|'/')+
+ * submodule      = Surl:<commit>
  * data           = ('0-9'|'a-z'|'A-Z'|' ')*    basically non-delimiter ascii
  * remote         = R<name>=[<url>]
  *                  [' '<name>=[<commit>](','<name>=[<commit>])*]
@@ -98,8 +99,10 @@ const RepoASTUtil  = require("../util/repoastutil");
  * S:C2-1;Bmaster=2           -- creates a new commit, '2' derived from '1'
  *                               introducing a file '2' containing the string
  *                               '2'.  Sets master to point to this new commit.
- * S:C2-1 foo=bar;Bmaster=2  -- same as above but changes the file "foo"
- *                                   to "bar"
+ * S:C2-1 foo=bar;Bmaster=2   -- same as above but changes the file "foo"
+ *                               to "bar"
+ * S:C2-1 foo=S/baz.gi:1      -- makes a commit setting the path 'foo' to
+ *                               be a submodule with a url 'baz' at commit '1'
  * S:Rorigin=/foo.git           -- 'S' repo with an origin of /foo.git
  * S:Rorigin=/foo.git master=1  -- same as above but with remote branch
  *                              -- named 'master' pointing to commit 1
@@ -164,6 +167,36 @@ function findChar(str, c, begin, end) {
     }
     const index = str.indexOf(c, begin);
     return (-1 === index || end <= index) ? null : index;
+}
+
+/**
+ * Return the path change data described by the specified `commitData`.  If
+ * `commitData` begins with an `S` it is a submodule description; otherwise, it
+ * is just `commitData`.
+ *
+ * @private
+ * @param {String} commitData
+ * @return {String|RepoAST.Submodule}
+ */
+function parseCommitData(commitData) {
+    const end = commitData.length;
+    if (0 === end || "S" !== commitData[0]) {
+        return commitData;                                            // RETURN
+    }
+
+    // Must have room for 'S', ':', and at least one char for the url and
+    // commit id
+
+    assert(commitData.length > 3, `Invalid submodule ${commitData}`);
+    const urlBegin = 1;
+    const urlEnd = findChar(commitData, ":", urlBegin, end);
+    assert.isNotNull(urlEnd);
+    const commitIdBegin = urlEnd + 1;
+    assert.notEqual(commitIdBegin, end);
+    return new RepoAST.Submodule(commitData.substr(urlBegin,
+                                                   urlEnd - urlBegin),
+                                 commitData.substr(commitIdBegin,
+                                                   end - commitIdBegin));
 }
 
 /**
@@ -428,7 +461,7 @@ exports.parseRepoShorthandRaw = function (shorthand) {
                 const path = shorthand.substr(changeStart,
                                               assign - changeStart);
                 const data = shorthand.substr(dataStart, next - dataStart);
-                changes[path] = data;
+                changes[path] = parseCommitData(data);
                 changeStart = Math.min(next + 1, end);
             }
         }

--- a/lib/util/status.js
+++ b/lib/util/status.js
@@ -33,8 +33,9 @@ const co = require("co");
 const colors = require("colors/safe");
 const NodeGit = require("nodegit");
 
-const GitUtil = require("../util/gitutil");
-const SubmoduleUtil = require("../util/submoduleutil");
+const GitUtil             = require("../util/gitutil");
+const SubmoduleUtil       = require("../util/submoduleutil");
+const SubmoduleConfigUtil = require("../util/submodule_config_util");
 
 /**
  * @enum {STAGESTATUS}
@@ -517,7 +518,7 @@ const getMetaStatus = co.wrap(function *(metaRepo) {
     // is an imp detail of submodules that we want to hide.
 
     return yield exports.getRepoStatus(metaRepo, path =>
-        SubmoduleUtil.modulesFilename !== path
+        SubmoduleConfigUtil.modulesFileName !== path
     );
 });
 

--- a/lib/util/submodule_config_util.js
+++ b/lib/util/submodule_config_util.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+/**
+ * @module {SubmoduleConfigUtil}
+ *
+ * This module contains utilties for processing submodule configuration data.
+ */
+
+/**
+ * name of the modules configuration file
+ *
+ * @static
+ * @property {String}
+ */
+exports.modulesFileName = ".gitmodules";
+
+/**
+ * Return a map from submodule name to url from the specified `text`.
+ * @param {String} text
+ */
+exports.parseSubmoduleConfig = function (text) {
+    const nameRe = /\[submodule *"(.*)"]/;
+    const urlRe  = /^[ \t]*url = (.*)$/;
+    let result = {};
+    const lines = text.split("\n");
+    let lastName = null;
+    for (let i = 0; i < lines.length; ++i) {
+        const line = lines[i];
+        const nameParseResult = nameRe.exec(line);
+        if (null !== nameParseResult) {
+            lastName = nameParseResult[1];
+        }
+        else if (null !== lastName) {
+            const urlParseResult = urlRe.exec(line);
+            if (null !== urlParseResult) {
+                result[lastName] = urlParseResult[1];
+            }
+        }
+    }
+    return result;
+};

--- a/lib/util/submoduleutil.js
+++ b/lib/util/submoduleutil.js
@@ -39,9 +39,9 @@ const NodeGit = require("nodegit");
 const fs      = require("fs-promise");
 const path    = require("path");
 
-const GitUtil = require("../util/gitutil");
+const GitUtil             = require("../util/gitutil");
+const SubmoduleConfigUtil = require("../util/submodule_config_util");
 
-exports.modulesFileName = ".gitmodules";
 
 /**
  * Return the names of the submodules stored in the specified `text` from a
@@ -52,17 +52,8 @@ exports.modulesFileName = ".gitmodules";
  * @return {String []}
  */
 function getSubmoduleNamesFromText(text) {
-    const re = /\[submodule *"(.*)"]/;
-    let result = new Set();
-    const lines = text.split("\n");
-    let parseResult;
-    for (let i = 0; i < lines.length; ++i) {
-        parseResult = re.exec(lines[i]);
-        if (null !== parseResult) {
-            result.add(parseResult[1]);
-        }
-    }
-    return Array.from(result.values());
+    const map = SubmoduleConfigUtil.parseSubmoduleConfig(text);
+    return Object.keys(map);
 }
 
 /**
@@ -77,7 +68,8 @@ function getSubmoduleNamesFromText(text) {
  * @return {String []}
  */
 exports.getSubmoduleNames = function (repo) {
-    const modulesPath = path.join(repo.workdir(), exports.modulesFileName);
+    const modulesPath = path.join(repo.workdir(),
+                                  SubmoduleConfigUtil.modulesFileName);
     return fs.readFile(modulesPath, {
         encoding: "utf8"
     })
@@ -110,7 +102,7 @@ exports.getSubmoduleNamesForCommit = co.wrap(function *(repo, commit) {
     // I don't know of any way to check for this file that doesn't result in an
     // exception.  If there is no '.gitmodules' file, there are not submodules.
     try {
-        entry = yield tree.entryByPath(exports.modulesFileName);
+        entry = yield tree.entryByPath(SubmoduleConfigUtil.modulesFileName);
     }
     catch (e) {
         return [];

--- a/test/util/close.js
+++ b/test/util/close.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert  = require("chai").assert;
+const co      = require("co");
+const NodeGit = require("nodegit");
+
+const close    = require("../../lib/util/close");
+const TestUtil = require("../../lib/util/testutil");
+
+describe("close", function () {
+
+    // Going to do a simple test here to verify that after closing a submodule:
+    //
+    // - the submodule dir contains only the `.git` line file.
+    // - the git repo is in a clean state
+
+    it("breathing", co.wrap(function *() {
+
+        // Create and set up repos.
+
+        const repo = yield TestUtil.createSimpleRepository();
+        const baseSubRepo = yield TestUtil.createSimpleRepository();
+        const baseSubPath = baseSubRepo.workdir();
+        const subHead = yield baseSubRepo.getHeadCommit();
+
+        // Set up the submodule.
+
+        const sub = yield NodeGit.Submodule.addSetup(repo,
+                                                     baseSubPath,
+                                                     "x/y",
+                                                     1);
+        const subRepo = yield sub.open();
+        const origin = yield subRepo.getRemote("origin");
+        yield origin.connect(NodeGit.Enums.DIRECTION.FETCH,
+                             new NodeGit.RemoteCallbacks(),
+                             function () {});
+                             yield subRepo.fetch("origin", {});
+        subRepo.setHeadDetached(subHead.id().tostrS());
+        yield sub.addFinalize();
+
+        // Commit the submodule it.
+
+        yield TestUtil.makeCommit(repo, ["x/y", ".gitmodules"]);
+
+        // Verify that the status currently indicates a visible submodule.
+
+        const addedStatus = yield NodeGit.Submodule.status(repo, "x/y", 0);
+        const WD_UNINITIALIZED = (1 << 7);  // means "closed"
+        assert(!(addedStatus & WD_UNINITIALIZED));
+
+        // Then close it and recheck status.
+
+        yield close.close(repo, "x/y");
+        const closedStatus = yield NodeGit.Submodule.status(repo, "x/y", 0);
+        assert(closedStatus & WD_UNINITIALIZED);
+
+        // Make sure we can reopen it.
+
+        yield sub.init(1);
+        yield sub.repoInit(1);
+        const reopenedStat = yield NodeGit.Submodule.status(repo, "x/y", 0);
+        assert(!(reopenedStat & WD_UNINITIALIZED));
+    }));
+});

--- a/test/util/repoastutil.js
+++ b/test/util/repoastutil.js
@@ -159,6 +159,84 @@ describe("repoastutil", function () {
                     }
                 }),
             },
+            "url submodule remap": {
+                i: new RepoAST({
+                    commits: {
+                        "2": new RepoAST.Commit({
+                            changes: { foo: new RepoAST.Submodule("x", "y") },
+                        }),
+                    },
+                    head: "2",
+                }),
+                u: { x: "z" },
+                e: new RepoAST({
+                    commits: {
+                        "2": new RepoAST.Commit({
+                            changes: { foo: new RepoAST.Submodule("z", "y") },
+                        }),
+                    },
+                    head: "2",
+                }),
+            },
+            "url commit remap": {
+                i: new RepoAST({
+                    commits: {
+                        "2": new RepoAST.Commit({
+                            changes: { foo: new RepoAST.Submodule("x", "3") },
+                        }),
+                    },
+                    head: "2",
+                }),
+                m: { "3": "4" },
+                e: new RepoAST({
+                    commits: {
+                        "2": new RepoAST.Commit({
+                            changes: { foo: new RepoAST.Submodule("x", "4") },
+                        }),
+                    },
+                    head: "2",
+                }),
+            },
+            "url and commit submodule remap": {
+                i: new RepoAST({
+                    commits: {
+                        "2": new RepoAST.Commit({
+                            changes: { foo: new RepoAST.Submodule("x", "3") },
+                        }),
+                    },
+                    head: "2",
+                }),
+                m: { "3": "4" },
+                u: { x: "z" },
+                e: new RepoAST({
+                    commits: {
+                        "2": new RepoAST.Commit({
+                            changes: { foo: new RepoAST.Submodule("z", "4") },
+                        }),
+                    },
+                    head: "2",
+                }),
+            },
+            "unchanged sub": {
+                i: new RepoAST({
+                    commits: {
+                        "2": new RepoAST.Commit({
+                            changes: { foo: new RepoAST.Submodule("x", "3") },
+                        }),
+                    },
+                    head: "2",
+                }),
+                m: { "8": "4" },
+                u: { r: "z" },
+                e: new RepoAST({
+                    commits: {
+                        "2": new RepoAST.Commit({
+                            changes: { foo: new RepoAST.Submodule("x", "3") },
+                        }),
+                    },
+                    head: "2",
+                }),
+            },
         };
         Object.keys(cases).forEach(caseName => {
             it(caseName, function () {

--- a/test/util/shorthandparserutil.js
+++ b/test/util/shorthandparserutil.js
@@ -39,6 +39,7 @@ const ShorthandParserUtil = require("../../lib/util/shorthandparserutil");
 describe("shorthandparserutil", function () {
     describe("parseRepoShorthandRaw", function () {
         const Commit = RepoAST.Commit;
+        const Submodule = RepoAST.Submodule;
         function m(args) {
             let result = {
                 type: args.type || "S",
@@ -177,6 +178,48 @@ describe("shorthandparserutil", function () {
                     branches: { baz: "1" },
                 }),
             },
+            "commit with submodule": {
+                i: "S:C2-1 baz=S/foo.git:1",
+                e: m({
+                    type: "S",
+                    commits: {
+                        "2": new Commit({
+                            parents: ["1"],
+                            changes: { "baz": new Submodule("/foo.git", "1") },
+                        }),
+                    },
+                }),
+            },
+            "commit with short submodule": {
+                i: "S:C2-1 baz=So:1;Bmaster=2",
+                e: m({
+                    type: "S",
+                    commits: {
+                        "2": new Commit({
+                            parents: ["1"],
+                            changes: { "baz": new Submodule("o", "1") },
+                        }),
+                    },
+                    branches: { master: "2"},
+                }),
+            },
+            "mixes with submodule": {
+                i: "S:C2-1 x=y,baz=S/foo.git:1,q=r,t=Smeh:3",
+                e: m({
+                    type: "S",
+                    commits: {
+                        "2": new Commit({
+                            parents: ["1"],
+                            changes: {
+                                "x": "y",
+                                "baz": new Submodule("/foo.git", "1"),
+                                "q": "r",
+                                "t": new Submodule("meh", "3"),
+                            },
+                        }),
+                    },
+                }),
+            }
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];

--- a/test/util/submodule_config_util.js
+++ b/test/util/submodule_config_util.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert = require("chai").assert;
+
+const SubmoduleConfigUtil = require("../../lib/util/submodule_config_util");
+
+describe("SubmoduleConfigUtil", function () {
+    describe("parseSubmoduleConfig", function () {
+        const cases = {
+            "trivial": {
+                input: "",
+                expected: {},
+            },
+            "one": {
+                input: `\
+[submodule "x/y"]
+    path = x/y
+[submodule "x/y"]
+    url = /foo/bar/baz
+`,
+                expected: {
+                    "x/y": "/foo/bar/baz",
+                }
+            },
+            "all in one": {
+                input: `\
+[submodule "x/y"]
+    path = x/y
+    url = /foo/bar/baz
+`,
+                expected: {
+                    "x/y": "/foo/bar/baz",
+                }
+            },
+            "two": {
+                input: `\
+[submodule "x/y"]
+    path = x/y
+[submodule "x/y"]
+    url = /foo/bar/baz
+[submodule "a"]
+    path = foo
+[submodule "a"]
+    url = wham-bam
+`,
+                expected: {
+                    "x/y": "/foo/bar/baz",
+                    a: "wham-bam",
+                }
+            },
+            "two togethers": {
+                input: `\
+[submodule "x/y"]
+    path = x/y
+    url = /foo/bar/baz
+[submodule "a"]
+    path = foo
+    url = wham-bam
+`,
+                expected: {
+                    "x/y": "/foo/bar/baz",
+                    a: "wham-bam",
+                }
+            },
+            "with tabs": {
+                input: `\
+[submodule "x/y"]
+\tpath = x/y
+\turl = /foo/bar/baz
+[submodule "a"]
+\tpath = foo
+\turl = wham-bam
+`,
+                expected: {
+                    "x/y": "/foo/bar/baz",
+                    a: "wham-bam",
+                }
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, function () {
+                const result =
+                             SubmoduleConfigUtil.parseSubmoduleConfig(c.input);
+                assert.deepEqual(result, c.expected);
+            });
+        });
+    });
+});
+

--- a/test/util/submoduleutil.js
+++ b/test/util/submoduleutil.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert = require("chai").assert;
+const co     = require("co");
+
+const RepoASTIOUtil       = require("../../lib/util/repoastioutil");
+const ShorthandParserUtil = require("../../lib/util/shorthandparserutil");
+const TestUtil            = require("../../lib/util/testutil");
+const SubmoduleUtil       = require("../../lib/util/submoduleutil");
+
+describe("submoduleutil", function () {
+    after(TestUtil.cleanup);
+
+    describe("getSubmoduleNames", function () {
+        const cases = {
+            "none": {
+                state: "S",
+                expected: [],
+            },
+            "one": {
+                state: "S:C2-1 foo=S/a:1;H=2",
+                expected: ["foo"],
+            },
+            "two": {
+                state: "S:C2-1 foo=S/a:1;C3-2 bar=S/b:2;H=3",
+                expected: ["foo", "bar"],
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                const ast = ShorthandParserUtil.parseRepoShorthand(c.state);
+                const path = yield TestUtil.makeTempDir();
+                const repo = (yield RepoASTIOUtil.writeRAST(ast, path)).repo;
+                const names = yield SubmoduleUtil.getSubmoduleNames(repo);
+                assert.deepEqual(names.sort(), c.expected.sort());
+            }));
+        });
+    });
+
+    describe("getSubmoduleNamesForCommit", function () {
+        const cases = {
+            "none": {
+                state: "S",
+                commit: "1",
+                expected: [],
+            },
+            "one": {
+                state: "S:C2-1 foo=S/a:1;H=2",
+                commit: "2",
+                expected: ["foo"],
+            },
+            "two": {
+                state: "S:C2-1 foo=S/a:1;C3-2 bar=S/b:2;H=3",
+                commit: "3",
+                expected: ["foo", "bar"],
+            },
+            "none from earlier commit": {
+                state: "S:C2-1 foo=S/a:1;C3-2 bar=S/b:2;H=3",
+                commit: "1",
+                expected: [],
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                const ast = ShorthandParserUtil.parseRepoShorthand(c.state);
+                const path = yield TestUtil.makeTempDir();
+                const result = yield RepoASTIOUtil.writeRAST(ast, path);
+                const repo = result.repo;
+                const mappedCommitSha = result.oldCommitMap[c.commit];
+                const commit = yield repo.getCommit(mappedCommitSha);
+                const names = yield SubmoduleUtil.getSubmoduleNamesForCommit(
+                                                                       repo,
+                                                                       commit);
+                assert.deepEqual(names.sort(), c.expected.sort());
+            }));
+        });
+    });
+});
+


### PR DESCRIPTION
- Also reworked writing to build tree for each commit from scratch instead of
  working from parent commit.  This change had a couple of benefits:
  * same logic could be used with root and child commits
  * no cleanup (e.g. with HEAD) issues for working dir during generation
  * don't need to actually connect to or fecth from submodules to add them
  * can create submodule references to repos/commits that don't exist
- split out the submodule config logic into a lower-level component usable by
  the test system
- logic to "render" a commit chain into a logical workdir tree