### PR TITLE
Fix when onto commits have submodule change.

### DIFF
--- a/node/test/util/rebase_util.js
+++ b/node/test/util/rebase_util.js
@@ -233,6 +233,14 @@ Bmaster=31;Bfoo=41;Bold=31",
                 expected: "\
 x=E:C3M-41 q=Sq:1;C31M-3M q=Sr:1;Bmaster=31M",
             },
+            "open sub ffwd'd": {
+                initial: `
+a=B:CX-1;Bmaster=X|
+x=U:C3-2 a=b;C4-2 s=Sa:X;Bmaster=3;Bfoo=4;Bold=3;Os`,
+                rebaser: rebaser("x", "4"),
+                expected: `
+x=E:C3M-4 a=b;Bmaster=3M;Os H=X`,
+            },
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];


### PR DESCRIPTION
If the commits being rebased onto have changes to an open submodule, at the end
of a rebase operation we were leaving the HEAD of such submodules on the wrong
commit.  This situation would have left those submodules in a bad state, but it
also caused the rebase commit generation to fail.

Fixes: https://github.com/twosigma/git-meta/issues/172