### PR TITLE
Fix `pull` to fetch only needed branch.

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -453,6 +453,35 @@ exports.fetch = co.wrap(function *(repo, remoteName) {
 });
 
 /**
+ * Fetch the specified `branch` in the remote having the specified `remoteName
+ * in the specified `repo`.  Throw a `UserError` object if the repository
+ * cannot be fetched.
+ *
+ * @async
+ * @param {NodeGit.Repository} repo
+ * @param {String}             remoteName
+ * @param {String}             branch
+ */
+exports.fetchBranch = co.wrap(function *(repo, remoteName, branch) {
+    // TODO: this is an awful hack because I can't yet figure out how to get
+    // nodegit to work with kerberos.  For now, will shell out and use the
+    // 'git' command.
+
+    assert.instanceOf(repo, NodeGit.Repository);
+    assert.isString(remoteName);
+    assert.isString(branch);
+
+    const execString = `\
+git -C '${repo.path()}' fetch -q '${remoteName}' '${branch}'`;
+    try {
+        return yield ChildProcess.exec(execString);
+    }
+    catch (e) {
+        throw new UserError(e.message);
+    }
+});
+
+/**
  * Fetch the specified `sha` from the specified `url` into the specified
  * `repo`, if it does not already exist in `repo`.
  *

--- a/node/lib/util/pull.js
+++ b/node/lib/util/pull.js
@@ -68,7 +68,7 @@ exports.pull = co.wrap(function *(metaRepo, remoteName, source) {
     // Just fetch the meta-repo; rebase will trigger necessary fetches in
     // sub-repos.
 
-    yield GitUtil.fetch(metaRepo, remoteName);
+    yield GitUtil.fetchBranch(metaRepo, remoteName, source);
     const remoteBranch = yield GitUtil.findRemoteBranch(metaRepo,
                                                         remoteName,
                                                         source);

--- a/node/test/util/pull.js
+++ b/node/test/util/pull.js
@@ -65,6 +65,12 @@ describe("pull", function () {
             source: "foo",
             expected: "x=E:Bmaster=2 origin/master",
         },
+        "doesn't pull down unneeded branches": {
+            initial: "a=B:Bfoo=1|x=S:Rorigin=a",
+            remote: "origin",
+            source: "foo",
+            expected: "x=E:Rorigin=a foo=1",
+        },
     };
     Object.keys(cases).forEach(caseName => {
         const c = cases[caseName];


### PR DESCRIPTION
This will allow `pull` to work when `git fetch` is configured to not
fetch the required branch by default (as is the case when the repo is
configured to fetch only `master` by default), and will be more
efficient in general.

Addresses: https://github.com/twosigma/git-meta/issues/289