### PR TITLE
Stop deleting edit message file.

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -704,9 +704,7 @@ exports.editMessage = co.wrap(function *(repo, initialContents) {
                              ["-c", `${editorCommand} '${messagePath}'`], {
         stdio: "inherit",
     });
-    const result = yield fs.readFile(messagePath, "utf8");
-    yield fs.unlink(messagePath);
-    return result;
+    return yield fs.readFile(messagePath, "utf8");
 });
 
 /**


### PR DESCRIPTION
Git leaves the 'COMMIT_EDITMSG' file intact and we should too.