### PR TITLE
Accurate error message on amend failure.

### DIFF
--- a/node/lib/cmd/commit.js
+++ b/node/lib/cmd/commit.js
@@ -225,6 +225,7 @@ const doAmend = co.wrap(function *(args) {
 
     const Commit          = require("../util/commit");
     const GitUtil         = require("../util/git_util");
+    const PrintStatusUtil = require("../util/print_status_util");
     const StatusUtil      = require("../util/status_util");
     const SubmoduleUtil   = require("../util/submodule_util");
     const UserError       = require("../util/user_error");
@@ -259,8 +260,10 @@ const doAmend = co.wrap(function *(args) {
                                                           status,
                                                           oldSubs);
     let bad = "";
-    amendable.newCommits.forEach(sub => {
-        bad += `${colors.red(sub)} has new commits.\n`;
+    Object.keys(amendable.newCommits).forEach(sub => {
+        const relation = amendable.newCommits[sub];
+        const description = PrintStatusUtil.getRelationDescription(relation);
+        bad += `${colors.red(sub)} : ${description}`;
     });
     amendable.mismatchCommits.forEach(sub => {
         bad += `The commit for ${colors.red(sub)} does not match.`;

--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -528,7 +528,7 @@ exports.sameCommitInstance = function (x, y) {
  * @param {Object}             oldSubs map from name to `Submodule`
  * @return {Object}
  * @return {String[]} return.deleted           submodule is removed
- * @return {String[]} return.newCommits        different commit in submodule
+ * @return {Object}   return.newCommits        map from sub name to relation
  * @return {String[]} return.mismatchCommits   commit doesn't match
  * @return {RepoStatus} return.status          adjusted repo status
  */
@@ -539,7 +539,7 @@ exports.checkIfRepoIsAmendable = co.wrap(function *(repo, status, oldSubs) {
 
     const head = yield repo.getHeadCommit();
     const deleted = [];
-    const newCommits = [];
+    const newCommits = {};
     const mismatchCommits = [];
     const subFetcher = new SubmoduleFetcher(repo, head);
     const currentSubs = status.submodules;
@@ -578,14 +578,11 @@ exports.checkIfRepoIsAmendable = co.wrap(function *(repo, status, oldSubs) {
             return;                                                   // RETURN
         }
 
-        // If a submodule has a different commit in its index or its workdir,
-        // fail.
+        // If a submodule has a different commit fail.
 
-        const SAME = RepoStatus.Submodule.COMMIT_RELATION.SAME;
-
-        if (SAME !== newSub.index.relation ||
-            (null !== newSub.workdir && SAME !== newSub.workdir.relation)) {
-            newCommits.push(subName);
+        const relation = newSub.index.relation;
+        if (RepoStatus.Submodule.COMMIT_RELATION.SAME !== relation) {
+            newCommits[subName] = relation;
             return;                                                   // RETURN
         }
 

--- a/node/test/util/commit.js
+++ b/node/test/util/commit.js
@@ -439,13 +439,13 @@ x=E:Cx-2 x=Sq:1;Bmaster=x;I s=~,x=~`,
                 input: `
 a=B:Ca-1;Cb-a;Bf=b|
 x=U:C3-2 s=Sa:a;Bmaster=3;I s=Sa:b`,
-                newCommits: ["s"],
+                newCommits: { s: RELATION.UNKNOWN },
             },
             "sub with new commit in workdir": {
                 input: `
 a=B:Ca-1;Cb-a;Bf=b|
 x=U:C3-2 s=Sa:a;Bmaster=3;Os H=b`,
-                newCommits: ["s"],
+                newCommits: { s: RELATION.AHEAD },
             },
             "sub with bad commit": {
                 input: "a=B:Ca message#a-1;Bf=a|x=U:C3-2 s=Sa:a;Bmaster=3;Os",
@@ -456,7 +456,7 @@ x=U:C3-2 s=Sa:a;Bmaster=3;Os H=b`,
 a=B:Ca-1;Cb-a;Ccommit me#c-b;Bf=c|
 x=S:C2-1 s=Sa:1,t=Sa:1,u=Sa:1;C3-2 s=Sa:b,t=Sa:b,u=Sa:c;I t=Sa:1;Bmaster=3`,
                 mismatchCommits: ["u"],
-                newCommits: ["t"],
+                newCommits: { t: RELATION.UNKNOWN },
                 newStatusSubs: ["s", "u"],
             },
             "deleted": {
@@ -487,8 +487,8 @@ x=S:C2-1 s=Sa:1,t=Sa:1,u=Sa:1;C3-2 s=Sa:b,t=Sa:b,u=Sa:c;I t=Sa:1;Bmaster=3`,
                 assert.deepEqual(result.deleted.sort(),
                                  c.deleted || [],
                                  "deleted");
-                assert.deepEqual(result.newCommits.sort(),
-                                 c.newCommits || [],
+                assert.deepEqual(result.newCommits,
+                                 c.newCommits || {},
                                  "newCommits");
                 assert.deepEqual(result.mismatchCommits.sort(),
                                  c.mismatchCommits || [],


### PR DESCRIPTION
Instead of always saying "new commits", display the actual commit relation.

Addresses: https://github.com/twosigma/git-meta/issues/234