### PR TITLE
Fixed bug parsing overrides.

### DIFF
--- a/lib/util/shorthand_parser_util.js
+++ b/lib/util/shorthand_parser_util.js
@@ -662,9 +662,7 @@ function parseOverrides(shorthand, begin, end, delimiter) {
     }
 
     while (begin !== end) {
-        const nextEnd = findChar(shorthand, delimiter, begin, end) ||
-                                                              shorthand.length;
-
+        const nextEnd = findChar(shorthand, delimiter, begin, end) || end;
         parseOverride(begin, nextEnd);
         begin = Math.min(nextEnd + 1, end);  // skip delimiter
     }

--- a/test/util/shorthand_parser_util.js
+++ b/test/util/shorthand_parser_util.js
@@ -283,6 +283,45 @@ describe("ShorthandParserUtil", function () {
                     },
                 }),
             },
+            "remote override": {
+                i: "S:Rorigin=a;H=2",
+                e: m({
+                    head: "2",
+                    remotes: {
+                        origin: {
+                            url: "a",
+                            branches: {},
+                        },
+                    },
+                }),
+            },
+            "submodule with remote override": {
+                i: "S:C2-1 a=Sa:1;Oa Rorigin=a;H=2",
+                e: m({
+                    commits: {
+                        "2": new RepoAST.Commit({
+                            parents: ["1"],
+                            changes: {
+                                a: new RepoAST.Submodule("a", "1"),
+                            },
+                        }),
+                    },
+                    head: "2",
+                    openSubmodules: {
+                        a: m({
+                            type: null,
+                            remotes: {
+                                origin: {
+                                    url: "a", 
+                                    branches: {
+                                    },
+                                },
+                            },
+                        }),
+                    },
+                }),
+            },
+//"a=S|x=S:C2-1 a=Sa:1;Oa Rorigin=a;H=2"
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];


### PR DESCRIPTION
Was using `shorthand.length` as end character instead of `end`, breaking
override parsing with open submodules.

Added test to catch this condition.