### PR TITLE
Improved performance of several commands

### DIFF
--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -49,7 +49,6 @@ const Open                = require("./open");
 const RepoStatus          = require("./repo_status");
 const PrintStatusUtil     = require("./print_status_util");
 const StatusUtil          = require("./status_util");
-const Submodule           = require("./submodule");
 const SubmoduleUtil       = require("./submodule_util");
 const TreeUtil            = require("./tree_util");
 const UserError           = require("./user_error");
@@ -720,16 +719,6 @@ exports.getSubmoduleAmendStatus = co.wrap(function *(status,
                                                      old,
                                                      getRepo,
                                                      all) {
-    assert.instanceOf(status, RepoStatus.Submodule);
-    if (null !== old) {
-        assert.instanceOf(old, Submodule);
-    }
-    else {
-        old = null;
-    }
-    assert.isFunction(getRepo);
-    assert.isBoolean(all);
-
     const index = status.index;
     const commit = status.commit;
     const workdir = status.workdir;
@@ -940,6 +929,7 @@ exports.getAmendStatus = co.wrap(function *(repo, options) {
         workdir: metaWorkdir,
         submodules: submodules,
     });
+
     return {
         status: resultStatus,
         subsToAmend: subsToAmend,

--- a/node/lib/util/status_util.js
+++ b/node/lib/util/status_util.js
@@ -222,24 +222,6 @@ exports.getSubmoduleStatus = co.wrap(function *(repo,
                                                 commitUrl,
                                                 indexSha,
                                                 commitSha) {
-    if (null !== repo) {
-        assert.instanceOf(repo, NodeGit.Repository);
-    }
-    if (null !== status) {
-        assert.instanceOf(status, RepoStatus);
-    }
-    if (null !== indexUrl) {
-        assert.isString(indexUrl);
-    }
-    if (null !== commitUrl) {
-        assert.isString(commitUrl);
-    }
-    if (null !== indexSha) {
-        assert.isString(indexSha);
-    }
-    if (null !== commitSha) {
-        assert.isString(commitSha);
-    }
     const Submodule = RepoStatus.Submodule;
     const COMMIT_RELATION = Submodule.COMMIT_RELATION;
 
@@ -419,7 +401,6 @@ exports.getRepoStatus = co.wrap(function *(repo, options) {
         const headUrls =
            yield SubmoduleConfigUtil.getSubmodulesFromCommit(repo, headCommit);
 
-
         // No paths specified, so we'll do all submodules, restricing to open
         // ones based on options.
 
@@ -440,7 +421,6 @@ exports.getRepoStatus = co.wrap(function *(repo, options) {
                                     Object.keys(headUrls).concat(indexNames)));
         }
         const commitTree = yield headCommit.getTree();
-
 
         // Make a list of promises to read the status for each submodule, then
         // evaluate them in parallel.
@@ -473,6 +453,7 @@ exports.getRepoStatus = co.wrap(function *(repo, options) {
                                                     indexSha,
                                                     headSha);
         }));
+
         const subStats = yield subStatMakers;
 
         // And copy them into the arguments.

--- a/node/test/util/repo_status.js
+++ b/node/test/util/repo_status.js
@@ -133,7 +133,6 @@ describe("RepoStatus", function () {
             const c = cases[caseName];
             it(caseName, function () {
                 const result = new Submodule(c.args);
-                assert.isFrozen(result);
                 const e = c.expected;
                 assert.deepEqual(result.commit, e.commit);
                 assert.deepEqual(result.index, e.index);


### PR DESCRIPTION
I removed assertions that were causing status commands with large
numbers of submodules to be slow and changed the `Opener` to load
submodule shas lazily.

Generally, status and commit are about 6X faster with very large numbers
of submodules.

Addresses: https://github.com/twosigma/git-meta/issues/291