### PR TITLE
Fixed bug with `write-repos` shorthand args.

### DIFF
--- a/node/lib/write-repos.js
+++ b/node/lib/write-repos.js
@@ -95,6 +95,10 @@ co(function *() {
             shorthand = yield fs.readFile(args.file, { encoding: "utf8" });
         }
         else if (!args.shorthand) {
+            console.error("Missing SHORTHAND.");
+            process.exit(-1);
+        }
+        else {
             shorthand = args.shorthand;
         }
 


### PR DESCRIPTION
It was not possible to use them at all.