### PR TITLE
Issue #112: Git meta push swallows stdout.

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -231,7 +231,13 @@ exports.push = co.wrap(function *(repo, remote, source, target, force) {
     const execString = `\
 git -C '${repo.workdir()}' push ${forceStr} ${remote} ${source}:${target}`;
     try {
-        yield exec(execString);
+        const result = yield exec(execString);
+        if (result.stdout) {
+            console.log(result.stdout);
+        }
+        if (result.stderr) {
+            console.error(result.stderr);
+        }
         return null;
     }
     catch (e) {


### PR DESCRIPTION
Print results of git push to console. Just print them in blocks for now.