### PR TITLE
Cache and uncache submodule states as needed.

### DIFF
--- a/node/lib/util/checkout.js
+++ b/node/lib/util/checkout.js
@@ -59,6 +59,8 @@ exports.checkout = co.wrap(function *(metaRepo, committish) {
     assert.instanceOf(metaRepo, NodeGit.Repository);
     assert.isString(committish);
 
+    metaRepo.submoduleCacheAll();
+
     const annotated = yield GitUtil.resolveCommitish(metaRepo, committish);
     if (null === annotated) {
         throw new UserError(`Could not resolve ${colors.red(committish)}.`);
@@ -165,4 +167,6 @@ exports.checkout = co.wrap(function *(metaRepo, committish) {
     if (null !== branch) {
         yield metaRepo.checkoutBranch(branch);
     }
+
+    metaRepo.submoduleCacheClear();
 });

--- a/node/lib/util/cherrypick.js
+++ b/node/lib/util/cherrypick.js
@@ -78,7 +78,9 @@ exports.cherryPick = co.wrap(function *(metaRepo, commit) {
     const head = yield metaRepo.getHeadCommit();
     const changes = yield SubmoduleUtil.getSubmoduleChanges(metaRepo, commit);
 
-    yield NodeGit.Cherrypick.cherrypick(metaRepo, commit, {});
+    yield SubmoduleUtil.cacheSubmodules(metaRepo, () => {
+        return NodeGit.Cherrypick.cherrypick(metaRepo, commit, {});
+    });
 
     let errorMessage = "";
     let indexChanged = false;

--- a/node/lib/util/merge.js
+++ b/node/lib/util/merge.js
@@ -140,10 +140,13 @@ ${colors.red(commitSha)}.`);
     // anything, has no effect.
 
     const head = yield metaRepo.getCommit(metaRepoStatus.headCommit);
-    const metaIndex = yield NodeGit.Merge.commits(metaRepo,
-                                                  head,
-                                                  commit,
-                                                  null);
+
+    const metaIndex = yield SubmoduleUtil.cacheSubmodules(metaRepo, () => {
+        return NodeGit.Merge.commits(metaRepo,
+                                     head,
+                                     commit,
+                                     null);
+    });
 
     let errorMessage = "";
 

--- a/node/lib/util/rebase_util.js
+++ b/node/lib/util/rebase_util.js
@@ -684,11 +684,13 @@ up-to-date.`);
                 yield NodeGit.AnnotatedCommit.fromRef(metaRepo, currentBranch);
         const ontoAnnotatedCommit =
                       yield NodeGit.AnnotatedCommit.lookup(metaRepo, commitId);
-        const rebase = yield NodeGit.Rebase.init(metaRepo,
-                                                 fromAnnotedCommit,
-                                                 ontoAnnotatedCommit,
-                                                 null,
-                                                 null);
+        const rebase = yield SubmoduleUtil.cacheSubmodules(metaRepo, () => {
+            return NodeGit.Rebase.init(metaRepo,
+                                       fromAnnotedCommit,
+                                       ontoAnnotatedCommit,
+                                       null,
+                                       null);
+        });
         console.log(`Rewinding to ${colors.green(commitId.tostrS())}.`);
         yield callNext(rebase);
         return rebase;
@@ -707,7 +709,9 @@ up-to-date.`);
 exports.abort = co.wrap(function *(repo) {
     assert.instanceOf(repo, NodeGit.Repository);
 
-    const rebase = yield NodeGit.Rebase.open(repo);
+    const rebase = yield SubmoduleUtil.cacheSubmodules(repo, () => {
+        return NodeGit.Rebase.open(repo);
+    });
     rebase.abort();
 
     const head = yield repo.head();
@@ -753,7 +757,9 @@ exports.continue = co.wrap(function *(repo) {
         console.log(`Continuing rebase from \
 ${colors.green(rebaseInfo.originalHead)} onto \
 ${colors.green(rebaseInfo.onto)}.`);
-        const rebase = yield NodeGit.Rebase.open(repo);
+        const rebase = yield SubmoduleUtil.cacheSubmodules(repo, () => {
+            return NodeGit.Rebase.open(repo);
+        });
         const curIdx = rebase.operationCurrent();
         const curOper = rebase.operationByIndex(curIdx);
         const curSha = curOper.id().tostrS();

--- a/node/lib/util/reset.js
+++ b/node/lib/util/reset.js
@@ -80,7 +80,9 @@ exports.reset = co.wrap(function *(repo, commit, type) {
 
     // First, reset the meta-repo.
 
-    yield NodeGit.Reset.reset(repo, commit, resetType);
+    yield SubmoduleUtil.cacheSubmodules(repo, () => {
+        return NodeGit.Reset.reset(repo, commit, resetType);
+    });
 
     // Then, all open subs.
 

--- a/node/lib/util/status_util.js
+++ b/node/lib/util/status_util.js
@@ -387,11 +387,13 @@ exports.getRepoStatus = co.wrap(function *(repo, options) {
             const treeId = head.treeId();
             tree = yield NodeGit.Tree.lookup(repo, treeId);
         }
-        const status = yield DiffUtil.getRepoStatus(repo,
-                                                    tree,
-                                                    options.paths,
-                                                    options.ignoreIndex,
-                                                    options.showAllUntracked);
+        const status = yield SubmoduleUtil.cacheSubmodules(repo, () => {
+            return DiffUtil.getRepoStatus(repo,
+                                          tree,
+                                          options.paths,
+                                          options.ignoreIndex,
+                                          options.showAllUntracked);
+        });
         args.staged = status.staged;
         args.workdir = status.workdir;
     }

--- a/node/lib/util/submodule_util.js
+++ b/node/lib/util/submodule_util.js
@@ -585,3 +585,27 @@ exports.addRefs = co.wrap(function *(repo, refs, submodules) {
         }));
     }));
 });
+
+/**
+ * Cache the submodules before invoking the specified `operation` and uncache
+ * them after the operation is completed, or before allowing an exception to
+ * propagte.  Return the result of `operation`.
+ *
+ * @param {NodeGit.Repository} repo
+ * @param {(repo ) => Promise} operation
+ */
+exports.cacheSubmodules = co.wrap(function *(repo, operation) {
+    assert.instanceOf(repo, NodeGit.Repository);
+    assert.isFunction(operation);
+    repo.submoduleCacheAll();
+    let result;
+    try {
+        result = yield operation(repo);
+    }
+    catch (e) {
+        repo.submoduleCacheClear();
+        throw e;
+    }
+    repo.submoduleCacheClear();
+    return result;
+});

--- a/node/package.json
+++ b/node/package.json
@@ -33,7 +33,7 @@
     "co": "",
     "colors": "",
     "fs-promise": "",
-    "nodegit": "^0.16.0",
+    "nodegit": "^0.19.0",
     "rimraf": "",
     "split": ""
   },

--- a/node/test/util/read_repo_ast_util.js
+++ b/node/test/util/read_repo_ast_util.js
@@ -983,7 +983,7 @@ describe("readRAST", function () {
         commits[mergeSha] = new Commit({
             parents: [cSha, bSha],
             changes: { foo: "foo" },
-            message: "Merged b into master",
+            message: "Merge branch 'b'",
         });
         const expected = new RepoAST({
             head: mergeSha,

--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -736,5 +736,30 @@ describe("SubmoduleUtil", function () {
             }));
         });
     });
+    describe("cacheSubmodules", function () {
+        it("breathing", co.wrap(function *() {
+            const repo = yield TestUtil.createSimpleRepository();
+            function op(r) {
+                assert.equal(repo, r);
+                return Promise.resolve(3);
+            }
+            const result = yield SubmoduleUtil.cacheSubmodules(repo, op);
+            assert.equal(result, 3);
+        }));
+        it("exception", co.wrap(function *() {
+            class MyException {}
+            function op() {
+                throw new MyException();
+            }
+            const repo = yield TestUtil.createSimpleRepository();
+            try {
+                yield SubmoduleUtil.cacheSubmodules(repo, op);
+            }
+            catch (e) {
+                assert.instanceOf(e, MyException);
+                return;
+            }
+            assert(false, "should have thrown");
+        }));
+    });
 });
-


### PR DESCRIPTION
Also upgraded nodegit.  Now we can cache this state explicitly just when we
need to.  Note that using the cache all the time causes operations like
`rebase` to fail.

Updated `read_repo_ast_util` test driver because libgit2 now creates a
different merge commit error message.