### PR TITLE
Read template path outside of open/submodule init.

### DIFF
--- a/node/lib/cmd/close.js
+++ b/node/lib/cmd/close.js
@@ -130,7 +130,6 @@ No submodules found from ${colors.yellow(filename)}.`);
         const sub = subStats[name];
         const subRepo = sub.repoStatus;
         if (null === subRepo) {
-            errorMessage += `${colors.cyan(name)} is not open.\n`;
             return;                                                   // RETURN
         }
 
@@ -143,7 +142,7 @@ No submodules found from ${colors.yellow(filename)}.`);
                                    0 !== Object.keys(subRepo.workdir).length) {
                 errorMessage += `\
 Could not close ${colors.cyan(name)} because it is not clean:
-${Status.printFileStatuses(subRepo.staged, subRepo.workdir)}.
+${Status.printRepoStatus(subRepo, "")}.
 Pass ${colors.magenta("--force")} to close it anyway.
 `;
                 return;                                               // RETURN

--- a/node/lib/cmd/submodule.js
+++ b/node/lib/cmd/submodule.js
@@ -154,12 +154,13 @@ const doStatusCommand = co.wrap(function *(paths, verbose) {
 const doFindCommand = co.wrap(function *(path, metaCommittish, subCommittish) {
     const colors = require("colors");
 
-    const GitUtil          = require("../util/git_util");
-    const LogUtil          = require("../util/log_util");
-    const Open             = require("../util/open");
-    const SubmoduleFetcher = require("../util/submodule_fetcher");
-    const SubmoduleUtil    = require("../util/submodule_util");
-    const UserError        = require("../util/user_error");
+    const GitUtil             = require("../util/git_util");
+    const LogUtil             = require("../util/log_util");
+    const Open                = require("../util/open");
+    const SubmoduleConfigUtil = require("../util/submodule_config_util");
+    const SubmoduleFetcher    = require("../util/submodule_fetcher");
+    const SubmoduleUtil       = require("../util/submodule_util");
+    const UserError           = require("../util/user_error");
 
     // We need to resolve and validate the committishes and submodule path
     // before calling `findMetaCommit` to do the real work.
@@ -215,7 +216,11 @@ Could not find ${colors.red(metaCommittish)} in the meta-repo.`);
                                                                    [subName],
                                                                    head);
         const subSha = shas[subName];
-        subRepo = yield Open.openOnCommit(fetcher, subName, subSha);
+        const templatePath = yield SubmoduleConfigUtil.getTemplatePath(repo);
+        subRepo = yield Open.openOnCommit(fetcher,
+                                          subName,
+                                          subSha,
+                                          templatePath);
     }
     else {
         subRepo = yield SubmoduleUtil.getRepo(repo, subName);

--- a/node/lib/util/cherrypick.js
+++ b/node/lib/util/cherrypick.js
@@ -36,6 +36,7 @@ const colors  = require("colors");
 const NodeGit = require("nodegit");
 
 const Open                = require("../util/open");
+const SubmoduleConfigUtil = require("../util/submodule_config_util");
 const SubmoduleFetcher    = require("./submodule_fetcher");
 const SubmoduleUtil       = require("../util/submodule_util");
 const UserError           = require("../util/user_error");
@@ -93,6 +94,7 @@ exports.cherryPick = co.wrap(function *(metaRepo, commit) {
 
     let submoduleCommits = {};
     const subFetcher = new SubmoduleFetcher(metaRepo, commit);
+    const templatePath = yield SubmoduleConfigUtil.getTemplatePath(metaRepo);
 
     const picker = co.wrap(function *(subName, headSha, commitSha) {
         let commitMap = {};
@@ -105,7 +107,8 @@ exports.cherryPick = co.wrap(function *(metaRepo, commit) {
             console.log(`Opening ${colors.blue(subName)}.`);
             repo = yield Open.openOnCommit(subFetcher,
                                            subName,
-                                           headSubs[subName].sha);
+                                           headSubs[subName].sha,
+                                           templatePath);
         }
         else {
             repo = yield SubmoduleUtil.getRepo(metaRepo, subName);

--- a/node/lib/util/merge.js
+++ b/node/lib/util/merge.js
@@ -35,13 +35,14 @@ const co      = require("co");
 const colors  = require("colors");
 const NodeGit = require("nodegit");
 
-const GitUtil          = require("./git_util");
-const Open             = require("./open");
-const RepoStatus       = require("./repo_status");
-const Status           = require("./status");
-const SubmoduleFetcher = require("./submodule_fetcher");
-const SubmoduleUtil    = require("./submodule_util");
-const UserError        = require("./user_error");
+const GitUtil             = require("./git_util");
+const Open                = require("./open");
+const RepoStatus          = require("./repo_status");
+const Status              = require("./status");
+const SubmoduleConfigUtil = require("../util/submodule_config_util");
+const SubmoduleFetcher    = require("./submodule_fetcher");
+const SubmoduleUtil       = require("./submodule_util");
+const UserError           = require("./user_error");
 
 /**
  * @enum {MODE}
@@ -160,6 +161,7 @@ ${colors.red(commitSha)}.`);
     const subs = metaRepoStatus.submodules;
 
     const subFetcher = new SubmoduleFetcher(metaRepo, commit);
+    const templatePath = yield SubmoduleConfigUtil.getTemplatePath(metaRepo);
 
     const mergeEntry = co.wrap(function *(entry) {
         const path = entry.path;
@@ -199,7 +201,10 @@ ${colors.red(commitSha)}.`);
             // If this submodule's not open, open it.
 
             console.log(`Opening ${colors.blue(path)}.`);
-            subRepo = yield Open.openOnCommit(subFetcher, path, subHeadSha);
+            subRepo = yield Open.openOnCommit(subFetcher,
+                                              path,
+                                              subHeadSha,
+                                              templatePath);
             subRepoStatus = yield Status.getRepoStatus(subRepo);
         }
         else {

--- a/node/lib/util/open.js
+++ b/node/lib/util/open.js
@@ -44,18 +44,26 @@ const SubmoduleFetcher    = require("./submodule_fetcher");
  * Open the submodule having the specified `submoduleName` in the meta-repo
  * associated with the specified `fetcher`; fetch the specified `submoduleSha`
  * using `fetcher` and set HEAD to point to it.  Configure the "origin" remote
- * to the `url` configured in the meta-repo.
+ * to the `url` configured in the meta-repo.  If the specified `templatePath`
+ * is provided, use it to configure the newly-opened submodule's repository.
  *
  * @async
  * @param {SubmoduleFetcher} fetcher
  * @param {String}           submoduleName
  * @param {String}           submoduleSha
+ * @param {String|null}      templatePath
  * @return {NodeGit.Repository}
  */
 exports.openOnCommit = co.wrap(function *(fetcher,
                                           submoduleName,
-                                          submoduleSha) {
+                                          submoduleSha,
+                                          templatePath) {
     assert.instanceOf(fetcher, SubmoduleFetcher);
+    assert.isString(submoduleName);
+    assert.isString(submoduleSha);
+    if (null !== templatePath) {
+        assert.isString(templatePath);
+    }
 
     const metaRepoUrl = yield fetcher.getMetaOriginUrl();
     const metaRepo = fetcher.repo;
@@ -67,7 +75,8 @@ exports.openOnCommit = co.wrap(function *(fetcher,
                                                                 metaRepoUrl,
                                                                 metaRepo,
                                                                 submoduleName,
-                                                                submoduleUrl);
+                                                                submoduleUrl,
+                                                                templatePath);
 
     // Fetch the needed sha.  Close if the fetch fails; otherwise, the
     // repository ends up in a state where it things the submodule is open, but

--- a/node/lib/util/rebase_util.js
+++ b/node/lib/util/rebase_util.js
@@ -328,6 +328,8 @@ const driveRebase = co.wrap(function *(metaRepo,
     let fetcher;          // Set to a SubmoduleFetcher bound to currentCommit
     let shas;             // submodule shas for current commit
 
+    const templatePath = yield SubmoduleConfigUtil.getTemplatePath(metaRepo);
+
     /**
      * Return the submodule rebaser for the specified `path`, or null if
      * `path` does not correspond to a submodule.  Open the subodule if it is
@@ -355,7 +357,10 @@ const driveRebase = co.wrap(function *(metaRepo,
             }
             else { 
                 console.log(`Submodule ${colors.blue(path)}: opening`);
-                repo = yield Open.openOnCommit(fetcher, path, submodule.sha);
+                repo = yield Open.openOnCommit(fetcher,
+                                               path,
+                                               submodule.sha,
+                                               templatePath);
             }
             return new SubmoduleRebaser(path,
                                         repo,

--- a/node/lib/util/submodule_config_util.js
+++ b/node/lib/util/submodule_config_util.js
@@ -299,13 +299,34 @@ exports.initSubmodule = co.wrap(function *(repoPath, name, url) {
 });
 
 /**
+ * Return the configured template path, from which to copy files into
+ * newly-opened submodules, for the specified `repo`, or null if no such path
+ * is configured.
+ *
+ * @async
+ * @param {NodeGit.Repository} templatePath
+ * @return {String | null}
+ */
+exports.getTemplatePath = co.wrap(function *(repo) {
+    const config = yield repo.config();
+    try {
+        return yield config.getString("meta.submoduleTemplatePath");
+    }
+    catch (e) {
+        return null;
+    }
+});
+
+/**
  * Open the submodule having the specified `name` and `url` for the `metaRepo`.
  * Configure the repository for this submodule to have `url` as its remote,
  * unless `url` is relative, in which case resolve `url` against the specified
  * `repoUrl`.  Throw a `UserError` if `null === repoUrl` and `url` is relative.
  * Return the newly opened repository.  Note that this command does not fetch
  * any refs from the remote for this submodule, and while its repo can be
- * opened it will be empty.
+ * opened it will be empty.  If the specified `templatePath` is provided,
+ * use it as a template from which to copy files in to the `.git` directory of
+ * the newly-opened repo.
  *
  * This method is largely needed to workaround deficiences in
  * `NodeGit.Submodule`, for example, it cannot be used to initialize a repo
@@ -316,18 +337,23 @@ exports.initSubmodule = co.wrap(function *(repoPath, name, url) {
  * @param {NodeGit.Repository} metaRepo
  * @param {String}             name
  * @param {String}             url
+ * @param {String|null}        templatePath
  * @return {NodeGit.Repository}
  */
 exports.initSubmoduleAndRepo = co.wrap(function *(repoUrl,
                                                   metaRepo,
                                                   name,
-                                                  url) {
+                                                  url,
+                                                  templatePath) {
     if (null !== repoUrl) {
         assert.isString(repoUrl);
     }
     assert.instanceOf(metaRepo, NodeGit.Repository);
     assert.isString(name);
     assert.isString(url);
+    if (null !== templatePath) {
+        assert.isString(templatePath);
+    }
 
     // Update the `.git/config` file.
 
@@ -338,19 +364,6 @@ exports.initSubmoduleAndRepo = co.wrap(function *(repoUrl,
     // flags so that it will set it up as a git link.
 
     const subRepoDir = path.join(repoPath, ".git", "modules", name);
-
-    // If there is a `submodule_template` directory in the git folder, copy its
-    // contents into the new `.git` directory for this submodule.
-
-    // Try to get configuration entry for template path.
-
-    const config = yield metaRepo.config();
-    let templatePath = null;
-    try {
-        templatePath = yield config.getString("meta.submoduleTemplatePath");
-    }
-    catch (e) {
-    }
 
     const FLAGS = NodeGit.Repository.INIT_FLAG;
 

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -839,7 +839,8 @@ git -C '${repo.path()}' -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
                                                                 originUrl,
                                                                 repo,
                                                                 subName,
-                                                                sub.url);
+                                                                sub.url,
+                                                                null);
             // Pull in commits from the commits repo, but remove the remote
             // when done.
 

--- a/node/test/util/open.js
+++ b/node/test/util/open.js
@@ -40,6 +40,8 @@ const SubmoduleFetcher = require("../../lib/util/submodule_fetcher");
 
 describe("openOnCommit", function () {
     // Assumption is that 'x' is the target repo.
+    // TODO: test for template path usage.  We're just passing it through but
+    // should verify that.
 
     const cases = {
         "simple": {
@@ -72,7 +74,8 @@ describe("openOnCommit", function () {
                 const fetcher = new SubmoduleFetcher(x, head);
                 const result = yield Open.openOnCommit(fetcher,
                                                        c.subName,
-                                                       commit);
+                                                       commit,
+                                                       null);
                 assert.instanceOf(result, NodeGit.Repository);
             });
             yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,

--- a/node/test/util/submodule_config_util.js
+++ b/node/test/util/submodule_config_util.js
@@ -413,6 +413,21 @@ foo
         }));
     });
 
+    describe("getTemplatePath", function () {
+        it("no path", co.wrap(function *() {
+            const repo = yield TestUtil.createSimpleRepository();
+            const result = yield SubmoduleConfigUtil.getTemplatePath(repo);
+            assert.isNull(result);
+        }));
+        it("a path", co.wrap(function *() {
+            const repo = yield TestUtil.createSimpleRepository();
+            const config = yield repo.config();
+            yield config.setString("meta.submoduleTemplatePath", "foo");
+            const result = yield SubmoduleConfigUtil.getTemplatePath(repo);
+            assert.equal(result, "foo");
+        }));
+    });
+
     describe("initSubmoduleAndRepo", function () {
 
         const runTest = co.wrap(function *(repo,
@@ -447,7 +462,8 @@ foo
                                                                      originUrl,
                                                                      repo,
                                                                      subName,
-                                                                     url);
+                                                                     url,
+                                                                     null);
             assert.instanceOf(result, NodeGit.Repository);
             assert(TestUtil.isSameRealPath(result.workdir(),
                                            path.join(repoPath, subName)));
@@ -505,8 +521,6 @@ foo
         it("with template", co.wrap(function *() {
             const templateDir = yield TestUtil.makeTempDir();
             const repo        = yield TestUtil.createSimpleRepository();
-            const config = yield repo.config();
-            yield config.setString("meta.submoduleTemplatePath", templateDir);
             const subDir = "bar";
             const subPath = path.join(templateDir, subDir);
             yield fs.mkdir(subPath);
@@ -545,7 +559,8 @@ foo
             yield SubmoduleConfigUtil.initSubmoduleAndRepo(url,
                                                            repo,
                                                            "foo",
-                                                           url);
+                                                           url,
+                                                           templateDir);
 
             const copiedPath = path.join(repo.path(),
                                          "modules",


### PR DESCRIPTION
Previously, we were reading the meta-repo's config file for its submodule
template path deep in `SubmoduleConfigUtil`.  This method was inefficient, and
tripped a bug in libgit2 (or nodegit) where reading the config file in parallel
seems to cause crashing.

(Also addressed a small bug formatting the status of a closed but dirty repo)

Addresses: https://github.com/twosigma/git-meta/issues/196