### PR TITLE
Stop using `Object.values`

### DIFF
--- a/node/lib/util/reset.js
+++ b/node/lib/util/reset.js
@@ -74,7 +74,7 @@ function getType(type) {
 exports.reset = co.wrap(function *(repo, commit, type) {
     assert.instanceOf(repo, NodeGit.Repository);
     assert.instanceOf(commit, NodeGit.Commit);
-    assert.oneOf(type, Object.values(TYPE));
+    assert.isString(type);
 
     const resetType = getType(type);
 


### PR DESCRIPTION
Not supported on earlier versions of node.  Note that an assertion will still
catch bad type values.