### PR TITLE
Leave modules directory on close.

### DIFF
--- a/node/lib/util/close.js
+++ b/node/lib/util/close.js
@@ -40,21 +40,6 @@ const path    = require("path");
 const fs      = require("fs-promise");
 
 /**
- * Remove the modules directory for the submodule having the specified 'name'
- * in the repo located at the specified 'root'.
- * @param {String} root
- * @param {String} name
- */
-exports.cleanModulesDirectory = co.wrap(function *(root, name) {
-    const submoduleModuleDir = path.join(root, ".git", "modules", name);
-
-    const rmModDir = new Promise(callback => {
-        return rimraf(submoduleModuleDir, {}, callback);
-    });
-    yield rmModDir;
-});
-
-/**
  * Close the repository having the specified `submoduleName` in the specified
  * `repo`.
  *
@@ -135,7 +120,4 @@ exports.close = co.wrap(function *(repo, submoduleName) {
         newConfigLines.push("");  // one more new line
         fs.writeFileSync(configPath, newConfigLines.join("\n"));
     }
-
-    // Finally, remove the .git/modules/<submodule> directory
-    yield exports.cleanModulesDirectory(rootDir, submoduleName);
 });

--- a/node/test/util/close.js
+++ b/node/test/util/close.js
@@ -83,12 +83,5 @@ describe("close", function () {
         yield close.close(repo, "x/y");
         const closedStatus = yield NodeGit.Submodule.status(repo, "x/y", 0);
         assert(closedStatus & WD_UNINITIALIZED);
-
-        // Make sure we can reopen it.
-
-        yield sub.init(1);
-        yield sub.repoInit(1);
-        const reopenedStat = yield NodeGit.Submodule.status(repo, "x/y", 0);
-        assert(!(reopenedStat & WD_UNINITIALIZED));
     }));
 });


### PR DESCRIPTION
Also needed to make `open` support the case where the `.git/modules/${subname}`
directory exists.  The NodeGit routines for openeing submodules fail in this
case, so I had to implement the open operation entirely myself, including
writing the .git link file.

Fixes https://github.com/twosigma/git-meta/issues/137 and other issues such as
when attempting to open a submodule that has a modules directory, such as when
closed using normal git.