### PR TITLE
Fix for missing shas in status, --verbose option to summary

### DIFF
--- a/lib/cmd/status.js
+++ b/lib/cmd/status.js
@@ -66,14 +66,23 @@ exports.configureParser = function (parser) {
 multiple times`,
     });
 
-    parser.addArgument(["-u", "--summary"], {
+    parser.addArgument(["-l", "--list-submodules"], {
+        defaultValue: false,
+        required: false,
+        action: "storeConst",
+        constant: true,
+        help: `show one-line summary of each open submodule: the current \
+SHA-1 for that submodule, followed by its name`
+    });
+
+    parser.addArgument(["-v", "--verbose"], {
         defaultValue: false,
         required: false,
         action: "storeConst",
         constant: true,
         help: `show one-line summary of each submodule: a '-' if the \
 submodule is closed, followed by the current SHA-1 for \
-that submodule, followed by its name`
+that submodule, followed by its name. `
     });
 };
 
@@ -133,7 +142,7 @@ exports.executeableSubcommand = co.wrap(function *(args) {
                                            args.sub_repo);
     });
 
-    const doSummary = co.wrap(function *() {
+    const doSummary = co.wrap(function *(showClosed) {
         const submoduleNames = yield SubmoduleUtil.getSubmoduleNames(repo);
         let requestedNames;
         if (null === args.sub_repo) {
@@ -157,13 +166,22 @@ exports.executeableSubcommand = co.wrap(function *(args) {
         let visStr;
         for (let i = 0; i < requestedNames.length; ++i) {
             visStr = visibility[i] ? " " : "-";
-            console.log(`${visStr} ${shas[i]} \
+            if (visibility[i] || showClosed) {
+                console.log(`${visStr} ${shas[i]} \
 ${colors.cyan(requestedNames[i])}`);
+            }
         }
     });
 
-    if (args.summary) {
-        yield doSummary;
+    if (args.verbose) {
+        console.log(`${colors.grey("All submodules: ")}`);
+        yield doSummary(true);
+        console.log(`${colors.grey("\nWorking tree: ")}`);
+        yield doStatus;
+    }
+    else if (args.list_submodules) {
+        console.log(`${colors.grey("Open submodules: ")}`);
+        yield doSummary(false);
     }
     else {
         yield doStatus;

--- a/lib/util/submodule_util.js
+++ b/lib/util/submodule_util.js
@@ -35,6 +35,7 @@
  */
 
 const co      = require("co");
+const colors  = require("colors");
 const NodeGit = require("nodegit");
 const fs      = require("fs-promise");
 const path    = require("path");
@@ -175,7 +176,11 @@ exports.getCurrentSubmoduleShas = co.wrap(function *(repo, submoduleNames) {
     let entry;
     for (let i = 0; i < submoduleNames.length; ++i) {
         entry = index.getByPath(submoduleNames[i]);
-        result.push(entry.id.tostrS());
+        if (entry) {
+            result.push(entry.id.tostrS());
+        } else {
+            result.push(`${colors.red("missing entry")}`);
+        }
     }
     return result;
 });


### PR DESCRIPTION
For #38 

Changes:

- Fixes the --summary option when shas are missing
- Changes --summary option to only show open submodules
- Create a --verbose option which prints status of all submodules and prints working directory

