### PR TITLE
GitUtil should use git fetch for sha.

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -357,7 +357,7 @@ exports.fetchSha  = co.wrap(function *(repo, sha) {
     }
 
     const execString = `\
-git -C ${repo.workdir()} fetch-pack -q '${origin.url()}' ${sha}
+git -C ${repo.workdir()} fetch -q '${origin.url()}' ${sha}
 `;
     try {
         return yield exec(execString);


### PR DESCRIPTION
GitUtil should use git fetch for sha-fetching.