### PR TITLE
Istanbul Code Coverage Tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+/coverage

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.2.0",
   "description": "large scale SCM made easy",
   "scripts": {
-    "test": "mocha test"
+    "test": "mocha test",
+    "coverage": "istanbul cover _mocha"
   },
   "directories": {
   },
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
       "deeper": "",
+      "istanbul": "",
       "mkdirp": "",
       "mocha": "",
       "mocha-jshint": "",


### PR DESCRIPTION
Completes #48 - Generates a full coverage report for code coverage in coverage

- Full mocha integration
- Run via `npm run coverage` or `istanbul cover _mocha`
- Cover a single file the same way as mocha, by passing the filename to above commands, eg. `npm run coverage test/util/branch`
- Generates a fantastic report in coverage/lcov-report/index.html
- Most popular code coverage tool, 4M downloads last month (and currently maintained)

Two points worth noting
- Coverage tool will only show files that are required at least once by a mocha test
- `npm run coverage` will generate coverage, but will fail (return code != 0) if a mocha test fails