### PR TITLE
Rebranding updates

### DIFF
--- a/node/lib/cmd/cherrypick.js
+++ b/node/lib/cmd/cherrypick.js
@@ -83,7 +83,8 @@ exports.executeableSubcommand = co.wrap(function *(args) {
     const Status     = require("../util/status");
 
     const repo = yield GitUtil.getCurrentRepo();
-    yield Status.ensureCleanAndConsistent(repo);
+    const status = yield Status.getRepoStatus(repo);
+    Status.ensureCleanAndConsistent(status);
 
     for (let i = 0; i < args.commits.length; ++i) {
         let commitish = args.commits[i];

--- a/node/lib/cmd/rebase.js
+++ b/node/lib/cmd/rebase.js
@@ -76,7 +76,8 @@ exports.executeableSubcommand = co.wrap(function *(args) {
     const Status  = require("../util/status");
 
     const repo = yield GitUtil.getCurrentRepo();
-    yield Status.ensureCleanAndConsistent(repo);
+    const status = yield Status.getRepoStatus(repo);
+    Status.ensureCleanAndConsistent(status);
     const commitish = yield GitUtil.resolveCommitish(repo, args.commit);
     if (null === commitish) {
         console.error(`Could not resolve ${colors.red(args.commit)} to a \
@@ -84,5 +85,5 @@ commit.`);
         process.exit(-1);
     }
     const commit = yield repo.getCommit(commitish.id());
-    yield Rebase.rebase(repo, commit);
+    yield Rebase.rebase(repo, commit, status);
 });

--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -200,9 +200,7 @@ exports.push = co.wrap(function *(repo, remote, source, target) {
     assert.isString(target);
 
     const execString = `\
-cd ${repo.workdir()}
-git push ${remote} ${source}:${target}
-`;
+git -C '${repo.workdir()}' push ${remote} ${source}:${target}`;
     try {
         yield exec(execString);
         return null;
@@ -299,10 +297,7 @@ exports.fetch = co.wrap(function *(repo, remoteName) {
     assert.instanceOf(repo, NodeGit.Repository);
     assert.isString(remoteName);
 
-    const execString = `\
-cd '${repo.workdir()}'
-git fetch -q '${remoteName}'
-`;
+    const execString = `git -C '${repo.workdir()}' fetch -q '${remoteName}'`;
     try {
         return yield exec(execString);
     }

--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -128,6 +128,27 @@ exports.isValidRemoteName = co.wrap(function *(repo, name) {
 });
 
 /**
+ * Return the URL for the remote named "origin" in the specified `repo`, or
+ * null if there is no remote named "origin".
+ *
+ * @async
+ * @param {NodeGit.Repository} repo
+ * @return {String|null}
+ */
+exports.getOriginUrl = co.wrap(function *(repo) {
+    assert.instanceOf(repo, NodeGit.Repository);
+
+    let remote;
+    try {
+        remote = yield repo.getRemote("origin");
+    }
+    catch (e) {
+        return null;
+    }
+    return remote.url();
+});
+
+/**
  * Return the remote branch having the specified local `branchName` in the
  * remote having the specified `remoteName` in the specified `repo`, or null if
  * no such branch exists.  The behavior is undefined unless 'remoteName' refers
@@ -464,4 +485,20 @@ exports.isUpToDate = co.wrap(function *(repo, source, target) {
         return true;                                                  // RETURN
     }
     return yield NodeGit.Graph.descendantOf(repo, source, target);
+});
+
+/**
+ * Set the HEAD of the specified `repo` to the specified `commit` and force the
+ * contents to match it.
+ *
+ * @async
+ * @param {NodeGit.Repository} repo
+ * @param {NodeGit.Commit}     commit
+ */
+exports.setHeadHard = co.wrap(function *(repo, commit) {
+    assert.instanceOf(repo, NodeGit.Repository);
+    assert.instanceOf(commit, NodeGit.Commit);
+
+    repo.setHeadDetached(commit);
+    yield NodeGit.Reset.reset(repo, commit, NodeGit.Reset.TYPE.HARD);
 });

--- a/node/lib/util/open.js
+++ b/node/lib/util/open.js
@@ -33,83 +33,54 @@
  * This module contains methods for opening repositories.
  */
 const assert  = require("chai").assert;
-const NodeGit = require("nodegit");
 const co      = require("co");
 
+const GitUtil             = require("./git_util");
 const SubmoduleConfigUtil = require("./submodule_config_util");
-const SubmoduleUtil       = require("./submodule_util");
 
 /**
  * Open the submodule having the specified `submoduleName` in the specified
- * `repo`; configure it to be checked out on the specified `branchName` on the
- * specified `commitSha`.
+ * `repo`; fetch the specified `commitSha` and set HEAD to point to it.
+ * Configure the "origin" remote to the specified `url`, using the specified
+ * `baseUrl` to resolve against `url` if it is relative.
  *
  * @async
- * @param {NodeGit.Repository} repo
- * @param {String}             submoduleName
- * @param {String}             url
- * @param {String}             branchName
- * @param {String}             commitSha
+ * @param {String|null} repoOriginUrl
+ * @param {String}      repoPath
+ * @param {String}      submoduleName
+ * @param {String}      url
+ * @param {String}      commitSha
  * @return {NodeGit.Repository}
  */
-exports.openBranchOnCommit = co.wrap(function *(repo,
-                                                submoduleName,
-                                                url,
-                                                branchName,
-                                                commitSha) {
-    assert.instanceOf(repo, NodeGit.Repository);
+exports.openOnCommit = co.wrap(function *(repoOriginUrl,
+                                          repoPath,
+                                          submoduleName,
+                                          url,
+                                          commitSha) {
+    if (null !== repoOriginUrl) {
+        assert.isString(repoOriginUrl);
+    }
+    assert.isString(repoPath);
     assert.isString(submoduleName);
     assert.isString(url);
-    assert.isString(branchName);
     assert.isString(commitSha);
 
+    // Set up the submodule.
+
     const submoduleRepo = yield SubmoduleConfigUtil.initSubmoduleAndRepo(
-                                                                repo.workdir(),
+                                                                repoOriginUrl,
+                                                                repoPath,
                                                                 submoduleName,
                                                                 url);
 
-    yield SubmoduleUtil.fetchSubmodule(repo, submoduleRepo);
+    // Fetch the needed sha.
 
-    const branch = yield submoduleRepo.createBranch(branchName,
-                                                    commitSha,
-                                                    0,
-                                                    repo.defaultSignature(),
-                                                    "git-meta branch");
+    yield GitUtil.fetchSha(submoduleRepo, commitSha);
 
-    // And check it out.
+    // Check out HEAD
 
-    yield submoduleRepo.checkoutBranch(branch);
+    const commit = yield submoduleRepo.getCommit(commitSha);
+    yield GitUtil.setHeadHard(submoduleRepo, commit);
+
     return submoduleRepo;
-});
-
-/**
- * Open the submodule having the specified `submoduleName` in the specified
- * `repo`.  Return an object containing the submodule and its repository.
- *
- * @async
- * @param {NodeGit.Repository} repo
- * @param {String}             submoduleName
- * @param {String}             url
- * @return {NodeGit.Repository}
- */
-exports.open = co.wrap(function *(repo, submoduleName, url) {
-    assert.instanceOf(repo, NodeGit.Repository);
-    assert.isString(submoduleName);
-    assert.isString(url);
-
-    const shas = yield SubmoduleUtil.getCurrentSubmoduleShas(repo,
-                                                             [submoduleName]);
-    const sha = shas[0];
-
-    // Identify the branch name used by the parent repository.  We'll use this
-    // name as the branch to configure the new submodule with.
-
-    const activeBranch = yield repo.getCurrentBranch();
-    const branchName = activeBranch.shorthand();
-
-    return yield exports.openBranchOnCommit(repo,
-                                            submoduleName,
-                                            url,
-                                            branchName,
-                                            sha);
 });

--- a/node/lib/util/pull.js
+++ b/node/lib/util/pull.js
@@ -99,7 +99,8 @@ exports.pull = co.wrap(function *(metaRepo, remoteName, source) {
     // First do some sanity checking on the repos to see if they have a remote
     // with `remoteName` and are clean.
 
-    yield Status.ensureCleanAndConsistent(metaRepo);
+    const status = yield Status.getRepoStatus(metaRepo);
+    Status.ensureCleanAndConsistent(status);
 
     // Fetch and validate the sub-repos.
 

--- a/node/lib/util/repo_ast_test_util.js
+++ b/node/lib/util/repo_ast_test_util.js
@@ -119,7 +119,7 @@ exports.createRepo = co.wrap(function *(input) {
  *
  * @param {String|RepoAST}  input
  * @param {String|RepoAST}  expectedShorthand
- * @param {(NodeGit.Repository) => Promise} manipulator
+ * @param {(NodeGit.Repository, commitMap, oldMap) => Promise} manipulator
  */
 exports.testRepoManipulator = co.wrap(function *(input,
                                                  expected,
@@ -130,7 +130,9 @@ exports.testRepoManipulator = co.wrap(function *(input,
     }
     const written = yield exports.createRepo(input);
     const repo = written.repo;
-    const userMap = yield manipulator(repo);
+    const userMap = yield manipulator(repo,
+                                      written.commitMap,
+                                      written.oldCommitMap);
     if (undefined !== userMap) {
         Object.assign(written.commitMap, userMap);
     }

--- a/node/lib/util/repo_status.js
+++ b/node/lib/util/repo_status.js
@@ -108,9 +108,6 @@ class Submodule {
      *     `workdirShaRelation` is not `COMMIT_RELATION.SAME`, or
      *     `workdirShaRelation` is `COMMIT_RELATION.SAME but `indexSha` and
      *     `repoStatus.headCommit` differ
-     *   - COMMIT_RELATION.UNKNOWN is specified for `workdirShaRelation` -- the
-     *     only reason for an unknown relation is when a commit is staged to
-     *     the index and the submodule repo is not open.
      *
      * @param {Object} status
      * @param {RepoStatus.FILESTATUS} [status.indexStatus]
@@ -257,8 +254,6 @@ class Submodule {
             else {
                 assert.notEqual(this.d_workdirShaRelation,
                                 COMMIT_RELATION.SAME);
-                assert.notEqual(this.d_workdirShaRelation,
-                                COMMIT_RELATION.UNKNOWN);
             }
         }
         else {

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -591,6 +591,14 @@ git -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
 
         let index = null;
 
+        // If the base repo has a remote, read its url.
+
+        const remotes = ast.remotes;
+        let originUrl = null;
+        if ("origin" in remotes) {
+            originUrl = remotes.origin.url;
+        }
+
         // Render open submodules.
 
         for (let subName in ast.openSubmodules) {
@@ -603,6 +611,7 @@ git -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
             const openSubAST = ast.openSubmodules[subName];
 
             const subRepo = yield SubmoduleConfigUtil.initSubmoduleAndRepo(
+                                                                originUrl,
                                                                 repo.workdir(),
                                                                 subName,
                                                                 sub.url);

--- a/node/test/util/cherrypick.js
+++ b/node/test/util/cherrypick.js
@@ -102,16 +102,14 @@ describe("cherrypick", function () {
         "picking one sub": {
             input: "\
 a=Ax:Cz-y;Cy-x;Bfoo=z|\
-x=S:C8-3 s=Sa:z;C3-2;C2-1 s=Sa:x;Bfoo=8;Bmaster=2;Os Bmaster=x!*=master",
-            expected:
-                "x=E:C9-2 s=Sa:zs;Bmaster=9;Os Czs-x z=z!Bmaster=zs!*=master",
+x=S:C8-3 s=Sa:z;C3-2;C2-1 s=Sa:x;Bfoo=8;Bmaster=2;Os H=x",
+            expected: "x=E:C9-2 s=Sa:zs;Bmaster=9;Os Czs-x z=z!H=zs",
         },
         "picking closed sub": {
             input: "\
 a=Ax:Cz-y;Cy-x;Bfoo=z|\
 x=S:C8-3 s=Sa:z;C3-2;C2-1 s=Sa:x;Bfoo=8;Bmaster=2",
-            expected:
-                "x=E:C9-2 s=Sa:zs;Bmaster=9;Os Czs-x z=z!Bmaster=zs!*=master",
+            expected: "x=E:C9-2 s=Sa:zs;Bmaster=9;Os Czs-x z=z!H=zs",
         },
         "picking two closed subs": {
             input: "\
@@ -123,8 +121,8 @@ Bfoo=8;Bmaster=2",
             expected: "\
 x=E:C9-2 s=Sa:zs,t=Sb:ct;\
 Bmaster=9;\
-Os Czs-x z=z!Bmaster=zs!*=master;\
-Ot Cct-a c=c!Bmaster=ct!*=master",
+Os Czs-x z=z!H=zs;\
+Ot Cct-a c=c!H=ct",
         },
     };
 

--- a/node/test/util/git_util.js
+++ b/node/test/util/git_util.js
@@ -109,6 +109,37 @@ describe("GitUtil", function () {
         });
     });
 
+    describe("getOriginUrl", function () {
+        const cases = {
+            "good": { i: "a=B|x=Ca", e: "a" },
+            "bad": { i: "x=S", e: null},
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                const written = yield RepoASTTestUtil.createMultiRepos(c.i);
+                const x = written.repos.x;
+                const result = yield GitUtil.getOriginUrl(x);
+
+                // If we are expecting a URL, `expected` will not be null.  In
+                // that case, we need map the physical value written to disk
+                // for that logical URL, and check that physical value against
+                // what was returned by `getOriginUrl`.
+
+                let expected = c.e;
+                if (null !== expected) {
+                    for (let key in written.urlMap) {
+                        if (expected === written.urlMap[key]) {
+                            expected = key;
+                        }
+                    }
+                }
+
+                assert.equal(result, expected);
+            }));
+        });
+    });
+
     describe("findRemoteBranch", function () {
         const cases = {
             "simple fail": {
@@ -215,11 +246,12 @@ describe("GitUtil", function () {
 
             try {
                 yield GitUtil.getCurrentRepo();
-                assert(false, "didn't throw error");
             }
             catch (e) {
                 assert.instanceOf(e, UserError);
+                return;
             }
+            assert(false, "didn't throw error");
         }));
     });
 
@@ -271,11 +303,12 @@ describe("GitUtil", function () {
                                                                 c.input,
                                                                 c.expected,
                                                                 c.manipulator);
-                    assert(!c.fail);
                 }
                 catch (e) {
                     assert(c.fail, e.stack);
+                    return;
                 }
+                assert(!c.fail);
             }));
         });
     });
@@ -406,11 +439,12 @@ describe("GitUtil", function () {
                                                                 c.input,
                                                                 c.expected,
                                                                 c.manipulator);
-                    assert(!c.fail);
                 }
                 catch (e) {
                     assert(c.fail, e.stack);
+                    return;
                 }
+                assert(!c.fail);
             }));
         });
     });
@@ -453,11 +487,12 @@ describe("GitUtil", function () {
             const bad = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
             try {
                 yield GitUtil.fetchSha(repo, bad);
-                assert(false, "Bad sha, should have failed");
             }
             catch (e) {
                 assert.instanceOf(e, UserError);
+                return;
             }
+            assert(false, "Bad sha, should have failed");
         }));
     });
 
@@ -549,6 +584,32 @@ describe("GitUtil", function () {
                 const to = oldMap[c.to];
                 const result = yield GitUtil.isUpToDate(repo, from, to);
                 assert.equal(result, c.expected);
+            }));
+        });
+    });
+
+    describe("setHeadHard", function () {
+        function makeSetter(commitId) {
+            return co.wrap(function *(repo, commitMap, oldMap) {
+                const realId = oldMap[commitId];
+                const commit = yield repo.getCommit(realId);
+                yield GitUtil.setHeadHard(repo, commit);
+            });
+        }
+        const cases = {
+            "same commit": { i: "S", c: "1", e: "S:H=1" },
+            "old commit": {
+                i: "S:C2-1;Bmaster=2",
+                c: "1",
+                e: "S:C2-1;H=1;Bmaster=2"
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            it(caseName, co.wrap(function *() {
+                const c = cases[caseName];
+                yield RepoASTTestUtil.testRepoManipulator(c.i,
+                                                          c.e,
+                                                          makeSetter(c.c));
             }));
         });
     });

--- a/node/test/util/include.js
+++ b/node/test/util/include.js
@@ -52,11 +52,12 @@ describe("include", function () {
             const path = "";
             try {
                 yield Include.include(repo, url, path);
-                assert(false, "didn't throw error");
             } 
             catch (e) {
                 assert.instanceOf(e, UserError);
+                return;
             }
+            assert(false, "didn't throw error");
         }));
 
         it("fails with an invalid url", co.wrap(function *() {
@@ -64,11 +65,12 @@ describe("include", function () {
             const path = "foo";
             try {
                 yield Include.include(repo, url, path);
-                assert(false, "didn't throw error");
             } 
             catch (e) {
                 assert.instanceOf(e, UserError);
+                return;
             }
+            assert(false, "didn't throw error");
         }));
     });
 
@@ -102,39 +104,18 @@ describe("include", function () {
             const submoduleRepo = 
                 yield NodeGit.Repository.open(repo.workdir() + path);
             const submoduleHead = yield submoduleRepo.getHeadCommit();
-            
+
             assert(externalHead.id().equal(submoduleHead.id()), 
                 "head commits should be equal");
         }));
 
-        it("should create the branch", co.wrap(function *() {
-            const externalBranch = yield externalRepo.getCurrentBranch();
-            const submoduleRepo = 
-                yield NodeGit.Repository.open(repo.workdir() + path);
+        it("current should be head and detached", co.wrap(function *() {
+            const submoduleRepo =
+                          yield NodeGit.Repository.open(repo.workdir() + path);
             const submoduleBranch = yield submoduleRepo.getCurrentBranch();
-            
-            assert.equal(submoduleBranch.shorthand(), 
-                externalBranch.shorthand());
-        }));
 
-        it("should create the branch if not on master", co.wrap(function *() {
-
-            // create a new repo on the branch "public" and 
-            // include the externalRepo
-
-            const branchName = "public";
-            const newRepo = 
-                yield TestUtil.createSimpleRepositoryOnBranch(branchName);
-            const newPath = "bar";
-            yield Include.include(newRepo, externalRepo.workdir(), newPath);
-
-            const repoBranch = yield newRepo.getCurrentBranch();
-            const submoduleRepo = 
-                yield NodeGit.Repository.open(newRepo.workdir() + newPath);
-            const submoduleBranch = yield submoduleRepo.getCurrentBranch();
-            
-            assert.equal(repoBranch.shorthand(), submoduleBranch.shorthand());
-            assert.equal(submoduleBranch.shorthand(), branchName);
+            assert.equal(submoduleBranch.shorthand(), "HEAD");
+            assert.equal(submoduleRepo.headDetached(), 1);
         }));
 
         it("should have signature of the current repo", co.wrap(function *() {

--- a/node/test/util/merge.js
+++ b/node/test/util/merge.js
@@ -143,14 +143,14 @@ describe("merge", function () {
         "ff merge with submodule change": {
             initial: "a=S:C4-1;Bfoo=4|x=U:C5-2 s=Sa:4;Bfoo=5",
             fromCommit: "5",
-            expected: "x=E:Bmaster=5;Os Bmaster=4!*=master",
+            expected: "x=E:Bmaster=5;Os H=4",
         },
         "fforwardable but disallowed with submodule change": {
             initial: "a=S:C4-1;Bfoo=4|x=U:C5-2 s=Sa:4;Bfoo=5",
             fromCommit: "5",
             mode: MODE.FORCE_COMMIT,
             expected:
-                "x=E:Bmaster=x;Cx-2,5 s=Sa:s;Os Cs-1,4 4=4!Bmaster=s!*=master",
+                "x=E:Bmaster=x;Cx-2,5 s=Sa:s;Os Cs-1,4 4=4!H=s",
         },
         "fforwardable merge with non-ffwd submodule change": {
             initial: "\
@@ -158,7 +158,7 @@ a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|\
 x=U:C3-2 s=Sa:b;C4-3 s=Sa:c;Bmaster=3;Bfoo=4",
             fromCommit: "4",
             expected:
-                "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!Bmaster=s!*=master;Bmaster=x",
+                "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!H=s;Bmaster=x",
         },
         "fforwardable merge with non-ffwd submodule change, ff requested": {
             initial: "\
@@ -166,7 +166,7 @@ a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|\
 x=U:C3-2 s=Sa:b;C4-3 s=Sa:c;Bmaster=3;Bfoo=4",
             fromCommit: "4",
             mode: MODE.FF_ONLY,
-            expected: "x=E:Os Bmaster=b!*=master",
+            expected: "x=E:Os H=b",
             fails: true,
         },
         "non-ffmerge with non-ffwd submodule change": {
@@ -175,22 +175,22 @@ a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|\
 x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4",
             fromCommit: "4",
             expected:
-                "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!Bmaster=s!*=master;Bmaster=x",
+                "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!H=s;Bmaster=x",
         },
         "non-ffmerge with non-ffwd submodule change, sub open": {
             initial: "\
 a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|\
-x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os Bmaster=b!*=master",
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os",
             fromCommit: "4",
             expected:
-                "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!Bmaster=s!*=master;Bmaster=x",
+                "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!H=s;Bmaster=x",
         },
         "submodule commit is up-to-date": {
             initial: "\
 a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|\
 x=U:C3-2 s=Sa:c;C4-2 s=Sa:b,x=y;Bmaster=3;Bfoo=4",
             fromCommit: "4",
-            expected: "x=E:Cx-3,4 x=y;Os Bmaster=c!*=master;Bmaster=x",
+            expected: "x=E:Cx-3,4 x=y;Os H=c;Bmaster=x",
         },
         "submodule commit is same": {
             initial: "\
@@ -206,8 +206,8 @@ x=U:C3-2 s=Sa:b,t=Sa:c;C4-3 s=Sa:c,t=Sa:d;Bmaster=3;Bfoo=4",
             fromCommit: "4",
             expected: "\
 x=E:Cx-3,4 s=Sa:s,t=Sa:d;Bmaster=x;\
-Os Cs-b,c c=c!Bmaster=s!*=master;\
-Ot Bmaster=d!*=master",
+Os Cs-b,c c=c!H=s;\
+Ot H=d",
         },
     };
     Object.keys(cases).forEach(caseName => {

--- a/node/test/util/rebase.js
+++ b/node/test/util/rebase.js
@@ -118,16 +118,14 @@ describe("rebase", function () {
 a=Aa:Cb-a;Cc-a;Bmaster=b;Bfoo=c|\
 x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Bother=3",
             rebaser: rebaser("x", "4"),
-            expected: "\
-x=E:C3M-4 s=Sa:bs;Bmaster=3M;Os Cbs-c b=b!Bmaster=bs!*=master",
+            expected: "x=E:C3M-4 s=Sa:bs;Bmaster=3M;Os Cbs-c b=b!H=bs",
         },
         "rebase change in sub, sub already open": {
             initial: "\
 a=Aa:Cb-a;Cc-a;Bmaster=b;Bfoo=c|\
-x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Bother=3;Os Bmaster=b!*=master",
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Bother=3;Os H=b",
             rebaser: rebaser("x", "4"),
-            expected: "\
-x=E:C3M-4 s=Sa:bs;Bmaster=3M;Os Cbs-c b=b!Bmaster=bs!*=master",
+            expected: "x=E:C3M-4 s=Sa:bs;Bmaster=3M;Os Cbs-c b=b!H=bs",
         },
         "ffwd, but not sub (should ffwd anyway)": {
             initial: "\
@@ -141,8 +139,7 @@ x=U:C3-2 s=Sa:b;C4-3 s=Sa:c;Bmaster=3;Bfoo=4;Bother=3",
 a=Aa:Cb-a;Cc-b;Bmaster=b;Bfoo=c|\
 x=U:C3-2 3=3,s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Bother=3",
             rebaser: rebaser("x", "4"),
-            expected: "\
-x=E:C3M-4 3=3;Bmaster=3M;Os Bmaster=c!*=master",
+            expected: "x=E:C3M-4 3=3;Bmaster=3M;Os H=c",
         },
         "rebase two changes in sub": {
             initial: "\
@@ -150,7 +147,7 @@ a=Aa:Cb-a;Cc-b;Cd-a;Bmaster=c;Bfoo=d|\
 x=U:C3-2 s=Sa:c;C4-2 s=Sa:d;Bmaster=3;Bfoo=4;Bother=3",
             rebaser: rebaser("x", "4"),
             expected: "\
-x=E:C3M-4 s=Sa:cs;Bmaster=3M;Os Ccs-bs c=c!Cbs-d b=b!Bmaster=cs!*=master",
+x=E:C3M-4 s=Sa:cs;Bmaster=3M;Os Ccs-bs c=c!Cbs-d b=b!H=cs",
         },
     };
     Object.keys(cases).forEach(caseName => {

--- a/node/test/util/repo_ast_test_util.js
+++ b/node/test/util/repo_ast_test_util.js
@@ -317,11 +317,12 @@ describe("RepoASTTestUtil", function () {
                                                                   c.m,
                                                                   c.userError,
                                                                   c.options);
-                    assert(!c.fails);
                 }
                 catch (e) {
                     assert(c.fails, e.stack);
+                    return;
                 }
+                assert(!c.fails);
             }));
         });
     });

--- a/node/test/util/repo_ast_util.js
+++ b/node/test/util/repo_ast_util.js
@@ -411,11 +411,12 @@ describe("RepoAstUtil", function () {
             it(caseName, function () {
                 try {
                     RepoASTUtil.assertEqualASTs(c.actual, c.expected);
-                    assert(!c.fails);
                 }
                 catch (e) {
                     assert(c.fails, e.stack);
+                    return;
                 }
+                assert(!c.fails);
             });
         });
     });

--- a/node/test/util/shorthand_parser_util.js
+++ b/node/test/util/shorthand_parser_util.js
@@ -586,8 +586,11 @@ describe("ShorthandParserUtil", function () {
     describe("parseMultiRepoShorthand", function () {
         const AST = RepoAST;
         const Commit = AST.Commit;
+        const Remote = AST.Remote;
         const Submodule = AST.Submodule;
+        const B = ShorthandParserUtil.RepoType.B;
         const S = ShorthandParserUtil.RepoType.S;
+        const U = ShorthandParserUtil.RepoType.U;
         const cases = {
             "simple": { i: "a=S", e: { a: "S"} },
             "multiple": {
@@ -665,6 +668,7 @@ describe("ShorthandParserUtil", function () {
                             foo: RepoASTUtil.cloneRepo(S, "a").copy({
                                 branches: {},
                                 currentBranchName: null,
+                                remotes: { origin: new Remote("a") },
                             })
                         }
                     }),
@@ -680,6 +684,7 @@ describe("ShorthandParserUtil", function () {
                             foo: RepoASTUtil.cloneRepo(S, "a").copy({
                                 branches: { m: "1" },
                                 currentBranchName: null,
+                                remotes: { origin: new Remote("a") },
                             })
                         }
                     }),
@@ -708,6 +713,7 @@ describe("ShorthandParserUtil", function () {
                                 },
                                 branches: { m: "1", aa: "2" },
                                 currentBranchName: null,
+                                remotes: { origin: new Remote("a") },
                             })
                         }
                     }),
@@ -725,6 +731,7 @@ describe("ShorthandParserUtil", function () {
                                 index: { x: "y"},
                                 workdir: { u: "2" },
                                 currentBranchName: null,
+                                remotes: { origin: new Remote("a") },
                             })
                         }
                     }),
@@ -785,7 +792,7 @@ describe("ShorthandParserUtil", function () {
                         },
                         openSubmodules: {
                             s: ShorthandParserUtil.parseRepoShorthand(
-                                "S:C3-1;H=3;Bmaster=;Rorigin=a master=1"),
+                                "S:C3-1;H=3;Bmaster=;Rorigin=a"),
                         },
                     }),
                 },
@@ -816,6 +823,7 @@ describe("ShorthandParserUtil", function () {
                                 },
                                 branches: { x: "2" },
                                 currentBranchName: null,
+                                remotes: { origin: new Remote("a") },
                             })
                         }
                     }),
@@ -861,6 +869,40 @@ describe("ShorthandParserUtil", function () {
                         branches: { master: "2" },
                         head: "2",
                         currentBranchName: "master",
+                    }),
+                },
+            },
+            "missing commits in open sub": {
+                i: "a=B:C8-1;Bmaster=8|b=U:Os",
+                e: {
+                    a: B.copy({
+                        commits: {
+                            "1": new Commit({
+                                changes: {
+                                    "README.md": "hello world"
+                                },
+                                message: "the first commit",
+                            }),
+                            "8": new Commit({
+                                parents: ["1"],
+                                changes: { "8": "8" },
+                                message: "message",
+                            }),
+                        },
+                        branches: {
+                            master: "8",
+                        },
+                        currentBranchName: "master",
+                    }),
+                    b: U.copy({
+                        openSubmodules: {
+                            s: RepoASTUtil.cloneRepo(S, "a").copy({
+                                branches: {},
+                                head: "1",
+                                currentBranchName: null,
+                                remotes: { origin: new Remote("a") },
+                            })
+                        },
                     }),
                 },
             },

--- a/node/test/util/status.js
+++ b/node/test/util/status.js
@@ -469,33 +469,6 @@ describe("Status", function () {
                 }),
                 regex: /foo/,
             },
-            "bad branch": {
-                input: new Submodule({
-                    indexStatus: STAT.ADDED,
-                    indexSha: "1",
-                    indexUrl: "a",
-                    workdirShaRelation: RELATION.SAME,
-                    repoStatus: new RepoStatus({
-                        headCommit: "1",
-                        currentBranchName: "bar",
-                    })
-                }),
-                branch: "foo",
-                regex: /On wrong branch.*bar/,
-            },
-            "no branch": {
-                input: new Submodule({
-                    indexStatus: STAT.ADDED,
-                    indexSha: "1",
-                    indexUrl: "a",
-                    workdirShaRelation: RELATION.SAME,
-                    repoStatus: new RepoStatus({
-                        headCommit: "1",
-                    })
-                }),
-                branch: "foo",
-                regex: /not on a branch/,
-            },
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];
@@ -623,8 +596,20 @@ describe("Status", function () {
                     }),
                 }),
             },
-            "old in open": {
+            "missing commit in open": {
                 state: "a=S:C2-1;Bb=2|x=S:I s=Sa:2;Os H=1",
+                expected: new Submodule({
+                    indexSha: "2",
+                    indexUrl: "a",
+                    indexStatus: FILESTATUS.ADDED,
+                    workdirShaRelation: RELATION.UNKNOWN,
+                    repoStatus: new RepoStatus({
+                        headCommit: "1",
+                    }),
+                }),
+            },
+            "old in open": {
+                state: "a=S:C2-1;Bb=2|x=S:I s=Sa:2;Os H=1!Bf=2",
                 expected: new Submodule({
                     indexSha: "2",
                     indexUrl: "a",
@@ -636,7 +621,7 @@ describe("Status", function () {
                 }),
             },
             "unrelated in open": {
-                state: "a=S:C2-1;C3-1;Bb=2;Bc=3|x=S:I s=Sa:2;Os H=3",
+                state: "a=S:C2-1;C3-1;Bb=2;Bc=3|x=S:I s=Sa:2;Os H=3!Bf=2",
                 expected: new Submodule({
                     indexSha: "2",
                     indexUrl: "a",
@@ -1006,10 +991,6 @@ describe("Status", function () {
                 state: "x=S",
                 fails: false,
             },
-            "no current branch": {
-                state: "x=S:*=",
-                fails: true,
-            },
             "good sub": {
                 state: "a=S|x=S:C2-1 s=Sa:1;Bmaster=2",
                 fails: false,
@@ -1021,14 +1002,6 @@ describe("Status", function () {
             "good open sub": {
                 state: "a=S|x=S:C2-1 s=Sa:1;Bmaster=2;Os Bmaster=1!*=master",
                 fails: false,
-            },
-            "no sub branch": {
-                state: "a=S|x=S:C2-1 s=Sa:1;Bmaster=2;Os",
-                fails: true,
-            },
-            "sub on wrong branch": {
-                state: "a=S|x=S:C2-1 s=Sa:1;Bmaster=2;Os Bfoo=1!*=foo",
-                fails: true,
             },
             "sub with new commit in open repo": {
                 state: "a=S|x=S:C2-1 s=Sa:1;Bmaster=2;Os Bmaster=2!*=master",
@@ -1068,10 +1041,6 @@ describe("Status", function () {
                 state: "x=S",
                 fails: false,
             },
-            "inconsistent": {
-                state: "x=S:*=",
-                fails: true,
-            },
             "unclean": {
                 state: "x=S:I foo=bar",
                 fails: true,
@@ -1083,8 +1052,9 @@ describe("Status", function () {
                 const w = yield RepoASTTestUtil.createMultiRepos(c.state);
                 const x = w.repos.x;
                 let error = "";
+                const status = yield Status.getRepoStatus(x);
                 try {
-                    yield Status.ensureCleanAndConsistent(x);
+                    Status.ensureCleanAndConsistent(status);
                     assert.equal(c.fails, false);
                     return;                                           // RETURN
                 }

--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -238,8 +238,9 @@ describe("SubmoduleUtil", function () {
             it(caseName, co.wrap(function *() {
                 const written = yield RepoASTTestUtil.createRepo(c.state);
                 const repo = written.repo;
+                const index = yield repo.index();
                 const result = yield SubmoduleUtil.getCurrentSubmoduleShas(
-                                                                      repo,
+                                                                      index,
                                                                       c.names);
                 const mappedResult = result.map(id => written.commitMap[id]);
                 assert.deepEqual(mappedResult, c.expected);
@@ -349,41 +350,6 @@ describe("SubmoduleUtil", function () {
             assert.equal(x.name, "x");
             assert.instanceOf(x.repo, NodeGit.Repository);
         }));
-    });
-
-    describe("fetchSubmodule", function () {
-        // This method should probably go away, but I'll do a quick test for it
-        // anyway.  It defers to `GitUtil.fetch`, so we'll just do basic
-        // testing.
-        // We'll always do the operation on repo 'x', subrepo 'a'.
-
-        const fetcher = co.wrap(function *(repos) {
-            const repo = repos.x;
-            const subRepo = yield SubmoduleUtil.getRepo(repo, "a");
-            const result = yield SubmoduleUtil.fetchSubmodule(repo, subRepo);
-            assert.equal(result, "origin");
-        });
-
-        const cases = {
-            "nothing fetched": {
-                state: "a=S|x=S:C2-1 a=Sa:1;Oa;H=2",
-                expected: "a=S|x=S:C2-1 a=Sa:1;Oa;H=2",
-            },
-            "fetched a branch": {
-                state: "a=S:Bfoo=1|x=S:C2-1 a=Sa:1;Oa;H=2",
-                expected:
-                  "a=S:Bfoo=1|x=S:C2-1 a=Sa:1;Oa Rorigin=a master=1,foo=1;H=2",
-            },
-        };
-
-        Object.keys(cases).forEach(caseName => {
-            const c = cases[caseName];
-            it(caseName, co.wrap(function *() {
-                yield RepoASTTestUtil.testMultiRepoManipulator(c.state,
-                                                               c.expected,
-                                                               fetcher);
-            }));
-        });
     });
 
     describe("getSubmoduleChanges", function () {


### PR DESCRIPTION
Fixed most of the commands to have synthetic-meta-ref logic. I include these in one PR because they depended on implementation code that changed and could not be done individually.