### PR TITLE
Tracking with slash

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -137,9 +137,10 @@ exports.getTrackingInfo = co.wrap(function *(branch) {
             remoteName: null,
         };
     }
+    const remoteName = parts.shift();
     return {
-        branchName: parts[1],
-        remoteName: parts[0],
+        branchName: parts.join("/"),
+        remoteName: remoteName,
     };
 });
 

--- a/node/test/util/git_util.js
+++ b/node/test/util/git_util.js
@@ -70,6 +70,14 @@ describe("GitUtil", function () {
                     branchName: "gob",
                 },
             },
+            "with slashes in branch name": {
+                state: "S:Rhoo=/a foo/bar=1;Bbar=1 hoo/foo/bar",
+                branch: "bar",
+                expected: {
+                    remoteName: "hoo",
+                    branchName: "foo/bar",
+                },
+            },
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];

--- a/node/test/util/write_repo_ast_util.js
+++ b/node/test/util/write_repo_ast_util.js
@@ -393,6 +393,8 @@ S:C2-1 x=y;C3-1 x=z;Bmaster=2;Bfoo=3;Erefs/heads/master,2,3;I x=q;H=3",
             },
             "new sub open w/o SHA": "a=B|x=S:I s=Sa:;Os",
             "cloned": "a=B|x=Ca",
+            "pathed tracking branch":
+                "a=B:Bfoo/bar=1|x=Ca:Bfoo/bar=1 origin/foo/bar",
         };
         Object.keys(cases).forEach(caseName => {
             const input = cases[caseName];


### PR DESCRIPTION
fix bug with tracking branches containing '/'