### PR TITLE
Check for bad type specification.

### DIFF
--- a/lib/util/shorthand_parser_util.js
+++ b/lib/util/shorthand_parser_util.js
@@ -656,6 +656,7 @@ exports.parseRepoShorthand = function (shorthand) {
 
     const rawResult = exports.parseRepoShorthandRaw(shorthand);
     assert.property(exports.RepoType, rawResult.type, "invalid override");
+    assert.notProperty(rawResult, "typeData", "type takes no data");
     const baseAST = exports.RepoType[rawResult.type];
 
     const resultArgs = prepareASTArguments(baseAST, rawResult);
@@ -775,6 +776,9 @@ exports.parseMultiRepoShorthand = function (shorthand) {
         }
        else {
             assert.property(exports.RepoType, rawRepo.type, `repo ${name}`);
+            assert.notProperty(rawRepo,
+                               "typeData",
+                               `${rawRepo.type} takes no data`);
             baseAST = exports.RepoType[rawRepo.type];
         }
         const resultArgs = prepareASTArguments(baseAST, rawRepo);

--- a/test/util/shorthand_parser_util.js
+++ b/test/util/shorthand_parser_util.js
@@ -217,12 +217,20 @@ describe("ShorthandParserUtil", function () {
                     type: "S",
                     index: { x: new Submodule("/x", "1") },
                 }),
-            }
+            },
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];
             it(caseName, function () {
-                const r = ShorthandParserUtil.parseRepoShorthandRaw(c.i);
+                let r;
+                try {
+                    r = ShorthandParserUtil.parseRepoShorthandRaw(c.i);
+                }
+                catch (e) {
+                    assert(c.fails, e.stack);
+                    return;
+                }
+                assert(!c.fails);
                 const e = c.e;
                 assert.equal(r.type, e.type);
                 assert.equal(r.typeData, e.typeData);
@@ -319,11 +327,23 @@ describe("ShorthandParserUtil", function () {
                     }
                 }),
             },
+            "bad type data": {
+                i: "S I max=maz",
+                fails: true,
+            }
         };
         Object.keys(cases).forEach(caseName => {
             it(caseName, function () {
                 const c = cases[caseName];
-                const result = ShorthandParserUtil.parseRepoShorthand(c.i);
+                let result;
+                try {
+                    result = ShorthandParserUtil.parseRepoShorthand(c.i);
+                }
+                catch (e) {
+                    assert(c.fails, e.stack);
+                    return;
+                }
+                assert(!c.fails);
                 RepoASTUtil.assertEqualASTs(result, c.e);
             });
         });
@@ -393,16 +413,27 @@ describe("ShorthandParserUtil", function () {
                     b: "S:Rorigin=a",
                 },
             },
+            "bad type data": {
+                i: "a=S I max=maz|b=S:C2-1 foo=Sa:1;Bmaster=2",
+                fails: true,
+            }
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];
             it(caseName, function () {
-                const result = 
-                              ShorthandParserUtil.parseMultiRepoShorthand(c.i);
+                let result;
+                try {
+                    result = ShorthandParserUtil.parseMultiRepoShorthand(c.i);
+                }
+                catch (e) {
+                    assert(c.fails, e.stack);
+                    return;
+                }
+                assert(!c.fails);
                 let expected = {};
                 for (let name in c.e) {
                     expected[name] =
-                             ShorthandParserUtil.parseRepoShorthand(c.e[name]);
+                        ShorthandParserUtil.parseRepoShorthand(c.e[name]);
                 }
                 RepoASTUtil.assertEqualRepoMaps(result, expected);
             });


### PR DESCRIPTION
Previously, syntax like: "S foo" would have worked, the " foo" being ignored.