### PR TITLE
Some minor hook patches

### DIFF
--- a/lib/util/synthetic_branch_util.js
+++ b/lib/util/synthetic_branch_util.js
@@ -58,7 +58,7 @@ function identity(v) {
      * @param {NodeGit.Commit} commit
      */
 exports.getSyntheticBranchForCommit = function(commit) {
-    return SYNTHETIC_BRANCH_BASE + commit.id();
+    return SYNTHETIC_BRANCH_BASE + commit;
 };
 
 function *urlToLocalPath(repo, url) {
@@ -108,6 +108,8 @@ function* checkSubmodule(repo, submoduleEntry) {
             yield submoduleRepo.getReferenceCommit(branch);
         return subrepoCommit.id().equal(submoduleEntry.id());
     } catch (e) {
+        console.error("Could not look up ", branch, " in ", localPath,
+                      ": ", e);
         return false;
     }
 }
@@ -206,6 +208,11 @@ function* checkUpdate(repo, oldSha, newSha, handled) {
 
     const newAnnotated = yield GitUtil.resolveCommitish(repo, newSha);
 
+    if (newAnnotated === null) {
+        // No such commit exists, error
+        return false;
+    }
+
     const newCommit = yield repo.getCommit(newAnnotated.id());
     const success = yield parentLoop(repo, newCommit, oldSha,
                                      handled);
@@ -290,10 +297,15 @@ function doPreReceive(check) {
             "ref" : parts[2]
         });
     }).on("end", function() {
-        process.exit(+co(function *() {
+        co(function *() {
             const repo = yield NodeGit.Repository.open(".");
-            check(repo, updates);
-        }));
+            return yield check(repo, updates);
+        }).then(function(res) {
+            process.exit(+res);
+        }, function(e) {
+            console.error(e);
+            process.exit(2);
+        });
     });
 }
 

--- a/lib/util/synthetic_branch_util.js
+++ b/lib/util/synthetic_branch_util.js
@@ -70,13 +70,20 @@ function *urlToLocalPath(repo, url) {
         yield config.getStringBuf("gitmeta.subrepourlbase");
     const subrepoRootPath =
         yield config.getStringBuf("gitmeta.subreporootpath");
+    let subrepoSuffix = "";
+    try {
+        subrepoSuffix = yield config.getStringBuf("gitmeta.subreposuffix");
+    } catch (e) {
+        //It's OK for this to be missing, but nodegit lacks an
+        //API that expresses this.
+    }
     if (!url.startsWith(subrepoUrlBase)) {
         throw "Your git configuration gitmeta.subrepoUrlBase, '" +
             subrepoUrlBase + "', must be a prefix of all submodule " +
             "urls.  Submodule url '" + url + "' fails.";
     }
     const remotePath = url.slice(subrepoUrlBase.length);
-    const localPath = path.join(subrepoRootPath, remotePath);
+    const localPath = path.join(subrepoRootPath, remotePath + subrepoSuffix);
     if (localPath[0] === "/") {
         return localPath;
     } else {


### PR DESCRIPTION
These bugs fixed by the first patch weren't caught by tests because in one case, the buggy method was mocked, and in another, we didn't actually test the hook itself because that would involve spinning up a whole new process, which our framework doesn't really support.

I tested this manually in success and in failure cases, and it seems to work now.

The second patch handles the traditional "foo.git" name for a bare repository.