### PR TITLE
Addded test utilities for non-manipulators.

### DIFF
--- a/lib/util/repo_ast_test_util.js
+++ b/lib/util/repo_ast_test_util.js
@@ -79,7 +79,28 @@ function createMultiRepoASTMap(input) {
     return result;
 }
 
-                          // End modue-local methods
+                          // End module-local methods
+
+/**
+ * Return the repository an object maps as returned by
+ * `RepoASTIOUtil.writeRAST` as described by the specified `input`.  The value
+ * of `input` may be a string parseable by
+ * `ShorthandParserUtil.parseRepoShorthand`, or a `RepoAST` object.  The
+ * behavior is undefined unless `TestUtil.cleanup` is called some time after
+ * this method.
+ */
+exports.createRepo = co.wrap(function *(input) {
+    let ast;
+    if ("string" === typeof input) {
+        ast = ShorthandParserUtil.parseRepoShorthand(input);
+    }
+    else {
+        assert.instanceOf(input, RepoAST);
+        ast = input;
+    }
+    const path = yield TestUtil.makeTempDir();
+    return yield RepoASTIOUtil.writeRAST(ast, path);
+});
 
 /**
  * Create a repository described by the specified `input`, apply the specified
@@ -98,16 +119,11 @@ function createMultiRepoASTMap(input) {
 exports.testRepoManipulator = co.wrap(function *(input,
                                                  expected,
                                                  manipulator) {
-    if (!(input instanceof RepoAST)) {
-        assert.isString(input);
-        input = ShorthandParserUtil.parseRepoShorthand(input);
-    }
     if (!(expected instanceof RepoAST)) {
         assert.isString(expected);
         expected = ShorthandParserUtil.parseRepoShorthand(expected);
     }
-    const path = yield TestUtil.makeTempDir();
-    let written = yield RepoASTIOUtil.writeRAST(input, path);
+    const written = yield exports.createRepo(input);
     const repo = written.repo;
     const userMap = yield manipulator(repo);
     if (undefined !== userMap) {
@@ -116,6 +132,20 @@ exports.testRepoManipulator = co.wrap(function *(input,
     const ast = yield RepoASTIOUtil.readRAST(repo);
     const actual = RepoASTUtil.mapCommitsAndUrls(ast, written.commitMap, {});
     RepoASTUtil.assertEqualASTs(actual, expected);
+});
+
+/**
+ * Return the repository an objects and mappings returned by
+ * `RepoASTIOUtil.writeMultiRAST` as described by the specified `input` map.
+ * The values of `input` may be strings parseable by
+ * `ShorthandParserUtil.parseRepoShorthand`, or `RepoAST` objects, or any mix
+ * of the two.  The behavior is undefined unless `TestUtil.cleanup` is called
+ * some time after this method.
+ */
+exports.createMultiRepos = co.wrap(function *(input) {
+    const inputASTs = createMultiRepoASTMap(input);
+
+    return yield RepoASTIOUtil.writeMultiRAST(inputASTs);
 });
 
 /**


### PR DESCRIPTION
`createRepo` and `createMultiRepos` that take care of:
1. making temp path
2. accepting either AST or shorthand input