### PR TITLE
git meta close checks for unpushed or uncommited changes

### DIFF
--- a/lib/cmd/close.js
+++ b/lib/cmd/close.js
@@ -55,6 +55,16 @@ exports.configureParser = function (parser) {
         help: "path of sub-repository to close",
         nargs: "+",
     });
+
+    parser.addArgument(["-f", "--force"], {
+        defaultValue: false,
+        required: false,
+        action: "storeConst",
+        constant: true,
+        help: `The command refuses to close submodules that have
+unpushed or uncommitted changes. This flag disables those checks.`
+    });
+
 };
 
 /**
@@ -69,7 +79,7 @@ exports.executeableSubcommand = co.wrap(function *(args) {
     const Close   = require("../util/close");
     const repo = yield GitUtil.getCurrentRepo();
     const closers = args.path.map(name => {
-        return Close.close(repo, name);
+        return Close.close(repo, name, args.force);
     });
     yield closers;
 });

--- a/lib/util/close.js
+++ b/lib/util/close.js
@@ -39,6 +39,11 @@ const rimraf  = require("rimraf");
 const path    = require("path");
 const fs      = require("fs-promise");
 
+const GitUtil   = require("./git_util");
+const NodeGit   = require("nodegit");
+const Status    = require("./status");
+const UserError = require("./user_error");
+
 /**
  * Remove the modules directory for the submodule having the specified 'name'
  * in the repo located at the specified 'root'.
@@ -61,22 +66,83 @@ exports.cleanModulesDirectory = co.wrap(function *(root, name) {
  * @async
  * @param {NodeGit.Repository} repo
  * @param {String}             submoduleName
+ * @param {Boolean}            force
  */
-exports.close = co.wrap(function *(repo, submoduleName) {
+exports.close = co.wrap(function *(repo, submoduleName, force) {
 
     // This operation is a major pain, first because libgit2 does not provide
     // any direct methods to do the equivalent of 'git deinit', and second
     // because nodegit does not expose the method that libgit2 does provide to
     // delete an entry from the config file.
 
-    // De-initting a submodule requires two things:
-    // 1. Remove all files under the path of the submodule, but not the
+    // De-initting a submodule requires the following things:
+    // 1. Confirms there are no unpushed (to any remote) commits
+    //    or uncommited changes (including new files).
+    // 2. Remove all files under the path of the submodule, but not the
     //    directory itself, which would look to Git as if we were trying
     //    to remove the submodule.
-    // 2. Remove the entry for the submodule from the '.git/config' file.
-    // 3. Remove the directory .git/modules/<submodule>
+    // 3. Remove the entry for the submodule from the '.git/config' file.
+    // 4. Remove the directory .git/modules/<submodule>
 
-    // First, we will clear out the path for the submodule.
+    // Confirm there are no unpushed commits and uncommited changes
+
+    if (!force) {
+
+        const submodule = yield NodeGit.Submodule.lookup(repo, submoduleName);
+        const subRepo = yield submodule.open();
+
+        const errorMessages = [];
+
+        // Determine if all of the commits have been pushed to some remote by
+        // finding the intersection of unpushed commits to each remote
+
+        let allUnpushedSet;
+
+        const headCommit = yield subRepo.getHeadCommit();
+        const remotes = yield NodeGit.Remote.list(subRepo);
+
+        // For each remote, find the unpushed commits and intersect them with
+        // the set allUnpushed
+
+        const checkUnpushedCommits = co.wrap(function *(remote) {
+
+            const unpushedCommits = new Set(yield GitUtil.listUnpushedCommits(
+                subRepo,
+                remote,
+                headCommit.toString()));
+
+            if (!allUnpushedSet) {
+                allUnpushedSet = unpushedCommits;
+            } else {
+                allUnpushedSet.filter(x => unpushedCommits.has(x));
+            }
+        });
+
+        yield remotes.map(checkUnpushedCommits);
+
+        if (0 !== allUnpushedSet.length) {
+            errorMessages.push("Unpushed commits");
+        }
+
+        // Determine if there are any uncommited changes:
+        // 1) Clean (no staged or unstaged changes)
+        // 2) new files
+
+        const repoStatus = yield Status.getRepoStatus(subRepo);
+        if (!repoStatus.isClean() || 0 !== repoStatus.untracked.length) {
+            errorMessages.push(Status.printFileStatuses(repoStatus));
+        }
+
+        // If everything is not pushed or committed, throw an error
+
+        if (0 !== errorMessages.length) {
+            throw new UserError("Could not close " + submoduleName
+                + " due to: \n"
+                + errorMessages.join("\n"));
+        }
+    }
+
+    // We will clear out the path for the submodule.
 
     const rootDir = repo.workdir();
     const submodulePath = path.join(rootDir, submoduleName);


### PR DESCRIPTION
Work for #29 

`git meta close` now requires `--force` to succeed if:
- There are unpushed changes (to any remote)
- The repository is not clean (uncommit or unstaged changes)
- There are new files
