### PR TITLE
support for prompting for commit message

### DIFF
--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -40,7 +40,6 @@ const NodeGit = require("nodegit");
 
 const RepoStatus    = require("./repo_status");
 const SubmoduleUtil = require("./submodule_util");
-const Status        = require("./status");
 
 /**
  * Commit changes in the specified `repo`.  If the specified `doAll` is true,
@@ -115,17 +114,18 @@ const commitRepo = co.wrap(function *(repo,
  * @async
  * @param {NodeGit.Repository} metaRepo
  * @param {Boolean}            all
+ * @param {RepoStatus}         metaStatus
  * @param {String}             message
  * @return {Object|null}
  * @return {String} return.metaCommit
  * @return {Object} submoduleCommits map from submodule name to new commit
  */
-exports.commit = co.wrap(function *(metaRepo, all, message) {
+exports.commit = co.wrap(function *(metaRepo, all, metaStatus, message) {
     assert.instanceOf(metaRepo, NodeGit.Repository);
     assert.isBoolean(all);
+    assert.instanceOf(metaStatus, RepoStatus);
     assert.isString(message);
 
-    const metaStatus = yield Status.getRepoStatus(metaRepo);
     const submodules = metaStatus.submodules;
 
     // Commit submodules.  If any changes, remember this so we know to generate

--- a/node/lib/util/status.js
+++ b/node/lib/util/status.js
@@ -69,7 +69,7 @@ exports.printFileStatuses = function (repoStatus) {
                 return "type changed: ";
         }
     }
-    const innerIndent = "        ";
+    const innerIndent = "\t";
 
     // Print status of staged files first.
 

--- a/node/test/util/commit.js
+++ b/node/test/util/commit.js
@@ -34,6 +34,7 @@ const co     = require("co");
 
 const Commit          = require("../../lib/util/commit");
 const RepoASTTestUtil = require("../../lib/util/repo_ast_test_util");
+const Status          = require("../../lib/util/status");
 
 
 // We'll always commit the repo named 'x'.  If a new commit is created ni the
@@ -42,7 +43,8 @@ const RepoASTTestUtil = require("../../lib/util/repo_ast_test_util");
 
 const committer = co.wrap(function *(doAll, message, repos) {
     const x = repos.x;
-    const result = yield Commit.commit(x, doAll, message);
+    const status = yield Status.getRepoStatus(x);
+    const result = yield Commit.commit(x, doAll, status, message);
     if (null === result) {
         return undefined;                                             // RETURN
     }


### PR DESCRIPTION
When "-m" is not specified, `git-meta commit` will now open the configured
editor and allow the user to edit the message.  I had to extend and tweak the
status logic because previously, we were relying on the result of
`Commit.commit` to determine (and warn) if no changes were available.  Now we
have to check ourselves before we (potentially) bring up the editor.