### PR TITLE
Fix timing bug with checkout.

### DIFF
--- a/node/lib/util/checkout.js
+++ b/node/lib/util/checkout.js
@@ -115,10 +115,10 @@ exports.checkout = co.wrap(function *(metaRepo, committish) {
         }
 
         const repo = yield SubmoduleUtil.getRepo(metaRepo, name);
-        subRepos.push(repo);
         const sha = shas[name];
         yield subFetcher.fetchSha(repo, name, sha);
         const commit = yield repo.getCommit(sha);
+        subRepos.push(repo);
         subCommits.push(commit);
         const error = yield dryRun(repo, commit);
         if (null !== error) {


### PR DESCRIPTION
During the checkout dry run, I populate an array of submodule repos and an
array of submodule commits to be checked out later if the dry run succeeds.
These arrays need to be matched so that the Nth element of the array of repos
will be checked out at the Nth commit.

Unfortunately, there were two `yield` statements in between adding to the end
of the array of repos and adding to the array of commits, such that the
ordering could have gotten off if, for example, a repo required a lengthy
fetch.

This change makes it so that the pushes to both array happen with no
intervening `yield` statements.