### PR TITLE
Fix rebase continue with untouched submodules.

### DIFF
--- a/node/lib/util/rebase_util.js
+++ b/node/lib/util/rebase_util.js
@@ -55,8 +55,7 @@ const UserError           = require("./user_error");
  * @return {String}
  */
 function submoduleConflictMessage(name) {
-    return `
-Conflict rebasing the submodule ${colors.red(name)}.`;
+    return `Conflict rebasing the submodule ${colors.red(name)}.`;
 }
 
 /**
@@ -240,9 +239,22 @@ rebase.`);
         return yield next(commitSha);
     });
 
+    /**
+     * Continue rebasing for this submodule from the specified `curSha` using
+     * the specified rebase `index` position.  Return false if the rebase
+     * cannot be continued and true otherwise.
+     *
+     * @param {String} curSha
+     * @param {Number} index
+     * @return {Boolean}
+     */
     const continueRebase = co.wrap(function *(curSha, index) {
+        // If the submodule is not rebasing, stage any commits it might have
+        // and return successfully.
+
         if (!repo.isRebasing()) {
-            return;                                                   // RETURN
+            yield index.addByPath(submoduleName);
+            return true;                                              // RETURN
         }
         const subInfo = yield RebaseFileUtil.readRebase(repo.path());
         console.log(`Submodule ${colors.blue(submoduleName)} continuing \

--- a/node/test/util/rebase_util.js
+++ b/node/test/util/rebase_util.js
@@ -319,6 +319,29 @@ x=U:C3-2 s=Sa:q;C4-2 s=Sa:r;
                 expected: `
 x=E:E;C3M-4 s=Sa:qs;Bmaster=3M;Os Cqs-r q=q!H=qs!E`
             },
+            "with rebase in submodule, staged commit in another submodule": {
+                initial: `
+a=B:Cq-1;Cr-1;Cs-q;Bmaster=q;Bfoo=r;Bbar=s|
+x=S:C2-1 s=Sa:1,t=Sa:1;C3-2 s=Sa:q,t=Sa:s;C4-2 s=Sa:r,t=Sa:q;
+    Bmaster=3;Bfoo=4;Bold=3;
+    Erefs/heads/master,3,4;
+    Os EHEAD,q,r!I q=q;
+    Ot H=s;
+    I t=Sa:s`,
+                expected: `
+x=E:E;C3M-4 s=Sa:qs,t=Sa:s;Bmaster=3M;Os Cqs-r q=q!H=qs!E;I t=~;Ot`
+            },
+            "with rebase in submodule, workdir commit in another submodule": {
+                initial: `
+a=B:Cq-1;Cr-1;Cs-q;Bmaster=q;Bfoo=r;Bbar=s|
+x=S:C2-1 s=Sa:1,t=Sa:1;C3-2 s=Sa:q,t=Sa:s;C4-2 s=Sa:r,t=Sa:q;
+    Bmaster=3;Bfoo=4;Bold=3;
+    Erefs/heads/master,3,4;
+    Os EHEAD,q,r!I q=q;
+    Ot H=s`,
+                expected: `
+x=E:E;C3M-4 s=Sa:qs,t=Sa:s;Bmaster=3M;Os Cqs-r q=q!H=qs!E;Ot H=s`
+            },
             "staged fix in submodule": {
                 initial: `
 a=B:Ca-1 q=r;Cb-1 q=s;Bmaster=a;Bfoo=b|


### PR DESCRIPTION
Return for submodules that weren't being rebased made them look like they were
in conflict.  Additionally, I changed it to stage commits that might have been
made in such a repo.  Added tests for both cases.

Addresses: https://github.com/twosigma/git-meta/issues/215