### PR TITLE
Backups .git/modules/submodule

### DIFF
--- a/lib/util/close.js
+++ b/lib/util/close.js
@@ -40,18 +40,29 @@ const path    = require("path");
 const fs      = require("fs-promise");
 
 /**
- * Remove the modules directory for the submodule having the specified 'name'
- * in the repo located at the specified 'root'.
+ * Backup the modules directory for the submodule having the specified 'name'
+ * in the repo located at the specified 'root'. It will be backed up to
+ * .git/metabackups/name<date>
  * @param {String} root
  * @param {String} name
  */
 exports.cleanModulesDirectory = co.wrap(function *(root, name) {
-    const submoduleModuleDir = path.join(root, ".git", "modules", name);
 
+    const backupDir = path.join(root, ".git", "metabackups");
     const rmModDir = new Promise(callback => {
-        return rimraf(submoduleModuleDir, {}, callback);
+        return rimraf(backupDir, {}, callback);
     });
     yield rmModDir;
+
+    yield fs.mkdir(backupDir);
+
+    const submoduleModuleDir = path.join(root, ".git", "modules", name);
+
+    const date = new Date();
+    const backupModuleDir = path.join(backupDir, name + "-" + date.getTime())
+
+    yield fs.rename(submoduleModuleDir, backupModuleDir);
+    console.log("Created a backup at " + backupModuleDir);
 });
 
 /**


### PR DESCRIPTION
Work for #29 

Looking for some feedback:

- Currently just kills the old backup directory and replaces it.
- .git/metabackups might not be the best directory (perhaps .gitmeta/backups?)
- In the future perhaps extend this into a util/backup?