### PR TITLE
Relative URLs to support '.'.

### DIFF
--- a/node/lib/util/shorthand_parser_util.js
+++ b/node/lib/util/shorthand_parser_util.js
@@ -1255,6 +1255,12 @@ exports.parseMultiRepoShorthand = function (shorthand, existingRepos) {
                 if (openUrl.startsWith("../")) {
                     openUrl = openUrl.substr(3);
                 }
+                else if ("." === openUrl) {
+                    const remotes = rawResult.remotes;
+                    assert.property(remotes, "origin", "dot must have origin");
+                    const origin = remotes.origin;
+                    openUrl = origin.url;
+                }
                 assert.property(result,
                                 openUrl,
 `cannot find url ${openUrl} for submodule ${subName} in repo ${name}.`);

--- a/node/lib/util/submodule_config_util.js
+++ b/node/lib/util/submodule_config_util.js
@@ -129,7 +129,7 @@ exports.resolveSubmoduleUrl = function (baseUrl, submoduleUrl) {
         assert.isString(baseUrl);
     }
     assert.isString(submoduleUrl);
-    if (submoduleUrl.startsWith("./") || submoduleUrl.startsWith("../")) {
+    if (submoduleUrl.startsWith(".")) {
         if (null === baseUrl) {
             throw new UserError(
       `Attempt to use relative url: ${submoduleUrl}, but no 'origin' remote.`);

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -556,7 +556,7 @@ exports.writeMultiRAST = co.wrap(function *(repos, rootDirectory) {
     let repoPaths = {};
     let urlMap = {};
     for (let repoName in repos) {
-        const repoPath = path.join(rootDirectory, repoName);
+        const repoPath = path.join(rootDirectory, repoName, "/");
         repoPaths[repoName] = repoPath;
         urlMap[repoPath] = repoName;
     }

--- a/node/test/util/repo_ast_test_util.js
+++ b/node/test/util/repo_ast_test_util.js
@@ -80,7 +80,10 @@ const makeClone = co.wrap(function *(repos, maps) {
     const a = repos.a;
     const bPath = yield TestUtil.makeTempDir();
     const aPath = yield fs.realpath(a.workdir());
-    const b = yield NodeGit.Clone.clone(aPath, bPath);
+
+    // Test framework expects a trailing '/' to support relative paths.
+
+    const b = yield NodeGit.Clone.clone(aPath + "/", bPath);
     const sig = b.defaultSignature();
     const head = yield b.getHeadCommit();
     yield b.createBranch("foo", head.id(), 1, sig, "branch commit");


### PR DESCRIPTION
These are mostly changes to the test framework (and a logical one to
`submodule_config_util`) allowing relative paths of '.' to indicate the same
URL as the origin of the meta-repo.