### PR TITLE
Fix crash when no tracking info on pull

### DIFF
--- a/node/lib/cmd/pull.js
+++ b/node/lib/cmd/pull.js
@@ -97,8 +97,10 @@ exports.executeableSubcommand = co.wrap(function *(args) {
         throw new UserError("Non-rebase pull not supported.");
     }
 
+    // TODO: move the following code into `util/push.js` and add test
+
     const branch = yield repo.getCurrentBranch();
-    const tracking = yield GitUtil.getTrackingInfo(branch);
+    const tracking = (yield GitUtil.getTrackingInfo(branch)) || {};
 
     // The source branch is (in order of preference): the name passed on the
     // commandline, the tracking branch name, or the current branch name.


### PR DESCRIPTION
Addresses: https://github.com/twosigma/git-meta/issues/285