### PR TITLE
Remove `ensureCleanAndConsistent` from `push`.

### DIFF
--- a/node/lib/cmd/push.js
+++ b/node/lib/cmd/push.js
@@ -94,13 +94,9 @@ if not specified.`,
  */
 exports.executeableSubcommand = co.wrap(function *(args) {
     const GitUtil = require("../util/git_util");
-    const status = require("../util/status");
     const push = require("../util/push");
 
     const repo = yield GitUtil.getCurrentRepo();
-
-    const repoStatus = yield status.getRepoStatus(repo);
-    status.ensureConsistent(repoStatus);
 
     let strRefspecs = [];
     if (0 === args.refspec.length) {


### PR DESCRIPTION
Wasn't necessary but was annoying.  Also, eliminating call to `getRepoStatus`
will make it faster.