### PR TITLE
Generate repo

### DIFF
--- a/node/bin/generate-repo
+++ b/node/bin/generate-repo
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require("./../lib/generate-repo.js");

--- a/node/lib/generate-repo.js
+++ b/node/lib/generate-repo.js
@@ -1,0 +1,457 @@
+#!/usr/bin/env node
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+const ArgumentParser = require("argparse").ArgumentParser;
+const co             = require("co");
+const NodeGit        = require("nodegit");
+const path           = require("path");
+const rimraf         = require("rimraf");
+
+const RepoAST             = require("./util/repo_ast");
+const Stopwatch           = require("./util/stopwatch");
+const SubmoduleUtil       = require("./util/submodule_util");
+const SubmoduleConfigUtil = require("./util/submodule_config_util");
+const SyntheticBranchUtil = require("./util/synthetic_branch_util");
+const WriteRepoASTUtil    = require("./util/write_repo_ast_util");
+
+const description = `Write the repos described by a string having the syntax \
+described in ./util/shorthand_parser_util.`;
+
+const parser = new ArgumentParser({
+    addHelp: true,
+    description: description
+});
+
+parser.addArgument(["destination"], {
+    type: "string",
+    help: `directory to create repository in.  If present and '--overwrite' \
+isn't specified, generate commits into the repository at that location.`
+});
+
+parser.addArgument(["-o", "--overwrite"], {
+    required: false,
+    action: "storeConst",
+    constant: true,
+    help: `automatically remove existing directories`,
+});
+
+parser.addArgument(["-c", "--count"], {
+    required: false,
+    defaultValue: -1,
+    type: "int",
+    help: "number of meta-repo commit block iterations, omit to go forever",
+});
+
+parser.addArgument(["-b", "--block-size"], {
+    required: false,
+    defaultValue: 100,
+    type: "int",
+    help: "number of commits to write at once",
+});
+
+const args = parser.parseArgs();
+
+/**
+ * Return a random integer in the range of [0, max).
+ * 
+ * @param {Number} max
+ * @return {Number}
+ */
+function randomInt(max) {
+    return Math.floor(Math.random() * max);
+}
+
+const baseChar = "a".charCodeAt(0);
+
+function generateCharacter() {
+    return String.fromCharCode(baseChar + randomInt(26));
+}
+
+function generatePath(depth) {
+    let result = "";
+    for (let i = 0; i < depth; ++i) {
+        if (0 !== i) {
+            result += "/";
+        }
+        result += (generateCharacter() + generateCharacter());
+    }
+    // Make leaves have three characters so they're always distinct from
+    // directories.
+
+    return result + generateCharacter();
+}
+
+
+class State {
+    constructor() {
+        this.treeCache        = {};     // used in writing commits
+        this.renderCache      = {};     // used in writing commits
+        this.oldCommitMap     = {};     // maps logical to physical sha
+        this.commits          = {};     // logical sha to RepoAST.Commit
+        this.submoduleNames   = [];     // paths of all subs
+        this.submoduleHeads   = {};     // map to last sub commit
+        this.oldHeads         = [];     // meta-refs to delete
+        this.metaHead         = null;   // array of shas
+        this.nextCommitId     = 2;      // next logical sha
+        this.totalCommits     = 0;      // total meta and sub commits made
+    }
+
+    generateCommitId() {
+        return "" + this.nextCommitId++;
+    }
+}
+
+function makeSubCommits(state, name, madeShas) {
+    const numCommits = randomInt(2) + 1;
+    const subHeads = state.submoduleHeads;
+    let lastHead = subHeads[name];
+    if (undefined !== lastHead) {
+        state.oldHeads.push(lastHead);
+    }
+    const commits = state.commits;
+    for (let i = 0; i < numCommits; ++i) {
+        const newHead = state.generateCommitId();
+        let changes = {};
+
+        // If this subrepo already has changes, we'll go back and update a few
+        // of them at random.
+
+        if (undefined !== lastHead) {
+            const oldChanges = RepoAST.renderCommit(state.renderCache,
+                                                    commits,
+                                                    lastHead);
+            const paths = Object.keys(oldChanges);
+            const numChanges = randomInt(2) + 1;
+            for (let j = 0; j < numChanges; ++j) {
+                const pathToUpdate = paths[randomInt(paths.length)];
+                changes[pathToUpdate] =
+                                      state.nextCommitId + generateCharacter();
+            }
+        }
+
+        // Add a path if there are no commits yet, or on a chance
+
+        if (undefined === lastHead || 0 === randomInt(6)) {
+            const path = generatePath(randomInt(3) + 1);
+            changes[path] = state.nextCommitId + generateCharacter();
+        }
+        const parents = undefined === lastHead ? [] : [lastHead];
+        lastHead = newHead;
+        subHeads[name] = newHead;
+        const commit = new RepoAST.Commit({
+            parents: parents,
+            changes: changes,
+            message: `a random commit for sub ${name}, #${newHead}`,
+        });
+        madeShas.push(newHead);
+        commits[newHead] = commit;
+    }
+    state.totalCommits += numCommits;
+    return lastHead;
+}
+
+/**
+ * Generate a commit in the specified `state`, storing in the specified
+ * `madeShas` all generated commit ids and in the specified `subHeads` the
+ * shas of submodule heads referenced by meta-repo commits.
+ *
+ * @param {State}     state
+ * @param {String []} madeShas
+ * @param {String []} subHeads
+ */
+function makeMetaCommit(state, madeShas, subHeads) {
+    const subsToChange = randomInt(2) + 1;
+    let subPaths = {};
+    const numSubs = state.submoduleNames.length;
+
+    if (0 !== numSubs) {
+        // randomly pick subs to modify
+
+        for (let i = 0; i < subsToChange; ++i) {
+            const index = randomInt(numSubs);
+            const name = state.submoduleNames[index];
+            if (!(name in subPaths)) {
+                subPaths[name] = true;
+            }
+        }
+    }
+
+    // Generate a new submodule if no submodules, or chance dictates.
+
+    if (0 === numSubs || 0 === randomInt(10)) {
+        while (true) {
+            const path = generatePath(3);
+            if (!(path in state.submoduleHeads)) {
+                subPaths[path] = true;
+                state.submoduleNames.push(path);
+                break;
+            }
+        }
+    }
+
+    const changes = {};
+    Object.keys(subPaths).forEach(function (path) {
+        const newHead = makeSubCommits(state, path, madeShas);
+        changes[path] = new RepoAST.Submodule(".", newHead);
+        subHeads.push(newHead);
+    });
+    const commitId = state.generateCommitId();
+    const lastHead = state.metaHead;
+    state.metaHead = commitId;
+    const parents = lastHead === null ? [] : [lastHead];
+    const commit = new RepoAST.Commit({
+        parents: parents,
+        changes: changes,
+        message: `a friendly meta commit, #${commitId}`,
+    });
+    state.commits[commitId] = commit;
+    madeShas.push(commitId);
+    ++state.totalCommits;
+}
+
+const renderRefs = co.wrap(function *(repo, oldCommitMap, shas) {
+    yield shas.map(sha => {
+        const target = oldCommitMap[sha];
+        const targetId = NodeGit.Oid.fromString(target);
+        return NodeGit.Reference.create(
+                       repo,
+                       SyntheticBranchUtil.getSyntheticBranchForCommit(target),
+                       targetId,
+                       0,
+                       "meta-ref");
+    });
+});
+
+const renderBlock = co.wrap(function *(repo, state, shas, subHeads) {
+    yield WriteRepoASTUtil.writeCommits(state.oldCommitMap,
+                                        state.treeCache,
+                                        repo,
+                                        state.commits,
+                                        shas);
+    yield renderRefs(repo, state.oldCommitMap, subHeads);
+    yield NodeGit.Reference.create(repo,
+                                   "refs/heads/master",
+                                   state.oldCommitMap[state.metaHead],
+                                   1,
+                                   "my ref");
+    yield state.oldHeads.map(co.wrap(function *(sha) {
+        const realSha = state.oldCommitMap[sha];
+        const metaRefName =
+                      SyntheticBranchUtil.getSyntheticBranchForCommit(realSha);
+        const ref = yield NodeGit.Reference.lookup(repo, metaRefName);
+        ref.delete();
+    }));
+    state.oldHeads = [];
+});
+
+
+function doGc(state) {
+    const toKeep = new Set();
+    function addToKeep(sha) {
+        toKeep.add(sha);
+    }
+    toKeep.add(state.metaHead);
+    const metaCommit = state.commits[state.metaHead];
+    metaCommit.parents.forEach(addToKeep);
+    for (let path in state.submoduleHeads) {
+        const sha = state.submoduleHeads[path];
+        toKeep.add(sha);
+        const commit = state.commits[sha];
+        if (undefined !== commit) {
+            commit.parents.forEach(addToKeep);
+        }
+    }
+    function copyIfUsed(map) {
+        let result = {};
+        for (let sha in map) {
+            if (toKeep.has(sha)) {
+                result[sha] = map[sha];
+            }
+        }
+        return result;
+    }
+    state.treeCache = copyIfUsed(state.treeCache);
+    state.oldCommitMap = copyIfUsed(state.oldCommitMap);
+    state.commits = copyIfUsed(state.commits);
+}
+
+/**
+ * @return {Object}
+ * @return {NodeGit.Tree} return.tree
+ * @return {Object}       return.subtrees
+ * @return {Object}       return.submodules
+ */
+const loadTree = co.wrap(function *(repo, treeId, renderCache, basePath) {
+    // We don't load any submodules here; that will be done manually for the
+    // meta-repo.
+
+    const tree = yield NodeGit.Tree.lookup(repo, treeId);
+    const entries = tree.entries();
+    const result = {
+        tree: tree,
+        subtrees: {},
+        submodules: {},
+    };
+    const subtrees = result.subtrees;
+    for (let i = 0; i < entries.length; ++i) {
+        const entry = entries[i];
+        const entryPath = entry.path();
+        const fullPath = null === basePath ?
+                                    entryPath : path.join(basePath, entryPath);
+        if (entry.isTree()) {
+            subtrees[entryPath] = yield loadTree(repo,
+                                                 entry.id(),
+                                                 renderCache,
+                                                 fullPath);
+        }
+        else {
+            // Just put a placeholder in the render cache for now; the only
+            // place we're using it is to determine what paths exist in a
+            // submodule.
+
+            renderCache[fullPath] = "";
+        }
+    }
+    return result;
+});
+
+const loadState = co.wrap(function *(repo) {
+    const master = yield repo.getBranch("master");
+    const masterCommitId = master.target();
+    const masterCommit = yield repo.getCommit(masterCommitId);
+    const state = new State();
+
+    state.submoduleNames = yield SubmoduleUtil.getSubmoduleNamesForCommit(
+                                                                 repo,
+                                                                 masterCommit);
+    const commitsToLoad = [];
+    const newToOld = {};
+    function mapSha(sha) {
+        const logical = state.generateCommitId();
+        state.oldCommitMap[logical] = sha;
+        newToOld[sha] = logical;
+        commitsToLoad.push(logical);
+        return logical;
+    }
+    state.metaHead = mapSha(masterCommitId.tostrS());
+    const subShas = yield SubmoduleUtil.getSubmoduleShasForCommit(
+                                                          repo,
+                                                          state.submoduleNames,
+                                                          masterCommit);
+    const subUrls = yield SubmoduleConfigUtil.getSubmodulesFromCommit(
+                                                                 repo,
+                                                                 masterCommit);
+    state.submoduleNames.forEach(name => {
+        const sha = subShas[name];
+        state.submoduleHeads[name] = mapSha(sha);
+    });
+    yield commitsToLoad.map(co.wrap(function *(logical) {
+        const sha = state.oldCommitMap[logical];
+        const commit = yield repo.getCommit(sha);
+        const treeId = commit.treeId();
+        const cache = {};
+        state.renderCache[logical] = cache;
+        state.treeCache[logical] = yield loadTree(repo, treeId, cache, null);
+    }));
+
+    // manually populate submodules for meta repo
+
+    const metaTreeCache = state.treeCache[state.metaHead];
+    const metaSubs = metaTreeCache.submodules;
+    state.submoduleNames.forEach(name => {
+        const url = subUrls[name];
+        metaSubs[name] = url;
+    });
+    return state;
+});
+
+co(function *() {
+    try {
+        const path = args.destination;
+        let repo;
+        let state;
+        if (args.overwrite) {
+            const timer = new Stopwatch();
+            process.stdout.write("Removing old files... ");
+            yield (new Promise(callback => {
+                return rimraf(path, {}, callback);
+            }));
+            process.stdout.write(`took ${timer.elapsed} seconds.\n`);
+        }
+        else {
+            // Try to use an existing repo.
+            try {
+                repo = yield NodeGit.Repository.open(path);
+            }
+            catch (e) {
+            }
+            if (repo) {
+                const loadTime = new Stopwatch();
+                process.stdout.write("Beginning from existing repository... ");
+                state = yield loadState(repo);
+                process.stdout.write(`took ${loadTime.elapsed}.\n`);
+            }
+        }
+
+        if (undefined === repo) {
+            repo = yield NodeGit.Repository.init(path, 1);
+            state = new State();
+        }
+        const count = args.count;
+        const blockSize = args.block_size;
+        console.log(`Generating ${count < 0 ? "infinite" : count} blocks of \
+${blockSize} commits.`);
+        const totalTime = new Stopwatch();
+        let metaCommits = 0;
+        for (let i = 0; -1 === count || i < count; ++i) {
+            const madeShas = [];
+            const subHeads = [];
+            for (let i = 0; i < blockSize; ++i) {
+                makeMetaCommit(state, madeShas, subHeads);
+            }
+            metaCommits += blockSize;
+            const time = new Stopwatch();
+            yield renderBlock(repo, state, madeShas, subHeads);
+            time.stop();
+            doGc(state);
+            console.log(`Writing ${madeShas.length} commits and \
+${subHeads.length} sub changes, took ${time.elapsed} seconds.  Commit \
+rate ${metaCommits / totalTime.elapsed}/s, meta commits ${metaCommits}, \
+total time ${totalTime.elapsed}, total subs: ${state.submoduleNames.length} \
+total commits ${state.totalCommits}, \
+${state.totalCommits / totalTime.elapsed}/s.`);
+        }
+    }
+    catch(e) {
+        console.error(e.stack);
+    }
+});

--- a/node/lib/util/read_repo_ast_util.js
+++ b/node/lib/util/read_repo_ast_util.js
@@ -235,8 +235,19 @@ exports.readRAST = co.wrap(function *(repo) {
     let branchName = null;
     let headCommitId = null;
     if (!repo.headDetached() && !repo.isEmpty()) {
-        const branch = yield repo.getCurrentBranch();
-        branchName = branch.shorthand();
+        // It's possible that the repo may be non-empty, non-head-detached
+        // (because it's bare), and still not have a current branch, in which
+        // case, `getCurrentBranch` will throw.
+
+        let branch = null;
+        try {
+            branch = yield repo.getCurrentBranch();
+        }
+        catch (e) {
+        }
+        if (null !== branch) {
+            branchName = branch.shorthand();
+        }
     }
 
     // If the repo isn't bare, process the index, HEAD, and workdir.

--- a/node/lib/util/stopwatch.js
+++ b/node/lib/util/stopwatch.js
@@ -1,0 +1,163 @@
+/*
+ *
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert = require("chai").assert;
+
+/**
+ * This module provides the `Stopwatch` class.
+ */
+
+/**
+ * `Stopwatch` is a mechanism class providing a way to measure elapsed wall
+ * time.  `Stopwatch` supports *reentrant* code (as is common with 
+ * asynchronous code), keeping so that after N calls to `start` it will
+ * accumulate time until it sees N calls to `stop`.
+ */
+class Stopwatch {
+
+    /**
+     * Create a new `Stopwatch` class; call `start` unles the specified
+     * `paused` is true.
+     *
+     * @param {Boolean} paused
+     */
+    constructor(paused) {
+        this.d_startCount = 0;
+        this.d_elapsed = 0;
+        this.d_startTime = null;
+
+        if (!paused) {
+            this.start();
+        }
+    }
+
+    /**
+     * Start accumulating elapsed time if `0 === this.startCount`; increment
+     * `this.startCount`.
+     */
+    start() {
+        if (1 === ++this.d_startCount) {
+            this.d_startTime = new Date();
+        }
+    }
+
+    /**
+     * Stop accumulating time if `1 === this.startCount` and decrement
+     * `this.startCount`; return `this.elapsed`.  The behavior is undefined
+     * unless `0 !== this.startCount`.
+    *
+     * @return {Number}
+     */
+    stop() {
+        assert(0 !== this.d_startCount);
+        if (1 === this.d_startCount) {
+            const current = this.getCurrentMs();
+            this.d_elapsed += current;
+            this.d_startTime = null;
+        }
+        --this.d_startCount;
+        return this.elapsed;
+    }
+
+    /**
+     * Stop accumulating time if accumulating, reset accumulated time to 0, and
+     * return the amount of time accumulated until now, in seconds.  If the
+     * specified `paused` is true, do not start the clock.  The behavior is
+     * undefined unless `1 >= this.startCount`.
+     *
+     * @param {Boolean} [paused]
+     * @return {Number}
+     */
+    reset(paused) {
+        assert(1 >= this.d_startCount);
+        const current = this.elapsed;
+        this.d_elapsed = 0;
+        this.d_startTime = null;
+        this.d_startCount = 0;
+        if (!paused) {
+            this.start();
+        }
+        return current;
+    }
+
+    /**
+     * Return the amount of time elapsed since `start` was called, in seconds.
+     * The behavior is undefined unless `0 !== this.startCount`.
+     *
+     * @return {Number}
+     */
+    getCurrent() {
+        assert(0 !== this.d_startCount);
+        return this.getCurrentMs() / 1000.0;
+    }
+
+    /**
+     * the amount of time elapased since `start` was called, in milliseconds.
+     * The behavior is undefined unless `0 !== this.startCount`.
+     *
+     * @return {Number}
+     */
+    getCurrentMs() {
+        assert(0 !== this.d_startCount);
+        return (new Date()) - this.d_startTime;
+    }
+
+    /**
+     * total amount of time accumulated in milliseconds
+     * @property {Number} 
+     */
+    get elapsed() {
+        return this.elapsedMs / 1000.0;
+    }
+
+    /**
+     * total amount of time accumulated in seconds
+     * @property {Number}
+     */
+    get elapsedMs() {
+        if (null !== this.d_startTime) {
+            return this.d_elapsed + this.getCurrentMs();
+        }
+        return this.d_elapsed;
+    }
+
+    /**
+     * true if currently accumulating time and false otherwise
+     * @property {Boolean}
+     */
+    get startCount() {
+        return this.d_startCount;
+    }
+}
+
+module.exports = Stopwatch;

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -45,6 +45,7 @@ const mkdirp   = require("mkdirp");
 const NodeGit  = require("nodegit");
 const path     = require("path");
 
+const DoWorkQueue         = require("./do_work_queue");
 const RebaseFileUtil      = require("./rebase_file_util");
 const RepoAST             = require("./repo_ast");
 const RepoASTUtil         = require("./repo_ast_util");
@@ -52,24 +53,6 @@ const SubmoduleConfigUtil = require("./submodule_config_util");
 const TestUtil            = require("./test_util");
 
                          // Begin module-local methods
-
-/**
- * Exec the specified `command` and return the result, omitting the "\n" at the
- * end.
- * @async
- * @private
- * @param {String} command
- * @return {String}
- */
-const doExec = co.wrap(function *(command) {
-    try {
-        const result = yield exec(command);
-        return result.stdout.split("\n")[0];
-    }
-    catch (e) {
-        throw e;
-    }
-});
 
 /**
  * Write the specified `data` to the specified `repo` and return its hash
@@ -81,113 +64,10 @@ const doExec = co.wrap(function *(command) {
  * @param {String}             data
  * @return {String}
  */
-const hashObject = co.wrap(function *(repo, data) {
-    const db = yield repo.odb();
+const hashObject = co.wrap(function *(db, data) {
     const BLOB = 3;
     const res = yield db.write(data, data.length, BLOB);
     return res.tostrS();
-});
-
-/**
- * Create and return the id of a `NodeGit.Tree` containing the contents of the
- * specified `flatTree` in the specified `repo`.  Use the specified
- * `getSubmoduleSha` to obtain the sha for any submodule commits.
- *
- * @private
- * @async
- * @param {NodeGit.Repo}     repo
- * @param {Object}           flatTree maps path to data or `RepoAST.Submodule`
- * @param {(sha) => Promise} getSubmoduleSha
- * @return {String}
- */
-const makeTree = co.wrap(function *(repo, flatTree, getSubmoduleSha) {
-    assert.instanceOf(repo, NodeGit.Repository);
-    assert.isObject(flatTree);
-    assert.isFunction(getSubmoduleSha);
-
-    // Strategy for making a tree:
-    // - take the flat data in `flatTree` and turn it into a hierarchy with
-    //   `buildDirectoryTree`
-    // - calculate contents of `.gitmodules` file and add to tree
-    // - invoke `writeHierarchy` to generate tree id, it will add a line for
-    //   each entry:
-    // ` - for a file, hash its contents and add a `blob` line
-    //   - for a submodule, add a line indicating its sha
-    //   - for a subtree, recurse and add a line with subtree id
-
-    const writeHierarchy = co.wrap(function *(hierarchy) {
-
-        let treeData = "";
-
-        function addToTree(fileType, dataType, id, path) {
-            if ("" !== treeData) {
-                treeData += "\n";
-            }
-            treeData += `${fileType} ${dataType} ${id}\t${path}`;
-        }
-
-        for (let path in hierarchy) {
-            const change = hierarchy[path];
-            if (change instanceof RepoAST.Submodule) {
-                const newSha = yield getSubmoduleSha(change.sha);
-                addToTree("160000", "commit", newSha, path);
-            }
-            else if ("string" === typeof change) {
-                // A string indicates files data.
-
-                const id = yield hashObject(repo, change);
-                addToTree("100644", "blob", id, path);
-            }
-            else {
-                // If it's not a submodule or a file, it must be a subtree.
-
-                const subTreeId = yield writeHierarchy(change);
-                addToTree("040000", "tree", subTreeId, path);
-            }
-        }
-
-        // If no data, make an empty tree
-        if ("" === treeData ) {
-            const builder = yield NodeGit.Treebuilder.create(repo, null);
-            const treeObj = builder.write();
-            return treeObj.tostrS();                                  // RETURN
-        }
-        const tempDir = yield TestUtil.makeTempDir();
-        const tempPath = path.join(tempDir, "treeData");
-        yield fs.writeFile(tempPath, treeData);
-        const makeTreeExecString = `\
-cat '${tempPath}' | git -C '${repo.path()}' mktree
-`;
-        return yield doExec(makeTreeExecString);
-    });
-
-    let gitModulesData = "";
-
-    // Pre-process submodules to get shas and the data for the .gitmodules
-    // file.
-
-    for (let path in flatTree) {
-        const data = flatTree[path];
-        if (data instanceof RepoAST.Submodule) {
-            const modulesStr = `\
-[submodule "${path}"]
-\tpath = ${path}
-\turl = ${data.url}
-`;
-            gitModulesData += modulesStr;
-        }
-    }
-
-    const directoryTree = exports.buildDirectoryTree(flatTree);
-    assert.notProperty(directoryTree,
-                       SubmoduleConfigUtil.modulesFileName,
-                       "no explicit changes to the git modules file");
-
-    if ("" !== gitModulesData) {
-        directoryTree[SubmoduleConfigUtil.modulesFileName] = gitModulesData;
-    }
-
-    return yield writeHierarchy(directoryTree);
 });
 
 /**
@@ -202,60 +82,229 @@ const configRepo = co.wrap(function *(repo) {
 });
 
 /**
- * Write the specified `commits` map into the specified `repo`.  Return maps
- * from old commit to new and new commit to old.
+ * Return the tree and a map of associated subtrees corresponding to the
+ * specified `flatChanges` in the specified `repo`, and based on the optionally
+ * specified `parent`.  Use the specified `shaMap` to resolve logical shas to
+ * actual written shas (such as for submodule heads).  Use the specified `db`
+ * to write objects.  If the specified `root` is true, generate a `.gitmodules`
+ * file containing an entry for each submodule.
  *
- * @private
  * @async
- * @param {NodeGit.Repository} repo
- * @param {Object}             commits   id to `RepoAST.Commit`
+ * @param {Boolean}               root
+ * @param {NodeGit.Repository}    repo
+ * @param {NodeGit.Odb}           db
+ * @param {Object}                shaMap maps logical to physical ID
+ * @param {Object}                flatChanges map of changes
+ * @param {Object}                [parent]
+ * @param {Object}                parent.subtrees   filename to return value
+ * @param {NodeGit.Tree}          parent.tree       generated tree object
+ * @param {Object}                parent.submodules name to url
  * @return {Object}
- * @return {Object} return.oldToNew  maps original to generated commit id
- * @return {Object} return.newToOld  maps generated to original commit id
+ * @return {Object}       return.submodules
+ * @return {Object}       return.subtrees
+ * @return {NodeGit.Tree} return.tree
  */
-const writeCommits = co.wrap(function *(repo, commits) {
-    let oldCommitMap = {};  // from old to new sha
+const writeTree = co.wrap(function *(root,
+                                     repo,
+                                     db,
+                                     shaMap,
+                                     changes,
+                                     parent) {
+    let subtrees = {};          // will contain written subtree entries
+    let parentTree = null;      // base root
+    const submodules = {};      // all submodule entries, including children
+
+    // If `parent` is provided, copy values into the above structures.
+
+    if (undefined !== parent) {
+        Object.assign(subtrees, parent.subtrees);
+        parentTree = parent.tree;
+        Object.assign(submodules, parent.submodules);
+    }
+
+    const wereSubs = 0 !== Object.keys(submodules).length;
+
+    // Initialize the builder with the previous tree from which the changes are
+    // derived.
+
+    const builder = yield NodeGit.Treebuilder.create(repo, parentTree);
+
+    const actions = [];  // tree updates to be applied in parallel
+
+    const writeSubtree = co.wrap(function *(filename, entry) {
+        const subtree = yield writeTree(false,
+                                        repo,
+                                        db,
+                                        shaMap,
+                                        entry,
+                                        subtrees[filename]);
+        subtrees[filename] = subtree;
+        yield builder.insert(filename,
+                             subtree.tree.id(),
+                             NodeGit.TreeEntry.FILEMODE.TREE);
+
+        // Reconstitute the submodule path and copy it into the right location.
+
+        for (let subPath in subtree.submodules) {
+            const sub = subtree.submodules[subPath];
+            submodules[path.join(filename, subPath)] = sub;
+        }
+    });
+
+    const writeBlob = co.wrap(function *(filename, data) {
+        const id = yield hashObject(db, data);
+        yield builder.insert(filename,
+                             id,
+                             NodeGit.TreeEntry.FILEMODE.BLOB);
+    });
+
+    // Loop through all the changes and store an action to apply them.
+
+    for (let filename in changes) {
+        const entry = changes[filename];
+
+        let isSubmodule = false;
+
+        if (null === entry) {
+            // Null means the entry was deleted.
+
+            builder.remove(filename);
+        }
+        else if ("string" === typeof entry) {
+            // A string is just plain data.
+
+            actions.push(writeBlob(filename, entry));
+        }
+        else if (entry instanceof RepoAST.Submodule) {
+            // For submodules, we must map the logical sha it contains to the
+            // actual sha that was written for the submodule commit.
+
+            const id = shaMap[entry.sha];
+            actions.push(builder.insert(filename,
+                                        id,
+                                        NodeGit.TreeEntry.FILEMODE.COMMIT));
+            submodules[filename] = entry.url;
+            isSubmodule = true;
+        }
+        else {
+            // Otherwise, we have a directory and must make a subtree.
+
+            actions.push(writeSubtree(filename, entry));
+        }
+        if (!isSubmodule) {
+            // In case this entry was previously a submodule, we have to remove
+            // it from the submodule list.
+
+            delete submodules[filename];  // can not be a submodule
+        }
+    }
+
+    // Apply the operations in parallel.
+
+    yield actions;
+
+    // If this is a "root" tree, and there are submodules, we must write the
+    // `.gitmodules` file.
+
+    if (root) {
+        const subNames = Object.keys(submodules).sort();
+        if (0 !== subNames.length) {
+            let data = "";
+            for (let i = 0; i < subNames.length; ++i) {
+                const filename = subNames[i];
+                const url = submodules[filename];
+                data += `\
+[submodule "${filename}"]
+\tpath = ${filename}
+\turl = ${url}
+`;
+            }
+            const dataId = yield hashObject(db, data);
+            yield builder.insert(SubmoduleConfigUtil.modulesFileName,
+                                 dataId,
+                                 NodeGit.TreeEntry.FILEMODE.BLOB);
+        }
+        else if (wereSubs) {
+            builder.remove(SubmoduleConfigUtil.modulesFileName);
+        }
+    }
+    const id = builder.write();
+    const tree = yield repo.getTree(id);
+    return {
+        tree: tree,
+        subtrees: subtrees,
+        submodules: submodules,
+    };
+});
+
+/**
+ * Write the commits having the specified `shas` from the specified `commits`
+ * map into the specified `repo`.  Read and write logical to physical sha
+ * mappings to and from the specified `oldCommitMap`.  Use the specifeid
+ * `treeCache` to store computed directory structures and trees.  Return a map
+ * from new (physical) sha from the original (logical) sha of the commits
+ * written.
+ *
+ * @async
+ * @param {Object} oldCommitMap old to new sha, read/write
+ * @param {Object} treeCache  cache of generated commit trees
+ * @param {NodeGit.Repository} repo
+ * @param {Object}             commits sha to `RepoAST.Commit`
+ * @param {String[]}           shas    array of shas to write
+ * @return {Object} maps generated to original commit id
+ */
+exports.writeCommits = co.wrap(function *(oldCommitMap,
+                                          treeCache,
+                                          repo,
+                                          commits,
+                                          shas) {
+    assert.isObject(oldCommitMap);
+    assert.isObject(treeCache);
+    assert.instanceOf(repo, NodeGit.Repository);
+    assert.isObject(commits);
+    assert.isArray(shas);
+
+    const db = yield repo.odb();
     let newCommitMap = {};  // from new to old sha
-    let renderCache = {};   // used to render commits
 
     const sig = repo.defaultSignature();
 
-    let commitObjs = {};  // map from new id to `Commit` object
+    const commitObjs = {};  // map from new id to `Commit` object
 
     const writeCommit = co.wrap(function *(sha) {
-        // TODO: extend libgit2 and nodegit to allow submoduel manipulations to
-        // `TreeBuilder`.  For now, we will do this ourselves using the `git`
-        // commandline tool.
-        //
-        // - First, we calculate the tree describred by the commit at `sha`.
-        // - Then, we build a string that describes that as if it were output
-        //   by `ls-tree`.
-        // - Next, we invoke `git-mktree` to create a tree id
-        // - finally, we invoke `git-commit-tree` to create the commit.
-
-        // Bail out if already written.
-
-        if (sha in oldCommitMap) {
-            return oldCommitMap[sha];
-        }
-
-        // Recursively get commit ids for parents.
-
         const commit = commits[sha];
         const parents = commit.parents;
 
+        // Get commit objects for parents.
+
+        let parentTrees;
         let newParents = [];  // Array of commit IDs
         for (let i = 0; i < parents.length; ++i) {
-            let parentSha = yield writeCommit(parents[i]);
-            newParents.push(commitObjs[parentSha]);
+            const parent = parents[i];
+            if (0 === i) {
+                parentTrees = treeCache[parent];
+            }
+            const parentSha = oldCommitMap[parent];
+            const parentCommit = yield repo.getCommit(parentSha);
+            newParents.push(parentCommit);
         }
 
-        // Calculate the tree.  `tree` describes the directory tree specified
-        // by the commit at `sha`.
+        // Calculate the tree.  `trees` describes the directory tree specified
+        // by the commit at `sha` and has caches for subtrees and submodules.
 
-        const tree = RepoAST.renderCommit(renderCache, commits, sha);
-        const treeId = yield makeTree(repo, tree, writeCommit);
-        const treeObj = yield repo.getTree(treeId);
+        const changes = exports.buildDirectoryTree(commit.changes);
+
+        const trees = yield writeTree(true,
+                                      repo,
+                                      db,
+                                      oldCommitMap,
+                                      changes,
+                                      parentTrees);
+
+        // Store the returned tree information for potential use by descendants
+        // of this commit.
+
+        treeCache[sha] = trees;
 
         // Make a commit from the tree.
 
@@ -265,21 +314,53 @@ const writeCommits = co.wrap(function *(repo, commits) {
                                                      sig,
                                                      0,
                                                      commit.message,
-                                                     treeObj,
+                                                     trees.tree,
                                                      newParents.length,
                                                      newParents);
         const commitSha = commitId.tostrS();
+
+        // Store bi-directional mappings between generated and logical sha.
+
         oldCommitMap[sha] = commitSha;
         newCommitMap[commitSha] = sha;
         commitObjs[commitSha] = (yield repo.getCommit(commitSha));
         return commitSha;
     });
 
-    for (let sha in commits) {
-        yield writeCommit(sha);
-    }
+    // Calculate the groups of commits that can be computed in parallel.
 
-    return { oldToNew: oldCommitMap, newToOld: newCommitMap };
+    const commitsByLevel = exports.levelizeCommitTrees(commits, shas);
+
+    for (let i = 0; i < commitsByLevel.length; ++i) {
+        const level = commitsByLevel[i];
+        yield DoWorkQueue.doInParallel(level, writeCommit);
+    }
+    return newCommitMap;
+});
+
+/**
+ * Write all of the specified `commits` into the specified `repo`.
+ *
+ * @async
+ * @private
+ * @param {NodeGit.Repository} repo
+ * @param {Object}             commits sha to `RepoAST.Commit`
+ * @param {Object}             treeCache
+ * @return {Object}
+ * @return {Object} return.oldToNew  maps original to generated commit id
+ * @return {Object} return.newToOld  maps generated to original commit id
+ */
+const writeAllCommits = co.wrap(function *(repo, commits, treeCache) {
+    const oldCommitMap = {};
+    const newIds = yield exports.writeCommits(oldCommitMap,
+                                              treeCache,
+                                              repo,
+                                              commits,
+                                              Object.keys(commits));
+    return {
+        newToOld: newIds,
+        oldToNew: oldCommitMap,
+    };
 });
 
 /**
@@ -293,8 +374,9 @@ const writeCommits = co.wrap(function *(repo, commits) {
  * @param {NodeGit.Repository} repo
  * @param {RepoAST}            ast
  * @param {Object}             commitMap  old to new id
+ * @param {Object}             treeCache  map of tree entries
  */
-const configureRepo = co.wrap(function *(repo, ast, commitMap) {
+const configureRepo = co.wrap(function *(repo, ast, commitMap, treeCache) {
     const makeRef = co.wrap(function *(name, commit) {
         const newSha = commitMap[commit];
         const newId = NodeGit.Oid.fromString(newSha);
@@ -403,18 +485,20 @@ const configureRepo = co.wrap(function *(repo, ast, commitMap) {
         // Set up the index.  We render the current commit and apply the index
         // on top of it.
 
-        let tree = ast.index;
+        let indexParent;
         if (null !== indexHead) {
-            tree =
-                  yield RepoAST.renderIndex(ast.commits, indexHead, ast.index);
+            indexParent = treeCache[indexHead];
         }
-
-        const treeId = yield makeTree(repo, tree, co.wrap(function *(sha) {
-            return yield Promise.resolve(commitMap[sha]);
-        }));
-
+        const db = yield repo.odb();
+        const changes = exports.buildDirectoryTree(ast.index);
+        const trees = yield writeTree(true,
+                                      repo,
+                                      db,
+                                      commitMap,
+                                      changes,
+                                      indexParent);
         const index = yield repo.index();
-        const treeObj = yield repo.getTree(treeId);
+        const treeObj = trees.tree;
         yield index.readTree(treeObj);
         yield index.write();
 
@@ -451,6 +535,72 @@ git -C '${repo.workdir()}' checkout-index -a -f
                           // End modue-local methods
 
 /**
+ * Return an array of arrays of commit shas such that the trees of the commits
+ * identified in an array depend only on the commits in previous arrays.  The
+ * tree of one commit depends on another commit (i.e., cannot be created until
+ * that commit exists) if it has a submodule sha referencing that commit.
+ * Until the commit is created, we do not know what its actual sha will be.
+ *
+ * @param {Object} commits map from sha to `RepoAST.Commit`.
+ * @return {Array} array of arrays of shas
+ */
+exports.levelizeCommitTrees = function (commits, shas) {
+    assert.isObject(commits);
+    assert.isArray(shas);
+
+    const includedShas = new Set(shas);
+
+    let result = [];
+    const commitLevels = {};  // from sha to number
+
+    function computeCommitLevel(sha) {
+        if (sha in commitLevels) {
+            return commitLevels[sha];
+        }
+        const commit = commits[sha];
+        const changes = commit.changes;
+        let level = 0;
+
+        // If this commit has a change that references another commit via a
+        // submodule sha, it must have a level at least one greater than that
+        // commit, if it is also in the set of shas being levelized.
+
+        for (let path in changes) {
+            const change = changes[path];
+            if (change instanceof RepoAST.Submodule) {
+                if (includedShas.has(change.sha)) {
+                    level = Math.max(computeCommitLevel(change.sha) + 1,
+                                     level);
+                }
+            }
+        }
+
+        // Similarly, with parents, a commit's level must be greater than that
+        // of parents that are included.
+
+        const parents = commit.parents;
+        for (let i = 0; i < parents.length; ++i) {
+            const parent = parents[i];
+            if (includedShas.has(parent)) {
+                level = Math.max(level, computeCommitLevel(parent) + 1);
+            }
+        }
+        commitLevels[sha] = level;
+        if (result.length === level) {
+            result.push([]);
+        }
+        result[level].push(sha);
+        return level;
+    }
+
+    for (let i = 0; i < shas.length; ++i) {
+        computeCommitLevel(shas[i]);
+    }
+
+    return result;
+};
+
+/**
  * Return a nested tree mapping the flat structure in the specified `flatTree`,
  * which consists of a map of paths to values, into a hierarchical structure
  * beginning at the root.  For example, if the input is:
@@ -458,11 +608,14 @@ git -C '${repo.workdir()}' checkout-index -a -f
  * the output will be:
  *     { a : { b: { c: 2, d: 3} } }
  *
+ * If `flatTree` contains submodules, render an appropriate `.gitmodules` file.
+ *
  * @param {Object} flatTree
  * @return {Object}
  */
 exports.buildDirectoryTree = function (flatTree) {
     let result = {};
+
     for (let path in flatTree) {
         const paths = path.split("/");
         let tree = result;
@@ -484,8 +637,13 @@ exports.buildDirectoryTree = function (flatTree) {
         }
         const leafPath = paths[paths.length - 1];
         assert.notProperty(tree, leafPath, `duplicate entry for ${path}`);
-        tree[leafPath] = flatTree[path];
+        const data = flatTree[path];
+        tree[leafPath] = data;
     }
+
+    assert.notProperty(result,
+                       SubmoduleConfigUtil.modulesFileName,
+                       "no explicit changes to the git modules file");
     return result;
 };
 
@@ -515,8 +673,13 @@ exports.writeRAST = co.wrap(function *(ast, path) {
 
     yield configRepo(repo);
 
-    const commits = yield writeCommits(repo, ast.commits);
-    const resultRepo = yield configureRepo(repo, ast, commits.oldToNew);
+    const treeCache = {};
+    const commits = yield writeAllCommits(repo, ast.commits, treeCache);
+    const resultRepo = yield configureRepo(repo,
+                                           ast,
+                                           commits.oldToNew,
+                                           treeCache);
+
     return {
         repo: resultRepo,
         commitMap: commits.newToOld,
@@ -592,7 +755,8 @@ exports.writeMultiRAST = co.wrap(function *(repos, rootDirectory) {
 
     // Write them:
 
-    const commitMaps = yield writeCommits(commitRepo, commits);
+    const treeCache = {};
+    const commitMaps = yield writeAllCommits(commitRepo, commits, treeCache);
 
     // We make a ref for each commit so that it is pulled down correctly.
 
@@ -628,7 +792,7 @@ exports.writeMultiRAST = co.wrap(function *(repos, rootDirectory) {
         yield NodeGit.Remote.delete(repo, "origin");
 
         // Then set up the rest of the repository.
-        yield configureRepo(repo, ast, commitMaps.oldToNew);
+        yield configureRepo(repo, ast, commitMaps.oldToNew, treeCache);
         const cleanupString = `\
 git -C '${repo.path()}' -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
 -c gc.rerereresolved=0 -c gc.rerereunresolved=0 \

--- a/node/test/util/git_util.js
+++ b/node/test/util/git_util.js
@@ -262,7 +262,7 @@ describe("GitUtil", function () {
         // done in terms of `git push`, though eventually it will be through
         // NodeGit.
 
-        function pusher(repoName, origin, local, remote, force) {
+        function pusher(repoName, origin, local, remote, force, quiet) {
             return co.wrap(function *(repos) {
                 force = force || false;
                 const result =
@@ -270,7 +270,8 @@ describe("GitUtil", function () {
                                        origin,
                                        local,
                                        remote,
-                                       force);
+                                       force,
+                                       quiet);
                 if (null !== result) {
                     throw new Error(result);
                 }
@@ -298,6 +299,11 @@ describe("GitUtil", function () {
                 input: "a=S|b=Ca:Bfoo=1",
                 expected: "a=S:Bfoo=1|b=Ca:Bfoo=1",
                 manipulator: pusher("b", "origin", "foo", "foo"),
+            },
+            "quiet push new branch": {
+                input: "a=S|b=Ca:Bfoo=1",
+                expected: "a=S:Bfoo=1|b=Ca:Bfoo=1",
+                manipulator: pusher("b", "origin", "foo", "foo", true),
             },
             "update a branch": {
                 input: "a=B|b=Ca:C2-1;Bmaster=2",

--- a/node/test/util/stopwatch.js
+++ b/node/test/util/stopwatch.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert = require("chai").assert;
+const co     = require("co");
+
+const Stopwatch = require("../../lib/util/stopwatch");
+
+function sleep(ms) {
+    return new Promise(callback => {
+        setTimeout(callback, ms);
+    });
+}
+
+describe("Stopwatch", function () {
+    // This is just a basic breathing test; TODO: something more extensive.
+
+    it("start running", function () {
+        const sw = new Stopwatch();
+        assert.equal(1, sw.startCount);
+        sw.start();
+        assert.equal(2, sw.startCount);
+        sw.stop();
+        assert.equal(1, sw.startCount);
+        sw.stop();
+        assert.equal(0, sw.startCount);
+    });
+
+    it("start paused", function () {
+        const sw = new Stopwatch(true);
+        assert.equal(0, sw.startCount);
+    });
+
+    it("with time and reset", co.wrap(function *() {
+        const time = 100;
+        const sw = new Stopwatch();
+        yield sleep(100);
+        assert(sw.elapsedMs >= time);
+        assert(sw.elapsed >= (time / 1000.0));
+        sw.reset(true);
+        assert.equal(0, sw.startCount);
+        assert.equal(0, sw.elapsedMs);
+        sw.reset();
+        assert.equal(1, sw.startCount);
+    }));
+});


### PR DESCRIPTION
Added utility to generate meta-repos and sub-repos. Improved efficiency of `write_repo_ast_util` and exposed some internals (adding tests for them) used by the generator. Also created a `Stopwatch` class for profiling (finding the ones available in NPM to be lacking).