### PR TITLE
Status rework

### DIFF
--- a/node/lib/cmd/add.js
+++ b/node/lib/cmd/add.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2017, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const co = require("co");
+
+/**
+ * This module contains methods for implementing the `add` command.
+ */
+
+/**
+ * help text for the `add` command
+ * @property {String}
+ */
+exports.helpText = `Add file contents to the index of the mono-repo.`;
+
+/**
+ * description of the `add` command
+ * @property {String}
+ */
+exports.description =`
+This command updates the (logical) mono-repo index using the current content
+found in the working tree, to prepare the content staged for the next commit.
+If a path is specified, this command will stage all modified content in the
+meta-repo and submodules rooted in that path.  Note that the index of a
+mono-repo is a logical construct derived from the state of the indices of its
+meta-repo and open submodules.  Thus, content that is staged in a submodule
+is added to the index for that submodule; the index of the meta-repo is not
+affected.  Note also that from the perspective of the mono-repo, the status of
+a submodule in the index is irrelevant: 'git meta commit' always stages changes
+to submodules with new commits in their working directories.
+`;
+
+exports.configureParser = function (parser) {
+    parser.addArgument(["--meta"], {
+        required: false,
+        action: "storeConst",
+        constant: true,
+        help: `
+Include changes to the meta-repo; disabled by default to improve performance \
+and avoid accidental changes to the meta-repo.`,
+        defaultValue: false,
+    });
+    parser.addArgument(["paths"], {
+        nargs: "+",
+        type: "string",
+        help: "the paths to add",
+    });
+};
+
+/**
+ * Execute the `add` command according to the specified `args`.
+ *
+ * @async
+ * @param {Object}   args
+ * @param {String[]} args.paths
+ */
+exports.executeableSubcommand = co.wrap(function *(args) {
+    const Add     = require("../util/add");
+    const GitUtil = require("../util/git_util");
+
+    const repo    = yield GitUtil.getCurrentRepo();
+    const workdir = repo.workdir();
+    const cwd     = process.cwd();
+
+    const paths = yield args.paths.map(filename => {
+        return  GitUtil.resolveRelativePath(workdir, cwd, filename);
+    });
+    yield Add.stagePaths(repo, paths, args.meta);
+});

--- a/node/lib/cmd/close.js
+++ b/node/lib/cmd/close.js
@@ -90,6 +90,7 @@ exports.executeableSubcommand = co.wrap(function *(args) {
 
     const workdir = repo.workdir();
     const cwd     = process.cwd();
+    const subs    = yield SubmoduleUtil.getSubmoduleNames(repo);
 
     // This logic is copy and pasted from `open`, but I'm not convinced yet
     // that it should be refactored; I feel like close/open specific logic may
@@ -111,7 +112,9 @@ exports.executeableSubcommand = co.wrap(function *(args) {
             }
             throw e;
         }
-        const result = yield SubmoduleUtil.getSubmodulesInPath(repo, relPath);
+        const result = yield SubmoduleUtil.getSubmodulesInPath(workdir,
+                                                               relPath,
+                                                               subs);
         if (0 === result.length) {
             console.warn(`\
 No submodules found from ${colors.orange(filename)}.`);
@@ -140,7 +143,7 @@ No submodules found from ${colors.orange(filename)}.`);
                                    0 !== Object.keys(subRepo.workdir).length) {
                 errorMessage += `\
 Could not close ${colors.cyan(name)} because it is not clean:
-${Status.printFileStatuses(subRepo)}.
+${Status.printFileStatuses(subRepo.staged, subRepo.workdir)}.
 Pass ${colors.magenta("--force")} to close it anyway.
 `;
                 return;                                               // RETURN

--- a/node/lib/cmd/open.js
+++ b/node/lib/cmd/open.js
@@ -88,6 +88,7 @@ exports.executeableSubcommand = co.wrap(function *(args) {
     const repo    = yield GitUtil.getCurrentRepo();
     const workdir = repo.workdir();
     const cwd     = process.cwd();
+    const subs = yield SubmoduleUtil.getSubmoduleNames(repo);
 
     const subLists = yield args.path.map(co.wrap(function *(filename) {
         // Compute the relative path for `filename` from the root of the repo,
@@ -105,7 +106,9 @@ exports.executeableSubcommand = co.wrap(function *(args) {
             }
             throw e;
         }
-        const result = yield SubmoduleUtil.getSubmodulesInPath(repo, relPath);
+        const result = yield SubmoduleUtil.getSubmodulesInPath(workdir,
+                                                               relPath,
+                                                               subs);
         if (0 === result.length) {
             console.warn(`\
 No submodules found from ${colors.orange(filename)}.`);

--- a/node/lib/git-meta.js
+++ b/node/lib/git-meta.js
@@ -37,6 +37,7 @@
 
 const ArgumentParser = require("argparse").ArgumentParser;
 
+const add        = require("./cmd/add");
 const checkout   = require("./cmd/checkout");
 const cherryPick = require("./cmd/cherrypick");
 const close      = require("./cmd/close");
@@ -106,6 +107,7 @@ const parser = new ArgumentParser({
 
 const subParser = parser.addSubparsers({});
 
+configureSubcommand(subParser, "add", add);
 configureSubcommand(subParser, "checkout", checkout);
 configureSubcommand(subParser, "cherry-pick", cherryPick);
 configureSubcommand(subParser, "close", close);

--- a/node/lib/git-meta.js
+++ b/node/lib/git-meta.js
@@ -49,6 +49,7 @@ const pull       = require("./cmd/pull");
 const push       = require("./cmd/push");
 const rebase     = require("./cmd/rebase");
 const reset      = require("./cmd/reset");
+const submodule  = require("./cmd/submodule");
 const status     = require("./cmd/status");
 const UserError  = require("./util/user_error");
 const version    = require("./cmd/version");
@@ -117,6 +118,7 @@ configureSubcommand(subParser, "pull", pull);
 configureSubcommand(subParser, "push", push);
 configureSubcommand(subParser, "rebase", rebase);
 configureSubcommand(subParser, "reset", reset);
+configureSubcommand(subParser, "submodule", submodule);
 configureSubcommand(subParser, "status", status);
 configureSubcommand(subParser, "version", version);
 

--- a/node/lib/util/add.js
+++ b/node/lib/util/add.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert    = require("chai").assert;
+const co        = require("co");
+const NodeGit   = require("nodegit");
+
+const Status        = require("./status");
+const SubmoduleUtil = require("./submodule_util");
+
+/**
+ * Stage modified content at the specified `paths` in the specified `repo`.  If
+ * a path in `paths` refers to a file, stage it; if it refers to  a directory,
+ * stage all modified content rooted at that path, including that in open
+ * submodules.  Note that a path of "" is taken to indicate the entire
+ * repository.  The behavior is undefined unless every path in `paths` is a
+ * valid relative path in `repo.workdir()`.
+ *
+ * @async
+ * @param {NodeGit.Repository} repo
+ * @param {String []}          paths
+ */
+exports.stagePaths = co.wrap(function *(repo, paths, stageMetaChanges) {
+    assert.instanceOf(repo, NodeGit.Repository);
+    assert.isArray(paths);
+    assert.isBoolean(stageMetaChanges);
+
+    const repoStatus = yield Status.getRepoStatus(repo, {
+        showMetaChanges: stageMetaChanges,
+        includeClosedSubmodules: false,
+        paths: paths,
+        showAllUntracked: true,
+    });
+
+    // First, stage submodules.
+
+    const subs = repoStatus.submodules;
+    yield Object.keys(subs).map(co.wrap(function *(name) {
+        const subStat = subs[name];
+        const subRepo = yield SubmoduleUtil.getRepo(repo, name);
+        const workdir = subStat.repoStatus.workdir;
+        const index = yield subRepo.index();
+        yield Object.keys(workdir).map(filename => index.addByPath(filename));
+        yield index.write();
+    }));
+
+    // Then meta changes.
+
+    const toAdd = Object.keys(repoStatus.workdir);
+    if (0 !== toAdd.length) {
+        const index = yield repo.index();
+        yield toAdd.map(filename => index.addByPath(filename));
+        yield index.write();
+    }
+});

--- a/node/lib/util/submodule_util.js
+++ b/node/lib/util/submodule_util.js
@@ -372,21 +372,21 @@ exports.getSubmodulesForCommit = co.wrap(function *(repo, commit) {
  *
  * @param {NodeGit.Repository} repo
  * @param {String}             dir
+ * @param {String []}          indexSubNames
  * @return {String[]}
  */
-exports.getSubmodulesInPath = co.wrap(function *(repo, dir) {
-    assert.instanceOf(repo, NodeGit.Repository);
+exports.getSubmodulesInPath = co.wrap(function *(workdir, dir, indexSubNames) {
+    assert.isString(workdir);
     assert.isString(dir);
+    assert.isArray(indexSubNames);
     if ("" !== dir) {
         assert.notEqual("/", dir[0]);
         assert.notEqual(".", dir[0]);
     }
-    const subNames = yield exports.getSubmoduleNames(repo);
     if ("" === dir) {
-        return subNames;
+        return indexSubNames;
     }
-    const subs = new Set(subNames);
-    const workdir = repo.workdir();
+    const subs = new Set(indexSubNames);
     const result = [];
     const listForFilename = co.wrap(function *(filepath) {
         if (subs.has(filepath)) {

--- a/node/test/util/add.js
+++ b/node/test/util/add.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2017, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const co = require("co");
+
+const Add             = require("../../lib/util/add");
+const RepoASTTestUtil = require("../../lib/util/repo_ast_test_util");
+
+describe("add", function () {
+    describe("stagePaths", function () {
+        const cases = {
+            "trivial": {
+                initial: "x=S",
+                paths: [],
+            },
+            "nothing to add": {
+                initial: "x=S",
+                paths: [""],
+            },
+            "missed modified file": {
+                initial: "x=S:I x/y/z=foo;W x/q/z=bar",
+                paths: ["x/y"],
+            },
+            "simple mod": {
+                initial: "x=S:W README.md=foo",
+                paths: ["README.md"],
+                expected: "x=S:I README.md=foo",
+            },
+            "deep from root": {
+                initial: "x=S:W x/y/z=meh",
+                paths: [""],
+                expected: "x=S:I x/y/z=meh",
+            },
+            "multiple from root": {
+                initial: "x=S:W x/y/z=meh,x/a/c=foo",
+                paths: [""],
+                expected: "x=S:I x/y/z=meh,x/a/c=foo",
+            },
+            "multiple from root dir": {
+                initial: "x=S:W x/y/z=meh,x/a/c=foo",
+                paths: ["x"],
+                expected: "x=S:I x/y/z=meh,x/a/c=foo",
+            },
+            "single from root": {
+                initial: "x=S:W x/y/z=meh,x/a/c=foo",
+                paths: ["x/y"],
+                expected: "x=S:I x/y/z=meh;W x/a/c=foo",
+            },
+            "single from root, direct": {
+                initial: "x=S:W x/y/z=meh,x/a/c=foo",
+                paths: ["x/y/z"],
+                expected: "x=S:I x/y/z=meh;W x/a/c=foo",
+            },
+            "multiple from sub dirs": {
+                initial: "x=S:W x/y/z=meh,x/a/c=foo",
+                paths: ["x/y", "x/a"],
+                expected: "x=S:I x/y/z=meh,x/a/c=foo",
+            },
+            "sub included by root": {
+                initial: "a=B|x=U:Os W README.md=foo",
+                paths: [""],
+                expected: "x=E:Os I README.md=foo",
+            },
+            "sub direct": {
+                initial: "a=B|x=U:Os W README.md=foo",
+                paths: ["s"],
+                expected: "x=E:Os I README.md=foo",
+            },
+            "sub included in path": {
+                initial: `
+a=B|x=S:C2-1 x/y/z=Sa:1;W x/r/z=foo;Ox/y/z W m/r=z;Bmaster=2`,
+                paths: ["x"],
+                expected: `
+x=E:I x/r/z=foo;W x/r/z=~;Ox/y/z I m/r=z`,
+            },
+            "multiple in sub": {
+                initial: "a=B|x=U:Os W README.md=foo,q/r=z",
+                paths: ["s"],
+                expected: "x=E:Os I README.md=foo,q/r=z",
+            },
+            "direct in sub": {
+                initial: "a=B|x=U:Os W README.md=foo",
+                paths: ["s/README.md"],
+                expected: "x=E:Os I README.md=foo",
+            },
+            "directory in nested sub": {
+                initial: `
+a=B|x=S:C2-1 a/b=Sa:1;Oa/b W x/y/z=a,x/r/z=b;Bmaster=2`,
+                paths: ["a/b/x"],
+                expected: `x=E:Oa/b I x/y/z=a,x/r/z=b`,
+            },
+            "multiple paths in nested sub": {
+                initial: `
+a=B|x=S:C2-1 a/b=Sa:1;Oa/b W x/y/z=a,x/r/z=b;Bmaster=2`,
+                paths: ["a/b/x/y", "a/b/x/r"],
+                expected: `x=E:Oa/b I x/y/z=a,x/r/z=b`,
+            },
+            "skip meta": {
+                initial: "x=S:W README.md=xxxxxx",
+                paths: [],
+                stageMeta: false,
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                let stageMeta = c.stageMeta;
+                if (undefined === stageMeta) {
+                    stageMeta = true;
+                }
+                const doAdd = co.wrap(function *(repos) {
+                    const repo = repos.x;
+                    yield Add.stagePaths(repo, c.paths, stageMeta);
+                });
+                yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,
+                                                               c.expected,
+                                                               doAdd,
+                                                               c.fails);
+            }));
+        });
+    });
+});

--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -595,8 +595,11 @@ describe("SubmoduleUtil", function () {
                 const written =
                                yield RepoASTTestUtil.createMultiRepos(c.state);
                 const x = written.repos.x;
-                const result = yield SubmoduleUtil.getSubmodulesInPath(x,
-                                                                       c.path);
+                const subs = yield SubmoduleUtil.getSubmoduleNames(x);
+                const result = yield SubmoduleUtil.getSubmodulesInPath(
+                                                                   x.workdir(),
+                                                                   c.path,
+                                                                   subs);
                 assert.deepEqual(result.sort(), c.expected.sort());
             }));
         });


### PR DESCRIPTION
This change reflects the move towards better support for the mono-repo.  `status` now supports path (and relative path) specification, and `add` is implemented in terms of it. New assumptions provide much more efficient operations with large repositories, and provide the way forward for a path-based `git-meta commit` and `git-meta reset`.

A lot more to do, but wanted to get review started on what's done so far.

addresses https://github.com/twosigma/git-meta/issues/175
