### PR TITLE
Push should follow git syntax.

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -518,3 +518,74 @@ exports.setHeadHard = co.wrap(function *(repo, commit) {
     });
     repo.setHeadDetached(commit);
 });
+
+/**
+ * @class {Refspec}
+ *
+ * This class represents the definition of a refspec.
+ */
+class Refspec {
+    /**
+     * Create a new `Refspec` object.
+     *
+     * @param {Boolean} force whether or not the refspec begins with +
+     * @param {String} src
+     * @param {String} dst
+     * @constructor
+     */
+    constructor(force, src, dst) {
+        assert.isBoolean(force);
+        assert.isString(src);
+        assert.isString(dst);
+        this.d_force = force;
+        this.d_src = src;
+        this.d_dst = dst;
+    }
+
+    /**
+     * @property {Boolean} update ref even if it isn’t a fast-forward
+     */
+    get force() {
+        return this.d_force;
+    }
+
+    /**
+     * @property {String}
+     */
+    get src() {
+        return this.d_src;
+    }
+
+    /**
+     * @property {String}
+     */
+    get dst() {
+        return this.d_dst;
+    }
+}
+
+/**
+ * Create a new `Refspec` object from a string.
+ *
+ * @param {String} str
+ */
+exports.parseRefspec = function(str) {
+    assert.isString(str);
+
+    let force = false;
+
+    if (0 === str.indexOf("+")) {
+        force = true;
+        str = str.replace(/^\+/, "");
+    }
+
+    const objs = str.split(":");
+    if (1 === objs.length) {
+        return new Refspec(force, objs[0], objs[0]);
+    }
+    else if (2 === objs.length && "" !== objs[1]) {
+        return new Refspec(force, objs[0], objs[1]);
+    }
+
+    throw new UserError("Refspec must match the format <src>:<dest>.");
+};

--- a/node/test/util/git_util.js
+++ b/node/test/util/git_util.js
@@ -628,4 +628,30 @@ describe("GitUtil", function () {
             }));
         });
     });
+
+    describe("parseRefspec", function () {
+        const cases = {
+            null: { fail: true },
+            "a": { d_force: false, d_src: "a", d_dst: "a" },
+            ":": { fail: true },
+            "a:": { fail: true },
+            ":b": { d_force: false, d_src: "", d_dst: "b" },
+            "a:b": { d_force: false, d_src: "a", d_dst: "b" },
+            "+a": { d_force: true, d_src: "a", d_dst: "a" },
+            "+:": { fail: true },
+            "+a:": { fail: true },
+            "+:b": { d_force: true, d_src: "", d_dst: "b"},
+            "+a:b": { d_force: true, d_src: "a", d_dst: "b" },
+        };
+        Object.keys(cases).forEach(str => {
+            it(str, function() {
+                try {
+                    const actual = GitUtil.parseRefspec(str);
+                    assert.deepEqual(cases[str], actual);
+                } catch (e) {
+                    assert(true === cases[str].fail);
+                }
+            });
+        });
+    });
 });


### PR DESCRIPTION
Fixes #127 and makes #120 no longer relevant. 

- Multiple refspecs with optional plus (+) and :\<dst\>
- Deleting via :\<dst\>
- Keeps old default behaviour (origin / currentbranch:currentbranch)
