### PR TITLE
Support alternate object directories in hook

### DIFF
--- a/node/lib/util/synthetic_branch_util.js
+++ b/node/lib/util/synthetic_branch_util.js
@@ -113,6 +113,18 @@ function* checkSubmodule(repo, metaCommit, submoduleEntry, url) {
 
     const localPath = yield *urlToLocalPath(repo, url);
     const submoduleRepo = yield NodeGit.Repository.open(localPath);
+    const odb = yield submoduleRepo.odb();
+    (process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES || "").split(":").forEach(
+        function(alt) {
+            if (alt !== "") {
+                odb.addDiskAlternate(alt);
+            }
+        }
+    );
+    const objectDirectory = process.env.GIT_OBJECT_DIRECTORY;
+    if (objectDirectory) {
+        odb.addDiskAlternate();
+    }
     const submoduleCommitId = submoduleEntry.id();
     const branch = exports.getSyntheticBranchForCommit(submoduleCommitId);
     try {


### PR DESCRIPTION
Git 2.11 quarantines incoming packs.  This means that they're not in
the normal object database -- they're in an alternate object database
untli the push is accepted.  Git tells us about the alternate ODB
through environment variables.  We need to use this alternate ODB
to look up objects in our hook.