### PR TITLE
Ignore remotes configured in submodules during fetch operations.

### DIFF
--- a/node/lib/cmd/open.js
+++ b/node/lib/cmd/open.js
@@ -78,17 +78,16 @@ exports.configureParser = function (parser) {
 exports.executeableSubcommand = co.wrap(function *(args) {
     const colors = require("colors");
 
-    const GitUtil       = require("../util/git_util");
-    const Open          = require("../util/open");
-    const Status        = require("../util/status");
-    const SubmoduleUtil = require("../util/submodule_util");
-    const UserError     = require("../util/user_error");
+    const GitUtil          = require("../util/git_util");
+    const Open             = require("../util/open");
+    const Status           = require("../util/status");
+    const SubmoduleFetcher = require("../util/submodule_fetcher");
+    const SubmoduleUtil    = require("../util/submodule_util");
+    const UserError        = require("../util/user_error");
 
     const repo   = yield GitUtil.getCurrentRepo();
     const index  = yield repo.index();
     const status = yield Status.getRepoStatus(repo);
-
-    const originUrl = yield GitUtil.getOriginUrl(repo);
 
     let errors = "";
 
@@ -98,6 +97,8 @@ exports.executeableSubcommand = co.wrap(function *(args) {
 
     const shas = yield SubmoduleUtil.getCurrentSubmoduleShas(index,
                                                              subsToOpen);
+    const head = yield repo.getHeadCommit();
+    const fetcher = new SubmoduleFetcher(repo, head);
 
     const openers = subsToOpen.map(co.wrap(function *(name, index) {
         if (!(name in subs)) {
@@ -112,11 +113,7 @@ exports.executeableSubcommand = co.wrap(function *(args) {
             errors += `Submodule ${colors.cyan(name)} has been deleted.\n`;
         }
         else {
-            yield Open.openOnCommit(originUrl,
-                                    repo,
-                                    name,
-                                    sub.indexUrl,
-                                    shas[index]);
+            yield Open.openOnCommit(fetcher, name, shas[index]);
         }
     }));
     yield openers;

--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -342,15 +342,17 @@ exports.fetch = co.wrap(function *(repo, remoteName) {
 });
 
 /**
- * Fetch the specified `sha` from the "origin" repository of the specifieded
- * `repo`.
+ * Fetch the specified `sha` from the specifid `url` into the specified `repo`,
+ * if it does not already exist in `repo`.
  *
  * @async
  * @param {NodeGit.Repository} repo
- * @param {String} sha
+ * @param {String}             url
+ * @param {String}             sha
  */
-exports.fetchSha  = co.wrap(function *(repo, sha) {
+exports.fetchSha  = co.wrap(function *(repo, url, sha) {
     assert.instanceOf(repo, NodeGit.Repository);
+    assert.isString(url);
     assert.isString(sha);
 
     // First, try to get the commit.  If we succeed, no need to fetch.
@@ -362,16 +364,8 @@ exports.fetchSha  = co.wrap(function *(repo, sha) {
     catch (e) {
     }
 
-    let origin;
-    try {
-        origin = yield repo.getRemote("origin");
-    }
-    catch (e) {
-        throw new UserError(`No origin at ${repo.workdir()}.`);
-    }
-
     const execString = `\
-git -C ${repo.workdir()} fetch -q '${origin.url()}' ${sha}
+git -C ${repo.workdir()} fetch -q '${url}' ${sha}
 `;
     try {
         return yield exec(execString);

--- a/node/lib/util/repo_ast_test_util.js
+++ b/node/lib/util/repo_ast_test_util.js
@@ -173,7 +173,7 @@ exports.createMultiRepos = co.wrap(function *(input) {
  *   argument containing a commit map and a url map.  It may return an
  *   object containing:
  *      - `commitMap`  -- specifying actual to logical mappings for new commits
- *      - `reverseMap` -- reverse of `commitMap` -- logical to actual
+ *      - `reverseCommitMap` -- reverse of `commitMap` -- logical to actual
  *      - `urlMap`     -- specifying repo name to path for new repos.  Note
  *                        that this is the opposite format returned by
  *                        `writeRAST` and expected by `mapCommitsAndUrls`.
@@ -203,8 +203,8 @@ exports.createMultiRepos = co.wrap(function *(input) {
  * @param {Object}               options.expectedTransformer.mapping
  * @param {Object}               options.expectedTransformer.mapping.commitMap
  * @param {Object}               options.expectedTransformer.mapping.urlMap
- * @param {Object}               options.expectedTransformer.mapping.reverseMap
- * @param {Object}            options.expectedTransformer.mapping.reverseUrlMap
+ * @param {Object}         options.expectedTransformer.mapping.reverseCommitMap
+ * @param {Object}         options.expectedTransformer.mapping.reverseUrlMap
  * @param {Object}               options.expectedTransformer.return
  */
 exports.testMultiRepoManipulator =
@@ -241,7 +241,7 @@ exports.testMultiRepoManipulator =
     const urlMap    = written.urlMap;
     const mappings = {
         commitMap: commitMap,
-        reverseMap: written.reverseMap,
+        reverseCommitMap: written.reverseCommitMap,
         urlMap: urlMap,
         reverseUrlMap: written.reverseUrlMap,
     };

--- a/node/lib/util/repo_ast_test_util.js
+++ b/node/lib/util/repo_ast_test_util.js
@@ -90,9 +90,7 @@ function createMultiRepoASTMap(input, expectedRepos) {
  * Return the repository an object maps as returned by
  * `WriteRepoASTUtil.writeRAST` as described by the specified `input`.  The
  * value of `input` may be a string parseable by
- * `ShorthandParserUtil.parseRepoShorthand`, or a `RepoAST` object.  The
- * behavior is undefined unless `TestUtil.cleanup` is called some time after
- * this method.
+ * `ShorthandParserUtil.parseRepoShorthand`, or a `RepoAST` object.
  */
 exports.createRepo = co.wrap(function *(input) {
     let ast;
@@ -112,10 +110,9 @@ exports.createRepo = co.wrap(function *(input) {
  * `manipulator` to it, then verify that it has the state described by the
  * specified `expected`.  The `manipulator` must return a map from IDs
  * in the repository to those described in `expectedShorthand`, or
- * `undefined` if no such mapping is required.  The behavior is undefined
- * unless `TestUtil.cleanup` is called some time after this method.  Both
- * `input` and `expected` may be either a string in the syntax accepted by
- * `parseRepoShorthand` or a `RepoAST` object.
+ * `undefined` if no such mapping is required.  Both `input` and `expected` may
+ * be either a string in the syntax accepted by `parseRepoShorthand` or a
+ * `RepoAST` object.
  *
  * @param {String|RepoAST}  input
  * @param {String|RepoAST}  expectedShorthand
@@ -146,8 +143,7 @@ exports.testRepoManipulator = co.wrap(function *(input,
  * `WriteRepoASTUtil.writeMultiRAST` as described by the specified `input` map.
  * The values of `input` may be strings parseable by
  * `ShorthandParserUtil.parseRepoShorthand`, or `RepoAST` objects, or any mix
- * of the two.  The behavior is undefined unless `TestUtil.cleanup` is called
- * some time after this method.
+ * of the two.
  */
 exports.createMultiRepos = co.wrap(function *(input) {
     const inputASTs = createMultiRepoASTMap(input);
@@ -243,20 +239,11 @@ exports.testMultiRepoManipulator =
     const inputRepos = written.repos;
     const commitMap = written.commitMap;
     const urlMap    = written.urlMap;
-    const reverseMap = {};
-    Object.keys(commitMap).forEach(id => {
-        reverseMap[commitMap[id]] = id;
-    });
-    const reverseUrlMap = {};
-    Object.keys(urlMap).forEach(url => {
-        reverseUrlMap[urlMap[url]] = url;
-    });
-
     const mappings = {
         commitMap: commitMap,
-        reverseMap: reverseMap,
+        reverseMap: written.reverseMap,
         urlMap: urlMap,
-        reverseUrlMap: reverseUrlMap,
+        reverseUrlMap: written.reverseUrlMap,
     };
 
     // Pass the repos off to the manipulator.

--- a/node/lib/util/reset.js
+++ b/node/lib/util/reset.js
@@ -34,8 +34,8 @@ const assert  = require("chai").assert;
 const co      = require("co");
 const NodeGit = require("nodegit");
 
-const SubmoduleUtil = require("./submodule_util");
-const GitUtil       = require("./git_util");
+const SubmoduleFetcher = require("./submodule_fetcher");
+const SubmoduleUtil    = require("./submodule_util");
 
 const TYPE = {
     SOFT: "soft",
@@ -87,6 +87,7 @@ exports.reset = co.wrap(function *(repo, commit, type) {
     const openNames = yield SubmoduleUtil.listOpenSubmodules(repo);
     const index = yield repo.index();
     const shas = yield SubmoduleUtil.getCurrentSubmoduleShas(index, openNames);
+    const fetcher = new SubmoduleFetcher(repo, commit);
 
     yield openNames.map(co.wrap(function *(name, index) {
         const sha = shas[index];
@@ -94,7 +95,7 @@ exports.reset = co.wrap(function *(repo, commit, type) {
 
         // Fetch the sha in case we don't already have it.
 
-        yield GitUtil.fetchSha(subRepo, sha);
+        yield fetcher.fetchSha(subRepo, name, sha);
 
         const subCommit = yield subRepo.getCommit(sha);
         yield NodeGit.Reset.reset(subRepo, subCommit, resetType);

--- a/node/lib/util/submodule_fetcher.js
+++ b/node/lib/util/submodule_fetcher.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert  = require("chai").assert;
+const co      = require("co");
+const NodeGit = require("nodegit");
+
+const GitUtil             = require("./git_util");
+const SubmoduleConfigUtil = require("./submodule_config_util");
+const UserError           = require("./user_error");
+
+/**
+ * This class provides a way to fetch submodules from a specific commit in a
+ * meta-repo that is simplified (meta-repo URL will be automatically derived)
+ * and optimized (sub-repo URLs are read in one shot from configuration, only
+ * if needed).
+ */
+class SubmoduleFetcher {
+
+    /**
+     * Create a `SubmoduleFetcher` object that can fetch shas for submodules in
+     * the specified meta `repo` using URLs specified on the specified
+     * `commit`.  Resolve submodule URLs against the specified `metaOriginUrl`,
+     * if provided, or the URL of the remote named "origin" in `repo`
+     * otherwise.  If `repo` has no remote named "origin", and `fetchSha` is
+     * called for a submodule that has a relativre URL, throw a `UserError`.
+     *
+     * @param {NodeGit.Repository} repo
+     * @param {NodeGit.Commit}     commit
+     */
+    constructor(repo, commit) {
+        assert.instanceOf(repo, NodeGit.Repository);
+        assert.instanceOf(commit, NodeGit.Commit);
+
+        this.d_repo   = repo;
+        this.d_commit = commit;
+        this.d_urls   = null;
+
+        // d_metaOrigin may have three types of values:
+        // 1. undefined -- we haven't tried to access it yet
+        // 2. null      -- no 'origin' for 'repo'
+        // 3. <string>  -- the URL for the meta repo's origin remote
+
+        this.d_metaOriginUrl = undefined;
+    }
+
+    /**
+     * @param {NodeGit.Repository} repo meta-repo associated with this fetcher
+     */
+    get repo() {
+        return this.d_repo;
+    }
+
+    /**
+     * @param {NodeGit.Commit} commit commit associated with this fetcher
+     */
+    get commit() {
+        return this.d_commit;
+    }
+}
+
+/**
+ * @async
+ * Return the metaOriginUrl used to resolve relative sub URLs.
+ * @return {String|null}
+ */
+SubmoduleFetcher.prototype.getMetaOriginUrl = co.wrap(function *() {
+    // If we haven't computed the URL yet, it will be `undefined`.  Null
+    // indicates that no URL was provided and there is no origin.
+
+    if (undefined === this.d_metaOriginUrl) {
+        this.d_metaOriginUrl = yield GitUtil.getOriginUrl(this.d_repo);
+    }
+    return this.d_metaOriginUrl;
+});
+
+/**
+ * @async
+ * Return the submodule URL configured in the meta-repo on the specified
+ * commit for the submodule having the specified `name`.  Throw a user error if
+ * the submodule does  not have a configured URL for `this.commit`.
+ * @param {String} name
+ */
+SubmoduleFetcher.prototype.getSubmoduleUrl = co.wrap(function *(name) {
+    assert.isString(name);
+    if (null === this.d_urls) {
+        this.d_urls = yield SubmoduleConfigUtil.getSubmodulesFromCommit(
+                                                                this.d_repo,
+                                                                this.d_commit);
+    }
+    if (!(name in this.d_urls)) {
+        throw new UserError(`No configured url for submodule ${name}.`);
+    }
+    return this.d_urls[name];
+});
+
+/**
+ *
+ * Fetch the specified `sha` in the specified submodule `repo` having the
+ * specified `name`.
+ *
+ * TODO: We may want to consider fetching from remotes other than `origin` if
+ * the fetch from `origin` fails.
+ *
+ * @param {Nodegit.Repository} repo
+ * @param {String}             name
+ * @param {String}             sha
+ */
+SubmoduleFetcher.prototype.fetchSha = co.wrap(function *(repo, name, sha) {
+    assert.instanceOf(repo, NodeGit.Repository);
+    assert.isString(name);
+    assert.isString(sha);
+
+    const subUrl = yield this.getSubmoduleUrl(name);
+    const metaUrl = yield this.getMetaOriginUrl();
+    const urlToFetch = SubmoduleConfigUtil.resolveSubmoduleUrl(metaUrl,
+                                                               subUrl);
+    yield GitUtil.fetchSha(repo, urlToFetch, sha);
+});
+
+module.exports = SubmoduleFetcher;

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -515,9 +515,11 @@ exports.writeRAST = co.wrap(function *(ast, path) {
  * @param {Object} repos
  * @param {String} rootDirectory
  * @return {Object}
- * @return {Object} return.repos       map from name to `NodeGit.Repository`
- * @return {Object} return.commitMap   map from new to old commit IDs
- * @return {Object} return.urlMap      map from url to name
+ * @return {Object} return.repos        map from name to `NodeGit.Repository`
+ * @return {Object} return.commitMap    map from new to old commit IDs
+ * @return {Object} return.reverseMap   map from old to new commit IDs
+ * @return {Object} return.urlMap       map from new url to old name
+ * @return {Object} return.reverseUrlMap map from old url to new name
  */
 exports.writeMultiRAST = co.wrap(function *(repos, rootDirectory) {
     // This operation is complicated by the need to have a single commit ID
@@ -668,11 +670,16 @@ git -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
             yield writeRepo(subRepo, openSubAST);
         }
     }
-
+    const reverseUrlMap = {};
+    Object.keys(urlMap).forEach(url => {
+        reverseUrlMap[urlMap[url]] = url;
+    });
     return {
         repos: resultRepos,
         commitMap: commitMaps.newToOld,
+        reverseMap: commitMaps.oldToNew,
         urlMap: urlMap,
+        reverseUrlMap: reverseUrlMap,
     };
 });
 

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -517,7 +517,7 @@ exports.writeRAST = co.wrap(function *(ast, path) {
  * @return {Object}
  * @return {Object} return.repos        map from name to `NodeGit.Repository`
  * @return {Object} return.commitMap    map from new to old commit IDs
- * @return {Object} return.reverseMap   map from old to new commit IDs
+ * @return {Object} return.reverseCommitMap   map from old to new commit IDs
  * @return {Object} return.urlMap       map from new url to old name
  * @return {Object} return.reverseUrlMap map from old url to new name
  */
@@ -677,7 +677,7 @@ git -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
     return {
         repos: resultRepos,
         commitMap: commitMaps.newToOld,
-        reverseMap: commitMaps.oldToNew,
+        reverseCommitMap: commitMaps.oldToNew,
         urlMap: urlMap,
         reverseUrlMap: reverseUrlMap,
     };

--- a/node/test/util/checkout.js
+++ b/node/test/util/checkout.js
@@ -125,7 +125,7 @@ x=U:C3-2 s=Sa:4;Bfoo=3;Os W bar=r",
                 return yield Checkout.checkout(x, branchName);
             }
             else {
-                const realCommit = mapping.reverseMap[commit];
+                const realCommit = mapping.reverseCommitMap[commit];
                 return yield Checkout.checkout(x, realCommit);
             }
         });

--- a/node/test/util/cherrypick.js
+++ b/node/test/util/cherrypick.js
@@ -58,9 +58,9 @@ describe("cherrypick", function () {
     const picker = co.wrap(function *(repos, maps) {
         const x = repos.x;
         const oldMap = maps.commitMap;
-        const reverseMap = maps.reverseMap;
-        assert.property(reverseMap, "8");
-        const eightCommitSha = reverseMap["8"];
+        const reverseCommitMap = maps.reverseCommitMap;
+        assert.property(reverseCommitMap, "8");
+        const eightCommitSha = reverseCommitMap["8"];
         const eightCommit = yield x.getCommit(eightCommitSha);
         const result  = yield Cherrypick.cherryPick(x, eightCommit);
 

--- a/node/test/util/git_util.js
+++ b/node/test/util/git_util.js
@@ -471,7 +471,7 @@ describe("GitUtil", function () {
             const written = yield WriteRepoASTUtil.writeRAST(ast, path);
             const commit = written.oldCommitMap["1"];
             const repo = written.repo;
-            yield GitUtil.fetchSha(repo, commit);
+            yield GitUtil.fetchSha(repo, "not a url", commit);
         }));
 
         it("fetch one", co.wrap(function *() {
@@ -484,8 +484,7 @@ describe("GitUtil", function () {
             const writtenY = yield WriteRepoASTUtil.writeRAST(astY, yPath);
             const commit = writtenX.oldCommitMap["2"];
             const repo = writtenY.repo;
-            yield NodeGit.Remote.create(repo, "origin", xPath);
-            yield GitUtil.fetchSha(repo, commit);
+            yield GitUtil.fetchSha(repo, xPath, commit);
             yield repo.getCommit(commit);
         }));
 
@@ -498,10 +497,9 @@ describe("GitUtil", function () {
             yield WriteRepoASTUtil.writeRAST(astX, xPath);
             const writtenY = yield WriteRepoASTUtil.writeRAST(astY, yPath);
             const repo = writtenY.repo;
-            yield NodeGit.Remote.create(repo, "origin", xPath);
             const bad = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
             try {
-                yield GitUtil.fetchSha(repo, bad);
+                yield GitUtil.fetchSha(repo, xPath, bad);
             }
             catch (e) {
                 assert.instanceOf(e, UserError);

--- a/node/test/util/merge.js
+++ b/node/test/util/merge.js
@@ -51,9 +51,9 @@ describe("merge", function () {
         const x = repos.x;
         const status = yield Status.getRepoStatus(x);
         const commitMap = maps.commitMap;
-        const reverseMap = maps.reverseMap;
-        assert.property(reverseMap, fromCommit);
-        const physicalCommit = reverseMap[fromCommit];
+        const reverseCommitMap = maps.reverseCommitMap;
+        assert.property(reverseCommitMap, fromCommit);
+        const physicalCommit = reverseCommitMap[fromCommit];
         const commit = yield x.getCommit(physicalCommit);
         const result = yield Merge.merge(x, status, commit, mode, "message");
         if (upToDate) {

--- a/node/test/util/open.js
+++ b/node/test/util/open.js
@@ -59,8 +59,8 @@ describe("openOnCommit", function () {
         const c = cases[caseName];
         it(caseName, co.wrap(function *() {
             const manipulator = co.wrap(function *(repos, maps) {
-                assert.property(maps.reverseMap, c.commitSha);
-                const commit = maps.reverseMap[c.commitSha];
+                assert.property(maps.reverseCommitMap, c.commitSha);
+                const commit = maps.reverseCommitMap[c.commitSha];
                 const x = repos.x;
                 const head = yield x.getHeadCommit();
                 const fetcher = new SubmoduleFetcher(x, head);

--- a/node/test/util/open.js
+++ b/node/test/util/open.js
@@ -34,8 +34,9 @@ const assert  = require("chai").assert;
 const co      = require("co");
 const NodeGit = require("nodegit");
 
-const Open            = require("../../lib/util/open");
-const RepoASTTestUtil = require("../../lib/util/repo_ast_test_util");
+const Open             = require("../../lib/util/open");
+const RepoASTTestUtil  = require("../../lib/util/repo_ast_test_util");
+const SubmoduleFetcher = require("../../lib/util/submodule_fetcher");
 
 describe("openOnCommit", function () {
     // Assumption is that 'x' is the target repo.
@@ -44,14 +45,12 @@ describe("openOnCommit", function () {
         "simple": {
             initial: "a=B|x=U",
             subName: "s",
-            url: "a",
             commitSha: "1",
             expected: "x=E:Os",
         },
         "not head": {
             initial: "a=B:C3-1;Bmaster=3|x=U",
             subName: "s",
-            url: "a",
             commitSha: "3",
             expected: "x=E:Os H=3",
         },
@@ -61,14 +60,12 @@ describe("openOnCommit", function () {
         it(caseName, co.wrap(function *() {
             const manipulator = co.wrap(function *(repos, maps) {
                 assert.property(maps.reverseMap, c.commitSha);
-                assert.property(maps.reverseUrlMap, c.url);
                 const commit = maps.reverseMap[c.commitSha];
-                const url = maps.reverseUrlMap[c.url];
                 const x = repos.x;
-                const result = yield Open.openOnCommit(null,
-                                                       x,
+                const head = yield x.getHeadCommit();
+                const fetcher = new SubmoduleFetcher(x, head);
+                const result = yield Open.openOnCommit(fetcher,
                                                        c.subName,
-                                                       url,
                                                        commit);
                 assert.instanceOf(result, NodeGit.Repository);
             });

--- a/node/test/util/push.js
+++ b/node/test/util/push.js
@@ -43,7 +43,7 @@ const RepoASTTestUtil = require("../../lib/util/repo_ast_test_util");
  * the form of `ref/commit/<logical commit id>` to
  * `ref/commit/<physical commit id>`, where <logical commit id> is the id of
  * the commit the ref points to.  The specified `mapping` argument contains a
- * `reverseMap` object that maps from logical to physical commit id.
+ * `reverseCommitMap` object that maps from logical to physical commit id.
  *
  * @param {Object} expected
  * @param {Object} mapping (as in RepoASTTestUtil)
@@ -51,14 +51,14 @@ const RepoASTTestUtil = require("../../lib/util/repo_ast_test_util");
  */
 function refMapper(expected, mapping) {
     const syntheticMetaRefRE = /(commits\/)(.*)/;
-    const reverseMap = mapping.reverseMap;
+    const reverseCommitMap = mapping.reverseCommitMap;
 
     function mapASTRefs(ast) {
         let newRefs = {};
         const oldRefs = ast.refs;
         Object.keys(oldRefs).forEach(ref => {
             const logicalId = oldRefs[ref];
-            const physicalId = reverseMap[logicalId];
+            const physicalId = reverseCommitMap[logicalId];
             const newRefName = ref.replace(syntheticMetaRefRE,
                                            `$1${physicalId}`);
             newRefs[newRefName] = logicalId;
@@ -134,7 +134,7 @@ describe("refMapper", function () {
                     },
                 }),
             },
-            reverseMap: {
+            reverseCommitMap: {
                 "1": "ffff",
             },
         },
@@ -173,7 +173,7 @@ describe("refMapper", function () {
                     },
                 }),
             },
-            reverseMap: {
+            reverseCommitMap: {
                 "1": "ffff",
             },
         },
@@ -183,7 +183,7 @@ describe("refMapper", function () {
         const c = cases[caseName];
         it(caseName, () => {
             const result = refMapper(c.input, {
-                reverseMap: c.reverseMap || {},
+                reverseCommitMap: c.reverseCommitMap || {},
             });
             RepoASTUtil.assertEqualRepoMaps(result, c.expected);
         });

--- a/node/test/util/rebase_util.js
+++ b/node/test/util/rebase_util.js
@@ -47,9 +47,9 @@ describe("rebase", function () {
             assert.property(repos, repoName);
             const repo = repos[repoName];
             const status = yield Status.getRepoStatus(repo);
-            const reverseMap = maps.reverseMap;
-            assert.property(reverseMap, commit);
-            const originalActualCommit = reverseMap[commit];
+            const reverseCommitMap = maps.reverseCommitMap;
+            assert.property(reverseCommitMap, commit);
+            const originalActualCommit = reverseCommitMap[commit];
             const originalCommit = yield repo.getCommit(originalActualCommit);
             const result = yield RebaseUtil.rebase(repo, originalCommit,
                                                    status);

--- a/node/test/util/repo_ast_test_util.js
+++ b/node/test/util/repo_ast_test_util.js
@@ -298,7 +298,7 @@ describe("RepoASTTestUtil", function () {
                     expectedTransformer: (expected, mappings) => {
                         const x = expected.x;
                         let branches = x.branches;
-                        const commitId = mappings.reverseMap["1"];
+                        const commitId = mappings.reverseCommitMap["1"];
                         branches[`foo-${commitId}`] = "1";
                         return {
                             x: x.copy({ branches: branches}),

--- a/node/test/util/reset.js
+++ b/node/test/util/reset.js
@@ -113,7 +113,7 @@ a=B:Ca-1 y=x;Bfoo=a|x=U:C3-2 t=Sa:1;C4-3 s=Sa:a,t=Sa:a;Bfoo=4;Bmaster=3;Os;Ot",
         const c = cases[caseName];
         it(caseName, co.wrap(function *() {
             const resetter = co.wrap(function *(repos, maps) {
-                const commitId = maps.reverseMap[c.to];
+                const commitId = maps.reverseCommitMap[c.to];
                 const repo = repos.x;
                 const commit = yield repo.getCommit(commitId);
                 yield Reset.reset(repo, commit, c.type);

--- a/node/test/util/submodule_fetcher.js
+++ b/node/test/util/submodule_fetcher.js
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert = require("chai").assert;
+const co     = require("co");
+
+const RepoASTTestUtil  = require("../../lib/util/repo_ast_test_util");
+const SubmoduleFetcher = require("../../lib/util/submodule_fetcher");
+const SubmoduleUtil    = require("../../lib/util/submodule_util");
+const UserError        = require("../../lib/util/user_error");
+
+describe("SubmoduleFetcher", function () {
+
+    describe("getMetaOriginUrl", function () {
+        // Always use repo 'x'.
+
+        const cases = {
+            "no origin": {
+                initial: "a=B:C4-1;Bfoo=4|b=B|x=U:Os Rorigin=c",
+                metaSha: "2",
+                expected: null,
+            },
+            "pulled from origin": {
+                initial: "a=B:C4-1;Bfoo=4|b=B|x=Ca",
+                metaSha: "1",
+                metaOriginUrl: null,
+                expected: "a",
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                const written =
+                             yield RepoASTTestUtil.createMultiRepos(c.initial);
+                const repo = written.repos.x;
+                const newSha = written.reverseMap[c.metaSha];
+                const commit = yield repo.getCommit(newSha);
+                let metaUrl = c.metaOriginUrl;
+                if (null !== metaUrl) {
+                    metaUrl = written.reverseUrlMap[metaUrl];
+                }
+                const fetcher = new SubmoduleFetcher(repo, commit);
+                let resultUrl = yield fetcher.getMetaOriginUrl();
+                if (null !== resultUrl) {
+                    resultUrl = written.urlMap[resultUrl];
+                }
+                assert.equal(resultUrl, c.expected);
+            }));
+        });
+    });
+
+    describe("simple accessors", function () {
+        it("repo", co.wrap(function *() {
+            const written = yield RepoASTTestUtil.createMultiRepos("x=S");
+            const x = written.repos.x;
+            const commit = yield x.getCommit(written.reverseMap["1"]);
+            const fetcher = new SubmoduleFetcher(x, commit);
+            assert.equal(x, fetcher.repo);
+        }));
+        it("commit", co.wrap(function *() {
+            const written = yield RepoASTTestUtil.createMultiRepos("x=S");
+            const x = written.repos.x;
+            const commit = yield x.getCommit(written.reverseMap["1"]);
+            const fetcher = new SubmoduleFetcher(x, commit);
+            assert.equal(commit, fetcher.commit);
+        }));
+    });
+
+    describe("getSubmoduleUrl", function () {
+        it("breathing", co.wrap(function *() {
+            const written = yield RepoASTTestUtil.createMultiRepos(
+                                                        "a=B:C4-1;Bfoo=4|x=U");
+            const x = written.repos.x;
+            const commit = yield x.getCommit(written.reverseMap["2"]);
+            const fetcher = new SubmoduleFetcher(x, commit);
+            const newUrl = yield fetcher.getSubmoduleUrl("s");
+            const resultUrl = written.urlMap[newUrl];
+            assert.equal(resultUrl, "a");
+        }));
+        it("bad on commit", co.wrap(function *() {
+            const written = yield RepoASTTestUtil.createMultiRepos(
+                                                        "a=B:C4-1;Bfoo=4|x=U");
+            const x = written.repos.x;
+            const commit = yield x.getCommit(written.reverseMap["1"]);
+            const fetcher = new SubmoduleFetcher(x, commit);
+            try {
+                yield fetcher.getSubmoduleUrl("s");
+            }
+            catch (e) {
+                assert.instanceOf(e, UserError);
+                return;                                               // RETURN
+            }
+            assert(false, "should have failed");
+        }));
+    });
+
+    describe("fetchSha", function () {
+        // Will always fetch from repo 'x'.
+
+        const cases = {
+            "simple": {
+                initial: "a=B:C4-1;Bfoo=4|x=U:Os",
+                metaSha: "2",
+                fetches: [
+                    {
+                        sub: "s",
+                        sha: "4",
+                    },
+                ],
+            },
+            "with ignored remote": {
+                initial: "a=B:C4-1;Bfoo=4|b=B|x=U:Os Rorigin=c",
+                metaSha: "2",
+                fetches: [
+                    {
+                        sub: "s",
+                        sha: "4",
+                    },
+                ],
+            },
+            "with relative url": {
+                initial:
+                    "a=B:C4-1;Bfoo=4|b=B|x=Cb:C2-1 s=S../a:1;Os;Bmaster=2",
+                metaSha: "2",
+                fetches: [
+                    {
+                        sub: "s",
+                        sha: "4",
+                    },
+                ],
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                const fetcher = co.wrap(function *(repos, maps) {
+                    const x = repos.x;
+                    const revMap = maps.reverseMap;
+                    const newShaw = revMap[c.metaSha];
+                    const commit = yield x.getCommit(newShaw);
+                    const subFetcher = new SubmoduleFetcher(x, commit);
+                    yield c.fetches.map(co.wrap(function *(fetch) {
+                        const repo = yield SubmoduleUtil.getRepo(x, fetch.sub);
+                        const newFetchSha = revMap[fetch.sha];
+                        yield subFetcher.fetchSha(repo,
+                                                  fetch.sub,
+                                                  newFetchSha);
+
+                        // Try to get the commit to verify it was retrieved.
+
+                        yield repo.getCommit(newFetchSha);
+                    }));
+                });
+                yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,
+                                                               c.expected,
+                                                               fetcher,
+                                                               c.fails);
+            }));
+        });
+    });
+});

--- a/node/test/util/submodule_fetcher.js
+++ b/node/test/util/submodule_fetcher.js
@@ -62,7 +62,7 @@ describe("SubmoduleFetcher", function () {
                 const written =
                              yield RepoASTTestUtil.createMultiRepos(c.initial);
                 const repo = written.repos.x;
-                const newSha = written.reverseMap[c.metaSha];
+                const newSha = written.reverseCommitMap[c.metaSha];
                 const commit = yield repo.getCommit(newSha);
                 let metaUrl = c.metaOriginUrl;
                 if (null !== metaUrl) {
@@ -82,14 +82,14 @@ describe("SubmoduleFetcher", function () {
         it("repo", co.wrap(function *() {
             const written = yield RepoASTTestUtil.createMultiRepos("x=S");
             const x = written.repos.x;
-            const commit = yield x.getCommit(written.reverseMap["1"]);
+            const commit = yield x.getCommit(written.reverseCommitMap["1"]);
             const fetcher = new SubmoduleFetcher(x, commit);
             assert.equal(x, fetcher.repo);
         }));
         it("commit", co.wrap(function *() {
             const written = yield RepoASTTestUtil.createMultiRepos("x=S");
             const x = written.repos.x;
-            const commit = yield x.getCommit(written.reverseMap["1"]);
+            const commit = yield x.getCommit(written.reverseCommitMap["1"]);
             const fetcher = new SubmoduleFetcher(x, commit);
             assert.equal(commit, fetcher.commit);
         }));
@@ -100,7 +100,7 @@ describe("SubmoduleFetcher", function () {
             const written = yield RepoASTTestUtil.createMultiRepos(
                                                         "a=B:C4-1;Bfoo=4|x=U");
             const x = written.repos.x;
-            const commit = yield x.getCommit(written.reverseMap["2"]);
+            const commit = yield x.getCommit(written.reverseCommitMap["2"]);
             const fetcher = new SubmoduleFetcher(x, commit);
             const newUrl = yield fetcher.getSubmoduleUrl("s");
             const resultUrl = written.urlMap[newUrl];
@@ -110,7 +110,7 @@ describe("SubmoduleFetcher", function () {
             const written = yield RepoASTTestUtil.createMultiRepos(
                                                         "a=B:C4-1;Bfoo=4|x=U");
             const x = written.repos.x;
-            const commit = yield x.getCommit(written.reverseMap["1"]);
+            const commit = yield x.getCommit(written.reverseCommitMap["1"]);
             const fetcher = new SubmoduleFetcher(x, commit);
             try {
                 yield fetcher.getSubmoduleUrl("s");
@@ -164,7 +164,7 @@ describe("SubmoduleFetcher", function () {
             it(caseName, co.wrap(function *() {
                 const fetcher = co.wrap(function *(repos, maps) {
                     const x = repos.x;
-                    const revMap = maps.reverseMap;
+                    const revMap = maps.reverseCommitMap;
                     const newShaw = revMap[c.metaSha];
                     const commit = yield x.getCommit(newShaw);
                     const subFetcher = new SubmoduleFetcher(x, commit);


### PR DESCRIPTION
Instead, use the `origin` remote from the meta-repo to resolve relative URLs -- this is the same behavior as `git submodule init`. I think we may want to consider a strategy where other remotes are consulted if the fetches fail, or a way for the user to specify a remote command to commands that can trigger a fetch, such as `git meta reset` that would not in the vanilla Git equivalent.

**NOTE** -- depends on https://github.com/twosigma/git-meta/pull/135