### PR TITLE
Fix problem with paths starting in '.'.

### DIFF
--- a/node/lib/util/submodule_util.js
+++ b/node/lib/util/submodule_util.js
@@ -366,11 +366,11 @@ exports.getSubmodulesForCommit = co.wrap(function *(repo, commit) {
 });
 
 /**
- * Return the list of submodules that are a descendant of the specified `dir`,
- * including (potentially) `dir` itself (unless `dir` is suffixed with '/'), in
- * the specified `repo`.  The behavior is undefined unless `dir` is empty or
- * refers to a valid path within `repo`.  Note that if `"" === dir`, the result
- * will be all submodules.
+ * Return the list of submodules, listed in the specified `indexSubNames`, that
+ * are a descendant of the specified `dir`, including (potentially) `dir`
+ * itself (unless `dir` is suffixed with '/'), in the specified `repo`.  The
+ * behavior is undefined unless `dir` is empty or refers to a valid path within
+ * `repo`.  Note that if `"" === dir`, the result will be all submodules.
  *
  * @param {NodeGit.Repository} repo
  * @param {String}             dir
@@ -383,7 +383,8 @@ exports.getSubmodulesInPath = co.wrap(function *(workdir, dir, indexSubNames) {
     assert.isArray(indexSubNames);
     if ("" !== dir) {
         assert.notEqual("/", dir[0]);
-        assert.notEqual(".", dir[0]);
+        assert.notEqual(".", dir);
+        assert.notEqual("..", dir);
     }
     if ("" === dir) {
         return indexSubNames;

--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -485,6 +485,59 @@ describe("SubmoduleUtil", function () {
             }));
         });
     });
+    describe("getSubmodulesInPath", function () {
+        const cases = {
+            "trivial": {
+                state: "x=S",
+                dir: "",
+                indexSubNames: [],
+                expected: [],
+            },
+            "got a sub": {
+                state: "a=B|x=S:C2-1 q/r=Sa:1;Bmaster=2",
+                dir: "",
+                indexSubNames: ["q/r"],
+                expected: ["q/r"],
+            },
+            "got a sub, by path": {
+                state: "a=B|x=S:C2-1 q/r=Sa:1;Bmaster=2",
+                dir: "q",
+                indexSubNames: ["q/r"],
+                expected: ["q/r"],
+            },
+            "got a sub, by exact path": {
+                state: "a=B|x=S:C2-1 q/r=Sa:1;Bmaster=2",
+                dir: "q/r",
+                indexSubNames: ["q/r"],
+                expected: ["q/r"],
+            },
+            "missed": {
+                state: "a=B|x=S:C2-1 q/r=Sa:1;Bmaster=2",
+                dir: "README.md",
+                indexSubNames: ["q/r"],
+                expected: [],
+            },
+            "missed, with a dot": {
+                state: "a=B|x=S:C2-1 q/r=Sa:1;Bmaster=2;W .foo=bar",
+                dir: ".foo",
+                indexSubNames: ["q/r"],
+                expected: [],
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                const written =
+                               yield RepoASTTestUtil.createMultiRepos(c.state);
+                const x = written.repos.x;
+                const result = yield SubmoduleUtil.getSubmodulesInPath(
+                                                              x.workdir(),
+                                                              c.dir,
+                                                              c.indexSubNames);
+                assert.deepEqual(result.sort(), c.expected.sort());
+            }));
+        });
+    });
     describe("resolveSubmoduleNames", function () {
         // We'll run this with 
         const cases = {


### PR DESCRIPTION
This is a very silly bug.  I also added a test driver that was missing for
`getSubmodulesInPath`.  Addresses:
https://github.com/twosigma/git-meta/issues/226