### PR TITLE
Improve resilience with "half-baked" submodules, and of open overall

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -332,7 +332,7 @@ exports.fetch = co.wrap(function *(repo, remoteName) {
     assert.instanceOf(repo, NodeGit.Repository);
     assert.isString(remoteName);
 
-    const execString = `git -C '${repo.workdir()}' fetch -q '${remoteName}'`;
+    const execString = `git -C '${repo.path()}' fetch -q '${remoteName}'`;
     try {
         return yield exec(execString);
     }
@@ -364,9 +364,7 @@ exports.fetchSha  = co.wrap(function *(repo, url, sha) {
     catch (e) {
     }
 
-    const execString = `\
-git -C ${repo.workdir()} fetch -q '${url}' ${sha}
-`;
+    const execString = `git -C '${repo.path()}' fetch -q '${url}' ${sha}`;
     try {
         return yield exec(execString);
     }

--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -254,7 +254,7 @@ git -C '${repo.workdir()}' push ${forceStr} ${remote} ${source}:${target}`;
 exports.getCurrentBranchName = co.wrap(function *(repo) {
     assert.instanceOf(repo, NodeGit.Repository);
 
-    if (1 !== repo.headDetached()) {
+    if (!repo.isEmpty() && 1 !== repo.headDetached()) {
         const branch = yield repo.getCurrentBranch();
         return branch.shorthand();
     }

--- a/node/lib/util/read_repo_ast_util.js
+++ b/node/lib/util/read_repo_ast_util.js
@@ -234,7 +234,7 @@ exports.readRAST = co.wrap(function *(repo) {
 
     let branchName = null;
     let headCommitId = null;
-    if (!repo.headDetached()) {
+    if (!repo.headDetached() && !repo.isEmpty()) {
         const branch = yield repo.getCurrentBranch();
         branchName = branch.shorthand();
     }
@@ -243,10 +243,14 @@ exports.readRAST = co.wrap(function *(repo) {
 
     let index = {};
     let workdir = {};
-    if (!repo.isBare()) {
-        const headCommit = yield repo.getHeadCommit();
+    const bare = repo.isBare() !== 0;
+    const headCommit = yield repo.getHeadCommit();
+    if (null !== headCommit) {
         yield loadCommit(headCommit.id());
         headCommitId = headCommit.id().tostrS();
+    }
+
+    if (!bare) {
 
         // Process index and workdir changes.
 
@@ -354,7 +358,7 @@ exports.readRAST = co.wrap(function *(repo) {
 
     let openSubmodules = {};
 
-    if (!repo.isBare()) {
+    if (!bare) {
         const subNames = yield repo.getSubmoduleNames();
         for (let i = 0; i < subNames.length; ++i) {
             const subName = subNames[i];
@@ -430,7 +434,6 @@ exports.readRAST = co.wrap(function *(repo) {
         workdir: workdir,
         openSubmodules: openSubmodules,
         rebase: rebase,
+        bare: bare,
     });
 });
-
-

--- a/node/lib/util/repo_ast_util.js
+++ b/node/lib/util/repo_ast_util.js
@@ -383,6 +383,17 @@ HEAD is ${colorAct(actual.head)} but expected ${colorExp(expected.head)}`
                    );
     }
 
+    // Check bare
+
+    if (actual.bare !== expected.bare) {
+        if (expected.bare) {
+            result.push(`Expected repository to be bare.`);
+        }
+        else {
+            result.push(`Expected repository not to be bare.`);
+        }
+    }
+
     // Next, the current branch name
 
     if (actual.currentBranchName !== expected.currentBranchName) {

--- a/node/lib/util/shorthand_parser_util.js
+++ b/node/lib/util/shorthand_parser_util.js
@@ -313,6 +313,7 @@ function prepareASTArguments(baseAST, rawRepo) {
         workdir: baseAST.workdir,
         openSubmodules: baseAST.openSubmodules,
         rebase: baseAST.rebase,
+        bare: baseAST.bare,
     };
 
     // Process HEAD.
@@ -1333,7 +1334,8 @@ exports.RepoType = (() => {
     function makeB() {
         const S = makeS();
         return S.copy({
-            head: null
+            bare: true,
+            head: "1",
         });
     }
     function makeU() {

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -423,8 +423,8 @@ const configureRepo = co.wrap(function *(repo, ast, commitMap) {
         // didn't seem to work..
 
         const checkoutIndexStr = `\
-git -C ${repo.workdir()} clean -f -d
-git -C ${repo.workdir()} checkout-index -a -f
+git -C '${repo.workdir()}' clean -f -d
+git -C '${repo.workdir()}' checkout-index -a -f
 `;
         yield exec(checkoutIndexStr);
 

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -156,8 +156,7 @@ const makeTree = co.wrap(function *(repo, flatTree, getSubmoduleSha) {
         const tempPath = path.join(tempDir, "treeData");
         yield fs.writeFile(tempPath, treeData);
         const makeTreeExecString = `\
-cd ${repo.path()}
-cat '${tempPath}' | git mktree
+cat '${tempPath}' | git -C ${repo.path()} mktree
 `;
         return yield doExec(makeTreeExecString);
     });
@@ -335,9 +334,12 @@ const configureRepo = co.wrap(function *(repo, ast, commitMap) {
 
     // Deal with bare repos.
 
-    if (ast.isBare()) {
+    if (ast.bare) {
         if (null !== ast.currentBranchName) {
             repo.setHead("refs/heads/" + ast.currentBranchName);
+        }
+        else {
+            repo.setHeadDetached(newHeadSha);
         }
     }
     else if (null !== ast.currentBranchName) {
@@ -345,7 +347,7 @@ const configureRepo = co.wrap(function *(repo, ast, commitMap) {
                    yield repo.getBranch("refs/heads/" + ast.currentBranchName);
         yield repo.checkoutBranch(currentBranch);
     }
-    else {
+    else if (null !== ast.head) {
         const headCommit = yield repo.getCommit(newHeadSha);
         repo.setHeadDetached(newHeadSha);
         yield NodeGit.Reset.reset(repo, headCommit, NodeGit.Reset.TYPE.HARD);
@@ -362,7 +364,7 @@ const configureRepo = co.wrap(function *(repo, ast, commitMap) {
         }
     }
 
-    if (null !== ast.head) {
+    if (!ast.bare) {
 
         let indexHead = ast.head;
 
@@ -401,8 +403,12 @@ const configureRepo = co.wrap(function *(repo, ast, commitMap) {
         // Set up the index.  We render the current commit and apply the index
         // on top of it.
 
-        const tree =
-                   yield RepoAST.renderIndex(ast.commits, indexHead, ast.index);
+        let tree = ast.index;
+        if (null !== indexHead) {
+            tree =
+                  yield RepoAST.renderIndex(ast.commits, indexHead, ast.index);
+        }
+
         const treeId = yield makeTree(repo, tree, co.wrap(function *(sha) {
             return yield Promise.resolve(commitMap[sha]);
         }));
@@ -417,9 +423,8 @@ const configureRepo = co.wrap(function *(repo, ast, commitMap) {
         // didn't seem to work..
 
         const checkoutIndexStr = `\
-cd ${repo.workdir()}
-git clean -f -d
-git checkout-index -a -f
+git -C ${repo.workdir()} clean -f -d
+git -C ${repo.workdir()} checkout-index -a -f
 `;
         yield exec(checkoutIndexStr);
 
@@ -506,7 +511,7 @@ exports.writeRAST = co.wrap(function *(ast, path) {
     assert.isString(path);
     assert.deepEqual(ast.openSubmodules, {}, "open submodules not supported");
 
-    const repo = yield NodeGit.Repository.init(path, ast.isBare() ? 1 : 0);
+    const repo = yield NodeGit.Repository.init(path, ast.bare ? 1 : 0);
 
     yield configRepo(repo);
 
@@ -625,8 +630,7 @@ exports.writeMultiRAST = co.wrap(function *(repos, rootDirectory) {
         // Then set up the rest of the repository.
         yield configureRepo(repo, ast, commitMaps.oldToNew);
         const cleanupString = `\
-cd ${repo.path()}
-git -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
+git -C ${repo.path()} -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
 -c gc.rerereresolved=0 -c gc.rerereunresolved=0 \
 -c gc.pruneExpire=now gc`;
         yield exec(cleanupString);
@@ -640,7 +644,7 @@ git -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
         const repoPath = repoPaths[repoName];
         const repo = yield NodeGit.Clone.clone(commitRepo.workdir(),
                                                repoPath, {
-            bare: ast.isBare() ? 1 : 0
+            bare: ast.bare ? 1 : 0
         });
         yield configRepo(repo);
         yield writeRepo(repo, ast, repoPath);

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -156,7 +156,7 @@ const makeTree = co.wrap(function *(repo, flatTree, getSubmoduleSha) {
         const tempPath = path.join(tempDir, "treeData");
         yield fs.writeFile(tempPath, treeData);
         const makeTreeExecString = `\
-cat '${tempPath}' | git -C ${repo.path()} mktree
+cat '${tempPath}' | git -C '${repo.path()}' mktree
 `;
         return yield doExec(makeTreeExecString);
     });
@@ -630,7 +630,7 @@ exports.writeMultiRAST = co.wrap(function *(repos, rootDirectory) {
         // Then set up the rest of the repository.
         yield configureRepo(repo, ast, commitMaps.oldToNew);
         const cleanupString = `\
-git -C ${repo.path()} -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
+git -C '${repo.path()}' -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
 -c gc.rerereresolved=0 -c gc.rerereunresolved=0 \
 -c gc.pruneExpire=now gc`;
         yield exec(cleanupString);

--- a/node/test/util/git_util.js
+++ b/node/test/util/git_util.js
@@ -38,6 +38,7 @@ const os     = require("os");
 const path   = require("path");
 
 const GitUtil             = require("../../lib/util/git_util");
+const RepoAST             = require("../../lib/util/repo_ast");
 const RepoASTTestUtil     = require("../../lib/util/repo_ast_test_util");
 const ShorthandParserUtil = require("../../lib/util/shorthand_parser_util");
 const TestUtil            = require("../../lib/util/test_util");
@@ -334,11 +335,15 @@ describe("GitUtil", function () {
             "no branch": { input: "S:Bmaster=;*=", expected: null },
             "detached head": { input: "S:*=", expected: null },
             "not master": { input: "S:Bmaster=;Bfoo=1;*=foo", expected: "foo"},
+            "empty": { input: new RepoAST(), expected: null },
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];
             it(caseName, co.wrap(function *() {
-                const ast = ShorthandParserUtil.parseRepoShorthand(c.input);
+                let ast = c.input;
+                if ("string" === typeof c.input) {
+                    ast = ShorthandParserUtil.parseRepoShorthand(c.input);
+                }
                 const path = yield TestUtil.makeTempDir();
                 const repo =
                             (yield WriteRepoASTUtil.writeRAST(ast, path)).repo;

--- a/node/test/util/open.js
+++ b/node/test/util/open.js
@@ -54,6 +54,12 @@ describe("openOnCommit", function () {
             commitSha: "3",
             expected: "x=E:Os H=3",
         },
+        "revert on bad fetch": {
+            initial: "a=B|b=B|x=Ca:C3-1;C2-1 s=Sb:3;Bmaster=2;Bfoo=3",
+            subName: "s",
+            commitSha: "2",
+            fails: true,
+        },
     };
     Object.keys(cases).forEach(caseName => {
         const c = cases[caseName];
@@ -71,7 +77,8 @@ describe("openOnCommit", function () {
             });
             yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,
                                                            c.expected,
-                                                           manipulator);
+                                                           manipulator,
+                                                           c.fails);
         }));
     });
 });

--- a/node/test/util/read_repo_ast_util.js
+++ b/node/test/util/read_repo_ast_util.js
@@ -390,9 +390,6 @@ describe("readRAST", function () {
         RepoASTUtil.assertEqualASTs(ast, expected);
     }));
 
-    // For now, we care about an explicit headless state, we're not concerned
-    // with empty repos.
-
     it("headless", co.wrap(function *() {
         const path = yield TestUtil.makeTempDir();
         const r = yield NodeGit.Repository.init(path, 0);

--- a/node/test/util/read_repo_ast_util.js
+++ b/node/test/util/read_repo_ast_util.js
@@ -383,9 +383,21 @@ describe("readRAST", function () {
         const expected = new RepoAST({
             commits: commits,
             branches: { "master": commit },
-            head: null,
+            head: commit,
             currentBranchName: "master",
+            bare: true,
         });
+        RepoASTUtil.assertEqualASTs(ast, expected);
+    }));
+
+    // For now, we care about an explicit headless state, we're not concerned
+    // with empty repos.
+
+    it("headless", co.wrap(function *() {
+        const path = yield TestUtil.makeTempDir();
+        const r = yield NodeGit.Repository.init(path, 0);
+        const ast = yield ReadRepoASTUtil.readRAST(r);
+        const expected = new RepoAST();
         RepoASTUtil.assertEqualASTs(ast, expected);
     }));
 

--- a/node/test/util/repo_ast_util.js
+++ b/node/test/util/repo_ast_util.js
@@ -161,6 +161,7 @@ describe("RepoAstUtil", function () {
                     workdir: { foo: "bar" },
                     openSubmodules: { y: anAST },
                     rebase: new Rebase("foo", "1", "1"),
+                    bare: false,
                 }),
                 expected: new AST({
                     commits: { "1": aCommit},
@@ -173,7 +174,13 @@ describe("RepoAstUtil", function () {
                     workdir: { foo: "bar" },
                     openSubmodules: { y: anAST },
                     rebase: new Rebase("foo", "1", "1"),
+                    bare: false,
                 }),
+            },
+            "bad bare": {
+                actual: new AST({ bare: true }),
+                expected: new AST({ bare: false }),
+                fails: true,
             },
             "wrong commit": {
                 actual: new AST({

--- a/node/test/util/shorthand_parser_util.js
+++ b/node/test/util/shorthand_parser_util.js
@@ -605,6 +605,23 @@ describe("ShorthandParserUtil", function () {
                 i: "B",
                 e: B,
             },
+            "bare with commit": {
+                i: "B:C2-1;Bmaster=2",
+                e: B.copy({
+                    commits: {
+                        "1": B.commits["1"],
+                        "2": new Commit({
+                            changes: { "2": "2" },
+                            message: "message",
+                            parents: ["1"],
+                        }),
+                    },
+                    branches: {
+                        "master": "2",
+                    },
+                    head: "2",
+                }),
+            },
             "A type": {
                 i: "Axyz",
                 e: new RepoAST({
@@ -736,6 +753,25 @@ describe("ShorthandParserUtil", function () {
         const U = ShorthandParserUtil.RepoType.U;
         const cases = {
             "simple": { i: "a=S", e: { a: "S"} },
+            "bare with commit": {
+                i: "a=B:C2-1;Bmaster=2",
+                e: {
+                    a: B.copy({
+                        commits: {
+                            "1": B.commits["1"],
+                            "2": new Commit({
+                                changes: { "2": "2" },
+                                message: "message",
+                                parents: ["1"],
+                            }),
+                        },
+                        branches: {
+                            "master": "2",
+                        },
+                        head: "2",
+                    }),
+                },
+            },
             "simple trimmed": { i: "\n  a=S", e: { a: "S"} },
             "multiple": {
                 i: "a=S|b=S:Bfoo=1",
@@ -1065,6 +1101,7 @@ describe("ShorthandParserUtil", function () {
                             master: "8",
                         },
                         currentBranchName: "master",
+                        head: "8",
                     }),
                     b: U.copy({
                         openSubmodules: {
@@ -1106,6 +1143,7 @@ x=S:Efoo,8,9`,
                             master: "8",
                             foo: "9",
                         },
+                        head: "8",
                     }),
                     x: S.copy({
                         commits: {

--- a/node/test/util/status.js
+++ b/node/test/util/status.js
@@ -34,6 +34,7 @@ const assert  = require("chai").assert;
 const co      = require("co");
 
 const Rebase              = require("../../lib/util/rebase");
+const RepoAST             = require("../../lib/util/repo_ast");
 const RepoASTTestUtil     = require("../../lib/util/repo_ast_test_util");
 const RepoStatus          = require("../../lib/util/repo_status");
 const Status              = require("../../lib/util/status");
@@ -709,6 +710,17 @@ describe("Status", function () {
                     currentBranchName: "master",
                     headCommit: "1",
                 }),
+            },
+            "bare": {
+                state: "x=B",
+                expected: new RepoStatus({
+                    currentBranchName: "master",
+                    headCommit: "1",
+                }),
+            },
+            "empty": {
+                state: { x: new RepoAST()},
+                expected: new RepoStatus(),
             },
             "rebase": {
                 state: "x=S:C2-1;C3-1;Bfoo=3;Bmaster=2;Erefs/heads/master,2,3",

--- a/node/test/util/write_repo_ast_util.js
+++ b/node/test/util/write_repo_ast_util.js
@@ -192,6 +192,10 @@ S:C2-1 x=y;C3-1 x=z;Bmaster=2;Bfoo=3;Erefs/heads/master,2,3;I x=q",
                 expected: "\
 S:C2-1 x=y;C3-1 x=z;Bmaster=2;Bfoo=3;Erefs/heads/master,2,3;I x=q;H=3",
             },
+            "headless": {
+                input: new RepoAST(),
+                expected: new RepoAST(),
+            },
         };
 
         Object.keys(cases).forEach(caseName => {
@@ -234,12 +238,18 @@ S:C2-1 x=y;C3-1 x=z;Bmaster=2;Bfoo=3;Erefs/heads/master,2,3;I x=q;H=3",
                   "a=S|b=S:I x/y/z=Sa:1,x/y/q=Sa:1;Ox/y/z;Ox/y/q W x=hello",
             "open sub with new commit":
                 "a=S|x=S:C2-1 s=Sa:1;Bmaster=2;Os Bmaster=2!*=master",
+            "headless": {
+                a: new RepoAST(),
+            },
         };
         Object.keys(cases).forEach(caseName => {
             const input = cases[caseName];
             it(caseName, co.wrap(function *() {
-                const inASTs =
+                let inASTs = input;
+                if ("string" === typeof input) {
+                    inASTs =
                             ShorthandParserUtil.parseMultiRepoShorthand(input);
+                }
                 const root = yield TestUtil.makeTempDir();
                 const result = yield WriteRepoASTUtil.writeMultiRAST(inASTs,
                                                                      root);


### PR DESCRIPTION
Previously, `Status.getRepoStatus` would choke if it encountered a submodule in a headless state. This change fixes that problem, and adds other features to improve resiliency, such as:

- `openOnCommit` will clean up if we fail to fetch the SHA needed to checkout the submodule
- `open` will not abort if a single submodule fails to open, but will try to open all of them
- generally better support for bare/empty repos