### PR TITLE
Pins NodeGit to 0.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "argparse": "",
       "chai": "",
       "child-process-promise": "",
-      "nodegit": "",
+      "nodegit": "0.12.2",
       "co": "",
       "fs-promise": "",
       "rimraf": "",


### PR DESCRIPTION
Currently NodeGit is at 0.13.0, part of these changes involves making index commands async (https://github.com/nodegit/nodegit/pull/971)
- `Index#addByPath`
- `Index#write`

which breaks commands such as commit

(see: [full changelog](https://github.com/nodegit/nodegit/blob/master/CHANGELOG.md) of NodeGit 0.13.0)