### PR TITLE
Add the ability to open/close trees of submodules.

### DIFF
--- a/node/test/util/git_util.js
+++ b/node/test/util/git_util.js
@@ -30,12 +30,13 @@
  */
 "use strict";
 
-const assert = require("chai").assert;
-const co     = require("co");
-const fs     = require("fs-promise");
-const NodeGit   = require("nodegit");
-const os     = require("os");
-const path   = require("path");
+const assert  = require("chai").assert;
+const co      = require("co");
+const fs      = require("fs-promise");
+const mkdirp  = require("mkdirp");
+const NodeGit = require("nodegit");
+const os      = require("os");
+const path    = require("path");
 
 const GitUtil             = require("../../lib/util/git_util");
 const RepoAST             = require("../../lib/util/repo_ast");
@@ -655,6 +656,84 @@ describe("GitUtil", function () {
                     assert(true === cases[str].fail);
                 }
             });
+        });
+    });
+
+    describe("resolveRelativePath", function () {
+        // We don't need to test this exhaustively -- the hard work is done by
+        // `fs` and `path` -- just that we're calling the APIs correctly and
+        // throwing the right errors.
+
+        const cases = {
+            trivial: {
+                paths: ["a"],
+                workdir: "a",
+                cwd: "a",
+                filename: ".",
+                expected: "",
+            },
+            "outside": {
+                paths: ["a"],
+                workdir: "a",
+                cwd: "a",
+                filename: "/",
+                fails: true,
+            },
+            "invalid": {
+                paths: ["a"],
+                workdir: "a",
+                cwd: "a",
+                filename: "b",
+                fails: true,
+            },
+            "inside": {
+                paths: ["a/b/c"],
+                workdir: "a",
+                cwd: "a",
+                filename: "b",
+                expected: "b",
+            },
+            "inside with trail": {
+                paths: ["a/b/c"],
+                workdir: "a",
+                cwd: "a",
+                filename: "b/",
+                expected: "b",
+            },
+            "inside and up": {
+                paths: ["a/b/c", "a/b/d"],
+                workdir: "a",
+                cwd: "a/b/c",
+                filename: "../d",
+                expected: "b/d",
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                const tempDir = yield TestUtil.makeTempDir();
+                c.paths.map(filename => {
+                    const dir = path.join(tempDir, filename);
+                    mkdirp.sync(dir);
+                });
+                const workdir = path.join(tempDir, c.workdir);
+                const cwd = path.join(tempDir, c.cwd);
+                let result;
+                try {
+                    result = yield GitUtil.resolveRelativePath(workdir,
+                                                               cwd,
+                                                               c.filename);
+                }
+                catch (e) {
+                    if (!c.fails) {
+                        throw e;
+                    }
+                    assert.instanceOf(e, UserError);
+                    return;
+                }
+                assert(!c.fails, "should fail");
+                assert.equal(result, c.expected);
+            }));
         });
     });
 });

--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -485,5 +485,121 @@ describe("SubmoduleUtil", function () {
             }));
         });
     });
+    describe("getSubmodulesForPath", function () {
+        // We'll run this with 
+        const cases = {
+            "trivial": {
+                state: "x=S",
+                path: "",
+                expected: [],
+            },
+            "non sm": {
+                state: "x=S",
+                path: "README.md",
+                expected: [],
+            },
+            "non sm dir": {
+                state: "x=S:C2-1 a/b/c=2;Bmaster=2",
+                path: "a/b",
+                expected: [],
+            },
+            "all subs": {
+                state: "a=B|x=U",
+                path: "",
+                expected: ["s"],
+            },
+            "all subs, explicit": {
+                state: "a=B|x=U",
+                path: "s",
+                expected: ["s"],
+            },
+            "all subs, explicit and open": {
+                state: "a=B|x=U:Os",
+                path: "s",
+                expected: ["s"],
+            },
+            "all subs, explicit and excluded": {
+                state: "a=B|x=U",
+                path: "s/",
+                expected: [],
+            },
+            "multiple subs": {
+                state: "a=B|x=U:C3-2 t=Sa:1;Bmaster=3",
+                path: "",
+                expected: ["s","t"],
+            },
+            "deep sub": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1;Bmaster=2",
+                path: "",
+                expected: ["x/y/z"],
+            },
+            "deep sub, mid ref": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1;Bmaster=2",
+                path: "x",
+                expected: ["x/y/z"],
+            },
+            "deep sub, mid ref with slash": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1;Bmaster=2",
+                path: "x/",
+                expected: ["x/y/z"],
+            },
+            "deep sub, mid ref two prefix": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1;Bmaster=2",
+                path: "x/y",
+                expected: ["x/y/z"],
+            },
+            "deep sub, direct ref": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1;Bmaster=2",
+                path: "x/y/z",
+                expected: ["x/y/z"],
+            },
+            "multiple deeps": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1,a/b/c=Sa:1;Bmaster=2",
+                path: "",
+                expected: ["x/y/z", "a/b/c"],
+            },
+            "multiple deeps, one excluded": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1,a/b/c=Sa:1;Bmaster=2",
+                path: "a",
+                expected: ["a/b/c"],
+            },
+            "multiple deeps in same subdir": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1,x/q/c=Sa:1,x/r=1;Bmaster=2",
+                path: "",
+                expected: ["x/y/z", "x/q/c"],
+            },
+            "multiple deeps with both inc": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1,x/q/c=Sa:1,x/r=1;Bmaster=2",
+                path: "x",
+                expected: ["x/y/z", "x/q/c"],
+            },
+            "multiple deeps with one inc": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1,x/q/c=Sa:1,x/r=1;Bmaster=2",
+                path: "x/y",
+                expected: ["x/y/z"],
+            },
+            "multiple deeps both ex": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1,x/q/c=Sa:1,x/r=1;Bmaster=2",
+                path: "x/r",
+                expected: [],
+            },
+            "multiple deeps both ex above": {
+                state: "a=B|x=S:C2-1 x/y/z=Sa:1,x/q/c=Sa:1,x/r=1;Bmaster=2",
+                path: "README.md",
+                expected: [],
+            }
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                const written =
+                               yield RepoASTTestUtil.createMultiRepos(c.state);
+                const x = written.repos.x;
+                const result = yield SubmoduleUtil.getSubmodulesInPath(x,
+                                                                       c.path);
+                assert.deepEqual(result.sort(), c.expected.sort());
+            }));
+        });
+    });
 });
 


### PR DESCRIPTION
Now, with `open` and `close`, each "path" argument is interpreted to apply to
all submodules found within this path (this also fixes the trailing "/"
problem).  We will appy this to other meta operations as relevant.

Addresses https://github.com/twosigma/git-meta/issues/4 and https://github.com/twosigma/git-meta/issues/95