### PR TITLE
Add support for writing hierarchical trees.

### DIFF
--- a/lib/util/repo_ast_io_util.js
+++ b/lib/util/repo_ast_io_util.js
@@ -82,79 +82,142 @@ const hashObject = co.wrap(function *(repo, data) {
 });
 
 /**
+ * Return a nested tree mapping the flat structure in the specified `flatTree`,
+ * which consists of a map of paths to values, into a hierarchical structure
+ * beginning at the root.  For example, if the input is:
+ *     { "a/b/c": 2, "a/b/d": 3}
+ * the output will be:
+ *     { a : { b: { c: 2, d: 3} } }
+ *
+ * @param {Object} flatTree
+ * @return {Object}
+ */
+exports.buildDirectoryTree = function (flatTree) {
+    let result = {};
+    for (let path in flatTree) {
+        const paths = path.split("/");
+        let tree = result;
+
+        // Navigate/build the tree until there is only one path left in paths,
+        // then write the entry.
+
+        for (let i = 0; i + 1 < paths.length; ++i) {
+            const nextPath = paths[i];
+            if (nextPath in tree) {
+                tree = tree[nextPath];
+                assert.isObject(tree, `for path ${path}`);
+            }
+            else {
+                const nextTree = {};
+                tree[nextPath] = nextTree;
+                tree = nextTree;
+            }
+        }
+        const leafPath = paths[paths.length - 1];
+        assert.notProperty(tree, leafPath, `duplicate entry for ${path}`);
+        tree[leafPath] = flatTree[path];
+    }
+    return result;
+};
+
+/**
  * Create and return the id of a `NodeGit.Tree` containing the contents of the
- * specified `tree` in the specified `repo`.  Use the specified
+ * specified `flatTree` in the specified `repo`.  Use the specified
  * `getSubmoduleSha` to obtain the sha for any submodule commits.
  *
  * @private
  * @async
  * @param {NodeGit.Repo}     repo
- * @param {Object}           tree maps path to data or `RepoAST.Submodule`
+ * @param {Object}           flatTree maps path to data or `RepoAST.Submodule`
  * @param {(sha) => Promise} getSubmoduleSha
  * @return {String}
  */
-const makeTree = co.wrap(function *(repo, tree, getSubmoduleSha) {
+const makeTree = co.wrap(function *(repo, flatTree, getSubmoduleSha) {
     assert.instanceOf(repo, NodeGit.Repository);
-    assert.isObject(tree);
+    assert.isObject(flatTree);
     assert.isFunction(getSubmoduleSha);
 
-    // Build the tree file; build the `.gitmodules` file as submodules are
-    // seen.
+    // Strategy for making a tree:
+    // - take the flat data in `flatTree` and turn it into a hierarchy with
+    //   `buildDirectoryTree`
+    // - calculate contents of `.gitmodules` file and add to tree
+    // - invoke `writeHierarchy` to generate tree id, it will add a line for
+    //   each entry:
+    // ` - for a file, hash its contents and add a `blob` line
+    //   - for a submodule, add a line indicating its sha
+    //   - for a subtree, recurse and add a line with subtree id
 
-    let gitModulesData = "";
-    let treeData = "";
+    const writeHierarchy = co.wrap(function *(hierarchy) {
 
-    function addToTree(fileType, dataType, id, path) {
-        if ("" !== treeData) {
-            treeData += "\n";
+        let treeData = "";
+
+        function addToTree(fileType, dataType, id, path) {
+            if ("" !== treeData) {
+                treeData += "\n";
+            }
+            treeData += `${fileType} ${dataType} ${id}\t${path}`;
         }
-        treeData += `${fileType} ${dataType} ${id}\t${path}`;
-    }
 
-    const addFile = co.wrap(function *(path, data) {
-        const id = yield hashObject(repo, data);
-        addToTree("100644", "blob", id, path);
-    });
+        for (let path in hierarchy) {
+            const change = hierarchy[path];
+            if (change instanceof RepoAST.Submodule) {
+                const newSha = yield getSubmoduleSha(change.sha);
+                addToTree("160000", "commit", newSha, path);
+            }
+            else if ("string" === typeof change) {
+                // A string indicates files data.
 
-    for (let path in tree) {
-        const change = tree[path];
-        if (change instanceof RepoAST.Submodule) {
-            const modulesStr = `\
-[submodule "${path}"]
-\tpath = ${path}
-\turl = ${change.url}
-`;
-            const newSha = yield getSubmoduleSha(change.sha);
-            gitModulesData += modulesStr;
-            addToTree("160000", "commit", newSha, path);
+                const id = yield hashObject(repo, change);
+                addToTree("100644", "blob", id, path);
+            }
+            else {
+                // If it's not a submodule or a file, it must be a subtree.
+
+                const subTreeId = yield writeHierarchy(change);
+                addToTree("040000", "tree", subTreeId, path);
+            }
         }
-        else {
-            yield addFile(path, change);
+
+        // If no data, make an empty tree
+        if ("" === treeData ) {
+            const builder = yield NodeGit.Treebuilder.create(repo, null);
+            const treeObj = builder.write();
+            return treeObj.tostrS();                                  // RETURN
         }
-    }
-
-    if ("" !== gitModulesData) {
-        yield addFile(SubmoduleConfigUtil.modulesFileName, gitModulesData);
-    }
-
-    let treeId;
-    if ("" !== treeData ) {
-
         const makeTreeExecString = `\
 cd ${repo.path()}
 echo '${treeData}' | git mktree
 `;
-        treeId = yield doExec(makeTreeExecString);
-    }
-    else {
-        // no entries, let's make an empty tree
+        return yield doExec(makeTreeExecString);
+    });
 
-        const builder = yield NodeGit.Treebuilder.create(repo, null);
-        const treeObj = builder.write();
-        treeId = treeObj.tostrS();
+    let gitModulesData = "";
+
+    // Pre-process submodules to get shas and the data for the .gitmodules
+    // file.
+
+    for (let path in flatTree) {
+        const data = flatTree[path];
+        if (data instanceof RepoAST.Submodule) {
+            const modulesStr = `\
+[submodule "${path}"]
+\tpath = ${path}
+\turl = ${data.url}
+`;
+            gitModulesData += modulesStr;
+        }
     }
 
-    return treeId;
+    const directoryTree = exports.buildDirectoryTree(flatTree);
+    assert.notProperty(directoryTree,
+                       SubmoduleConfigUtil.modulesFileName,
+                       "no explicit changes to the git modules file");
+
+    if ("" !== gitModulesData) {
+        directoryTree[SubmoduleConfigUtil.modulesFileName] = gitModulesData;
+    }
+
+    return yield writeHierarchy(directoryTree);
 });
 
 /**


### PR DESCRIPTION
Previously, you could not write out `RepoAST` objects containing paths such ast
`x/y`.

I exposed a helper function, `buildDirectoryTree` used to translate the flat
set of stored changes into a hieararchical tree, so that I could test it.