### PR TITLE
Fix notes readRAST test

### DIFF
--- a/test/util/read_repo_ast_util.js
+++ b/test/util/read_repo_ast_util.js
@@ -1196,7 +1196,7 @@ describe("readRAST", function () {
         const head = yield r.getHeadCommit();
         const headId = head.id();
 
-        const sig = NodeGit.Signature.default(r);
+        const sig = r.defaultSignature();
 
         yield NodeGit.Note.create(r, "refs/notes/test",
                                   sig, sig, headId, "note", 0);


### PR DESCRIPTION
This is failing in Travis -- I hypothesize that the "default signature" depends on git config, which defaults to my ~/.gitconfig.  But I'm not actutally sure.  This fix is based on copying what the remainder of the tests here do.  Fixes #77.