### PR TITLE
expectation transformation in testMultiRepoManipulator

### DIFF
--- a/lib/util/repo_ast_test_util.js
+++ b/lib/util/repo_ast_test_util.js
@@ -183,6 +183,12 @@ exports.createMultiRepos = co.wrap(function *(input) {
  *   If it returns `undefined` then it is assumed no mapping is necessary.  The
  *   behvior is undefined if either map contains entries for commits or urls
  *   that already existed in the original map.
+ * - If `options.expectedTransformer` is provided, the map of expected ASTs,
+ *   along with an object containing mapping information will be passed to it
+ *   with the expectation that it will return a (potentially changed) expected
+ *   map.  This facility is provided to allow for cases where some aspect of a
+ *   repository state may be dependent on mapping information, such as if a
+ *   commit ID is embedded in a ref name.
  *
  * TODO: We should change this so that manipulators are given object/url maps
  * to manipulate in-place so that mappings may be recorded even if errors are
@@ -193,9 +199,18 @@ exports.createMultiRepos = co.wrap(function *(input) {
  * @param {String|Object}        [expected]
  * @param {(repoMap, { commitMap, urlMap}) => Promise} manipulator
  * @param {Boolean|undefined}    shouldFail
+ * @param {Object}               [options]
+ * @param {Function}             [options.expectedTransformer]
+ * @param {Object}               options.expectedTransformer.expected
+ * @param {Object}               options.expectedTransformer.mapping
+ * @param {Object}               options.expectedTransformer.mapping.commitMap
+ * @param {Object}               options.expectedTransformer.mapping.urlMap
+ * @param {Object}               options.expectedTransformer.mapping.reverseMap
+ * @param {Object}            options.expectedTransformer.mapping.reverseUrlMap
+ * @param {Object}               options.expectedTransformer.return
  */
 exports.testMultiRepoManipulator =
-                 co.wrap(function *(input, expected, manipulator, shouldFail) {
+        co.wrap(function *(input, expected, manipulator, shouldFail, options) {
     if (undefined !== shouldFail) {
         assert.isBoolean(shouldFail);
     }
@@ -204,6 +219,18 @@ exports.testMultiRepoManipulator =
     }
     if (undefined === expected) {
         expected = {};
+    }
+    if (undefined === options) {
+        options = {};
+    }
+    else {
+        assert.isObject(options);
+    }
+    if (!("expectedTransformer" in options)) {
+        options.expectedTransformer = (expected) => expected;
+    }
+    else {
+        assert.isFunction(options.expectedTransformer);
     }
     const inputASTs = createMultiRepoASTMap(input);
 
@@ -223,17 +250,19 @@ exports.testMultiRepoManipulator =
         reverseUrlMap[urlMap[url]] = url;
     });
 
+    const mappings = {
+        commitMap: commitMap,
+        reverseMap: reverseMap,
+        urlMap: urlMap,
+        reverseUrlMap: reverseUrlMap,
+    };
+
     // Pass the repos off to the manipulator.
 
     let manipulated;
     let failed = false;
     try {
-        manipulated = yield manipulator(inputRepos, {
-            commitMap: commitMap,
-            reverseMap: reverseMap,
-            urlMap: urlMap,
-            reverseUrlMap: reverseUrlMap,
-        });
+        manipulated = yield manipulator(inputRepos, mappings);
     }
     catch (e) {
         if (!shouldFail) {
@@ -277,6 +306,10 @@ exports.testMultiRepoManipulator =
             expectedASTs[repoName] = inputASTs[repoName];
         }
     }
+
+    // Allow a transformer a chance to apply mappings to the expected ASTs.
+
+    expectedASTs = options.expectedTransformer(expectedASTs, mappings);
 
     // Read in the states of the repos.
 


### PR DESCRIPTION
Changed `testMultiRepoManipulator` to allow the caller to transformn the map of
expected ASTs immediately prior to checking them against the actual result.
This capability is necessary to test cases where the actual state of the
repository may contain generated (mapped) values where the system cannot adjust
them -- for example, if a branch (or ref) name has the ID of a commit embedded
in it.