### PR TITLE
Ensure commit messages end with '\n'

### DIFF
--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -54,6 +54,16 @@ const TreeUtil            = require("./tree_util");
 const UserError           = require("./user_error");
 
 /**
+ * If the specified `message` does not end with '\n', return the result of
+ * appending '\n' to 'message'; otherwise, return 'message'.
+ *
+ * @param {String} message
+ */
+function ensureEolOnLastLine(message) {
+    return message.endsWith("\n") ? message : (message + "\n");
+}
+
+/**
  * Return the `NodeGit.Tree` object for the (left) parent of the head commit
  * in the specified `repo`, or null if the commit has no parent.
  *
@@ -220,7 +230,7 @@ const commitRepo = co.wrap(function *(repo,
         return yield repo.createCommitOnHead([],
                                              signature,
                                              signature,
-                                             message);
+                                             ensureEolOnLastLine(message));
     }
     return null;
 });
@@ -604,7 +614,7 @@ exports.writeRepoPaths = co.wrap(function *(repo, status, message) {
                                                  sig,
                                                  sig,
                                                  0,
-                                                 message,
+                                                 ensureEolOnLastLine(message),
                                                  tree,
                                                  parents.length,
                                                  parents);
@@ -952,7 +962,8 @@ exports.amendRepo = co.wrap(function *(repo, message) {
     const index = yield repo.index();
     const treeId = yield index.writeTree();
     const tree = yield NodeGit.Tree.lookup(repo, treeId);
-    const id = yield head.amend("HEAD", null, null, null, message, tree);
+    const termedMessage = ensureEolOnLastLine(message);
+    const id = yield head.amend("HEAD", null, null, null, termedMessage, tree);
     return id.tostrS();
 });
 

--- a/node/lib/util/shorthand_parser_util.js
+++ b/node/lib/util/shorthand_parser_util.js
@@ -110,7 +110,7 @@ const RepoASTUtil  = require("../util/repo_ast_util");
  * second is its parent.  A new commit introduces a change with a file having
  * the same name as its id and content that is also its id, unless changes are
  * specified.  If no commit message is specified, the default value is
- * "message".  Note that in a test case, an expected commit message of "*"
+ * "message\n".  Note that in a test case, an expected commit message of "*"
  * indicates that any message is acceptable; this is necessary to match
  * generated messages.
  *
@@ -654,7 +654,7 @@ function parseOverrides(shorthand, begin, end, delimiter) {
         // up the start of the 'id' and message boundaries appropriately.
 
         const messageSeparator = findChar(shorthand, "#", begin, end);
-        let message = "message";
+        let message = "message\n";
         if (null !== messageSeparator) {
             message = shorthand.substr(begin, messageSeparator - begin);
         }

--- a/node/lib/util/test_util.js
+++ b/node/lib/util/test_util.js
@@ -212,7 +212,10 @@ exports.makeCommit = co.wrap(function *(repo, files) {
     files.forEach((name, i) => assert.isString(name, i));
 
     const sig = repo.defaultSignature();
-    const commitId = yield repo.createCommitOnHead(files, sig, sig, "message");
+    const commitId = yield repo.createCommitOnHead(files,
+                                                   sig,
+                                                   sig,
+                                                   "message\n");
     return yield repo.getCommit(commitId);
 });
 

--- a/node/test/util/commit.js
+++ b/node/test/util/commit.js
@@ -847,8 +847,14 @@ Untracked files:
             "staged addition": {
                 initial: "x=S:I a=b",
                 doAll: true,
+                message: "hello\n",
+                expected: "x=S:Chello\n#x-1 a=b;Bmaster=x",
+            },
+            "add newline": {
+                initial: "x=S:I a=b",
+                doAll: true,
                 message: "hello",
-                expected: "x=S:Chello#x-1 a=b;Bmaster=x",
+                expected: "x=S:Chello\n#x-1 a=b;Bmaster=x",
             },
             "staged addition, unstaged modification but all": {
                 initial: "x=S:I a=b;W a=c",
@@ -946,7 +952,7 @@ x=E:Cx-2 x=Sq:1;Bmaster=x;I s=~,x=~`,
                 subMessages: {
                     s: "this message",
                 },
-                expected: "x=E:Os Cthis message#s-1 u=v!H=s",
+                expected: "x=E:Os Cthis message\n#s-1 u=v!H=s",
             },
             "staged change in submodule with commit override": {
                 initial: "a=S|x=U:Os I u=v",
@@ -956,7 +962,7 @@ x=E:Cx-2 x=Sq:1;Bmaster=x;I s=~,x=~`,
                     s: "this message",
                 },
                 expected:
-                    "x=U:Cx-2 s=Sa:s;Os Cthis message#s-1 u=v!H=s;Bmaster=x",
+                    "x=U:Cx-2 s=Sa:s;Os Cthis message\n#s-1 u=v!H=s;Bmaster=x",
             },
             "new commit in a submodule": {
                 initial: "a=S|x=U:Ca-1;Bx=a;I s=Sa:a;Ba=a",
@@ -1420,9 +1426,15 @@ a=B:Chi#a-1;Ba=a|x=U:C3-2 s=Sa:a;Bmaster=3;Os W README.md=888`,
         const cases = {
             "trivial": {
                 input: "x=S",
+                message: "foo\n",
+                expected: `
+x=N:Cfoo\n#x README.md=hello world;*=master;Bmaster=x`,
+            },
+            "added newline": {
+                input: "x=S",
                 message: "foo",
                 expected: `
-x=N:Cfoo#x README.md=hello world;*=master;Bmaster=x`,
+x=N:Cfoo\n#x README.md=hello world;*=master;Bmaster=x`,
             },
         };
         Object.keys(cases).forEach(caseName => {
@@ -1495,65 +1507,65 @@ x=U:Cx-2 3=3,s=Sa:s;Bmaster=x;Os Cs-1 a=b,README.md=3!H=s`,
                 input: "a=B:Ca-1;Bx=a|x=U:C3-2 s=Sa:a;Bmaster=3;Os",
                 message: "hi",
                 expected: `
-x=U:Chi#x-2 s=Sa:s;Bmaster=x;Os Chi#s-1 a=a!H=s`,
+x=U:Chi\n#x-2 s=Sa:s;Bmaster=x;Os Chi\n#s-1 a=a!H=s`,
             },
             "amended subrepo with index change": {
                 input: "a=B:Ca-1;Bx=a|x=U:C3-2 s=Sa:a;Bmaster=3;Os I q=4",
                 message: "hi",
                 expected: `
-x=U:Chi#x-2 s=Sa:s;Bmaster=x;Os Chi#s-1 a=a,q=4!H=s`,
+x=U:Chi\n#x-2 s=Sa:s;Bmaster=x;Os Chi\n#s-1 a=a,q=4!H=s`,
             },
             "amended subrepo with unstaged change": {
                 input: `
 a=B:Ca-1;Bx=a|x=U:C3-2 s=Sa:a;Bmaster=3;Os W README.md=2`,
-                message: "hi",
+                message: "hi\n",
                 expected: `
-x=U:Chi#x-2 s=Sa:s;Bmaster=x;Os Chi#s-1 a=a!H=s!W README.md=2`,
+x=U:Chi\n#x-2 s=Sa:s;Bmaster=x;Os Chi\n#s-1 a=a!H=s!W README.md=2`,
             },
             "amended subrepo with change to stage": {
                 input: `
 a=B:Ca-1;Bx=a|x=U:C3-2 s=Sa:a;Bmaster=3;Os W README.md=2`,
-                message: "hi",
+                message: "hi\n",
                 expected: `
-x=U:Chi#x-2 s=Sa:s;Bmaster=x;Os Chi#s-1 a=a,README.md=2!H=s`,
+x=U:Chi\n#x-2 s=Sa:s;Bmaster=x;Os Chi\n#s-1 a=a,README.md=2!H=s`,
                 all: true,
             },
             "strip submodule commit": {
                 input: `
 a=B:Ca-1;Bmaster=a|x=U:C3-2 s=Sa:a,3=3;Os I a;Bmaster=3`,
                 message: "foo",
-                expected: `x=U:Cfoo#x-2 3=3;Bmaster=x;Os`,
+                expected: `x=U:Cfoo\n#x-2 3=3;Bmaster=x;Os`,
             },
             "strip submodule commit, leave untracked": {
                 input: `
 a=B:Ca-1;Bmaster=a|x=U:C3-2 s=Sa:a,3=3;Os I a!W x=y;Bmaster=3`,
                 message: "foo",
-                expected: `x=U:Cfoo#x-2 3=3;Bmaster=x;Os W x=y`,
+                expected: `x=U:Cfoo\n#x-2 3=3;Bmaster=x;Os W x=y`,
             },
             "strip submodule commit, leave modified": {
                 input: `
 a=B:Ca-1;Bmaster=a|x=U:C3-2 s=Sa:a,3=3;Os I a!W README.md=2;Bmaster=3`,
                 message: "foo",
-                expected: `x=U:Cfoo#x-2 3=3;Bmaster=x;Os W README.md=2`,
+                expected: `x=U:Cfoo\n#x-2 3=3;Bmaster=x;Os W README.md=2`,
             },
             "strip submodule commit unchange from index": {
                 input: `
 a=B:Ca-1;Cb-a a=9;Bmaster=b|x=U:C3-2 s=Sa:b,3=3;Os I a=a;Bmaster=3`,
                 message: "foo",
-                expected: `x=U:Cfoo#x-2 3=3,s=Sa:a;Bmaster=x;Os`
+                expected: `x=U:Cfoo\n#x-2 3=3,s=Sa:a;Bmaster=x;Os`
             },
             "not strip submodule commit unchange from workdir": {
                 input: `
 a=B:Ca-1;Cb-a a=9;Bmaster=b|x=U:C3-2 s=Sa:b,3=3;Os W a=a;Bmaster=3`,
                 message: "foo",
                 expected: `
-x=U:Cfoo#x-2 3=3,s=Sa:s;Bmaster=x;Os Cfoo#s-a a=9!W a=a`
+x=U:Cfoo\n#x-2 3=3,s=Sa:s;Bmaster=x;Os Cfoo\n#s-a a=9!W a=a`
             },
             "strip submodule commit unchange from workdir, when all": {
                 input: `
 a=B:Ca-1;Cb-a a=9;Bmaster=b|x=U:C3-2 s=Sa:b,3=3;Os W a=a;Bmaster=3`,
                 message: "foo",
-                expected: `x=U:Cfoo#x-2 3=3,s=Sa:a;Bmaster=x;Os`,
+                expected: `x=U:Cfoo\n#x-2 3=3,s=Sa:a;Bmaster=x;Os`,
                 all: true,
             },
             "skipped meta repo": {
@@ -1562,7 +1574,7 @@ a=B:Ca-1;Cb-a a=9;Bmaster=b|x=U:C3-2 s=Sa:b,3=3;Os W a=a;Bmaster=3`,
                 subMessages: {
                     s: "hi",
                 },
-                expected: `x=E:Os Chi#s-1 a=a!H=s`,
+                expected: `x=E:Os Chi\n#s-1 a=a!H=s`,
             },
             "skipped non-amend": {
                 input: "a=B|x=U:C3-2;Bmaster=3;I q=r;Os I y=z;B3=3",
@@ -1575,7 +1587,7 @@ a=B:Ca-1;Cb-a a=9;Bmaster=b|x=U:C3-2 s=Sa:b,3=3;Os W a=a;Bmaster=3`,
                     s: "hola",
                 },
                 expected: `
-x=E:Cx-2 3=3,s=Sa:s;Bmaster=x;Os Chola#s-1 y=z!H=s`,
+x=E:Cx-2 3=3,s=Sa:s;Bmaster=x;Os Chola\n#s-1 y=z!H=s`,
             },
             "amended subrepo skipped with subMessage": {
                 input: `
@@ -1583,7 +1595,7 @@ a=B:Ca-1;Bx=a|x=U:C3-2 s=Sa:a;Bmaster=3;Os;I foo=moo`,
                 subMessages: {},
                 message: "hi",
                 expected: `
-x=U:Chi#x-2 foo=moo,s=Sa:a;Bmaster=x;Os`,
+x=U:Chi\n#x-2 foo=moo,s=Sa:a;Bmaster=x;Os`,
             },
             "amended subrepo skipped with own message": {
                 input: `
@@ -1593,7 +1605,7 @@ a=B:Ca-1;Bx=a|x=U:C3-2 s=Sa:a;Bmaster=3;Os;I foo=moo`,
                 },
                 message: "hi",
                 expected: `
-x=U:Chi#x-2 foo=moo,s=Sa:s;Bmaster=x;Os Cmeh#s-1 a=a!H=s`,
+x=U:Chi\n#x-2 foo=moo,s=Sa:s;Bmaster=x;Os Cmeh\n#s-1 a=a!H=s`,
             },
         };
         Object.keys(cases).forEach(caseName => {
@@ -1609,7 +1621,7 @@ x=U:Chi#x-2 foo=moo,s=Sa:s;Bmaster=x;Os Cmeh#s-1 a=a!H=s`,
                     });
                     const subsToAmend = Object.keys(amend.subsToAmend);
                     const subMessages = c.subMessages || null;
-                    let message = "message";
+                    let message = "message\n";
                     if (undefined !== c.message) {
                         message = c.message;
                     }
@@ -1905,6 +1917,14 @@ my message
                 },
                 expected: "x=S:Cx-1 README.md=haha;Bmaster=x",
             },
+            "simple staged change, added eol": {
+                state: "x=S:I README.md=haha",
+                message: "hah",
+                fileChanges: {
+                    "README.md": FILESTATUS.MODIFIED,
+                },
+                expected: "x=S:Chah\n#x-1 README.md=haha;Bmaster=x",
+            },
             "simple workdir change": {
                 state: "x=S:W README.md=haha",
                 fileChanges: { "README.md": FILESTATUS.MODIFIED, },
@@ -1913,8 +1933,8 @@ my message
             "simple change with message": {
                 state: "x=S:I README.md=haha",
                 fileChanges: { "README.md": FILESTATUS.MODIFIED, },
-                expected: "x=S:Chello world#x-1 README.md=haha;Bmaster=x",
-                message: "hello world",
+                expected: "x=S:Chello world\n#x-1 README.md=haha;Bmaster=x",
+                message: "hello world\n",
             },
             "added file": {
                 state: "x=S:W q=3",
@@ -1977,7 +1997,7 @@ x=S:C2-1 q/r/s=Sa:1;Bmaster=2;Oq/r/s H=a`,
             const writer = co.wrap(function *(repos) {
                 const repo = repos.x;
                 let status = yield StatusUtil.getRepoStatus(repo);
-                const message = c.message || "message";
+                const message = c.message || "message\n";
                 const subChanges = c.subChanges || [];
                 const subs = {};
                 const submodules = status.submodules;
@@ -3020,8 +3040,8 @@ and for d
             },
             "meta commit": {
                 initial: "x=S:I a=b",
-                message: "foo",
-                expected: "x=S:Cfoo#x-1 a=b;Bmaster=x",
+                message: "foo\n",
+                expected: "x=S:Cfoo\n#x-1 a=b;Bmaster=x",
             },
             "meta commit, with editor": {
                 initial: "x=S:I a=b",
@@ -3035,14 +3055,14 @@ and for d
                 initial: "x=S:W README.md=2",
                 all: true,
                 message: "foo",
-                expected: "x=S:Cfoo#x-1 README.md=2;Bmaster=x",
+                expected: "x=S:Cfoo\n#x-1 README.md=2;Bmaster=x",
             },
             "paths, cwd": {
                 initial: "x=S:I a/b=b,b=d",
                 message: "foo",
                 paths: ["b"],
                 cwd: "a",
-                expected: "x=S:Cfoo#x-1 a/b=b;I b=d;Bmaster=x",
+                expected: "x=S:Cfoo\n#x-1 a/b=b;I b=d;Bmaster=x",
             },
             "uncommitable": {
                 initial: "a=B|x=S:I a=Sa:;Oa",
@@ -3134,41 +3154,41 @@ x=U:Chola\n#x-2 s=Sa:s;Bmaster=x;Os Cthere\n#s-1 a=a!H=s`,
             "simple amend": {
                 initial: "x=S:C2-1 README.md=foo;Bmaster=2",
                 message: "foo",
-                expected: "x=S:Cfoo#x-1 README.md=foo;Bmaster=x",
+                expected: "x=S:Cfoo\n#x-1 README.md=foo;Bmaster=x",
             },
             "amend with change": {
                 initial: "x=S:C2-1 README.md=foo;Bmaster=2;I a=b",
                 message: "foo",
-                expected: "x=S:Cfoo#x-1 README.md=foo,a=b;Bmaster=x",
+                expected: "x=S:Cfoo\n#x-1 README.md=foo,a=b;Bmaster=x",
             },
             "amend with no all": {
                 initial: "x=S:C2-1;Bmaster=2;W README.md=8",
                 message: "foo",
-                expected: "x=S:Cfoo#x-1 2=2;Bmaster=x;W README.md=8",
+                expected: "x=S:Cfoo\n#x-1 2=2;Bmaster=x;W README.md=8",
             },
             "amend with all": {
                 initial: "x=S:C2-1;Bmaster=2;W README.md=8",
                 message: "foo",
                 all: true,
-                expected: "x=S:Cfoo#x-1 2=2,README.md=8;Bmaster=x",
+                expected: "x=S:Cfoo\n#x-1 2=2,README.md=8;Bmaster=x",
             },
             "amend with all but no meta": {
                 initial: "x=S:C2-1;Bmaster=2;W README.md=8",
                 message: "foo",
                 all: true,
                 meta: false,
-                expected: "x=S:Cfoo#x-1 2=2;Bmaster=x;W README.md=8",
+                expected: "x=S:Cfoo\n#x-1 2=2;Bmaster=x;W README.md=8",
             },
             "mismatch": {
                 initial: `
-a=B:Chello#a-1;Ba=a|x=U:Cworld#3-2 s=Sa:a;Bmaster=3`,
+a=B:Chello\n#a-1;Ba=a|x=U:Cworld\n#3-2 s=Sa:a;Bmaster=3`,
                 message: "hahaha",
                 expected: "x=E:Os",
                 fails: true,
             },
             "mismatch interactive": {
                 initial: `
-a=B:Chello#a-1;Ba=a|x=U:Cworld#3-2 s=Sa:a;Bmaster=3`,
+a=B:Chello\n#a-1;Ba=a|x=U:Cworld\n#3-2 s=Sa:a;Bmaster=3`,
                 interactive: true,
                 editor: () => Promise.resolve(`\
 hola

--- a/node/test/util/merge.js
+++ b/node/test/util/merge.js
@@ -55,7 +55,7 @@ describe("merge", function () {
         assert.property(reverseCommitMap, fromCommit);
         const physicalCommit = reverseCommitMap[fromCommit];
         const commit = yield x.getCommit(physicalCommit);
-        const result = yield Merge.merge(x, status, commit, mode, "message");
+        const result = yield Merge.merge(x, status, commit, mode, "message\n");
         if (upToDate) {
             assert.isNull(result);
             return;                                                   // RETURN

--- a/node/test/util/read_repo_ast_util.js
+++ b/node/test/util/read_repo_ast_util.js
@@ -106,7 +106,7 @@ const repoWithCommit = co.wrap(function *() {
             "README.md": "bleh",
             "foobar": "meh",
         },
-        message: "message",
+        message: "message\n",
     });
     const expected = new RepoAST({
         commits: commits,
@@ -152,7 +152,7 @@ const repoWithDeeperCommits = co.wrap(function *() {
     commits[secondCommit] = new Commit({
         changes: { "README.md": "bleh" },
         parents: [firstCommit],
-        message: "message",
+        message: "message\n",
     });
     const expected = new RepoAST({
         commits: commits,
@@ -268,7 +268,7 @@ describe("readRAST", function () {
         commits[secondSha] = new Commit({
             parents: [firstSha],
             changes: { "foo/bar": "meh" },
-            message: "message",
+            message: "message\n",
         });
         const expected = new RepoAST({
             commits: commits,
@@ -298,7 +298,7 @@ describe("readRAST", function () {
         commits[delSha] = new Commit({
             parents: [headSha],
             changes: { "README.md": null },
-            message: "message",
+            message: "message\n",
         });
         const expected = new RepoAST({
             commits: commits,
@@ -411,7 +411,7 @@ describe("readRAST", function () {
                                                      sig,
                                                      sig,
                                                      0,
-                                                     "message",
+                                                     "message\n",
                                                      tree,
                                                      0,
                                                      []);
@@ -420,7 +420,7 @@ describe("readRAST", function () {
         const commits = {};
         const sha = commitId.tostrS();
         commits[sha] = new RepoAST.Commit({
-            message: "message",
+            message: "message\n",
         });
         const expected = new RepoAST({
             commits: commits,
@@ -546,7 +546,7 @@ describe("readRAST", function () {
                 "x/y": new RepoAST.Submodule(baseSubPath,
                                              subHead.id().tostrS()),
             },
-            message: "message",
+            message: "message\n",
         });
         const expected = new RepoAST({
             commits: commits,
@@ -594,7 +594,7 @@ describe("readRAST", function () {
                 "x/y": new RepoAST.Submodule(baseSubPath,
                                              subHead.id().tostrS()),
             },
-            message: "message",
+            message: "message\n",
         });
         const expected = new RepoAST({
             commits: commits,
@@ -646,7 +646,7 @@ describe("readRAST", function () {
                 "x/y": new RepoAST.Submodule(baseSubPath,
                                              subHead.id().tostrS()),
             },
-            message: "message",
+            message: "message\n",
         });
         commits[lastCommit.id().tostrS()] = new Commit({
             parents: [commit.id().tostrS()],
@@ -655,7 +655,7 @@ describe("readRAST", function () {
                                             baseSubPath,
                                             anotherSubCommit.id().tostrS())
             },
-            message: "message",
+            message: "message\n",
         });
         const expected = new RepoAST({
             commits: commits,
@@ -852,7 +852,7 @@ describe("readRAST", function () {
                 "x/y": new RepoAST.Submodule(baseSubPath,
                                              subHead.id().tostrS()),
             },
-            message: "message",
+            message: "message\n",
         });
         const expected = new RepoAST({
             commits: commits,
@@ -1027,12 +1027,12 @@ describe("readRAST", function () {
         commits[bSha] = new Commit({
             parents: [firstSha],
             changes: { foo: "foo" },
-            message: "message",
+            message: "message\n",
         });
         commits[cSha] = new Commit({
             parents: [firstSha],
             changes: { bar: "bar" },
-            message: "message",
+            message: "message\n",
         });
         commits[mergeSha] = new Commit({
             parents: [cSha, bSha],
@@ -1132,7 +1132,7 @@ describe("readRAST", function () {
                                                  "HEAD",
                                                  sig,
                                                  sig,
-                                                 "message",
+                                                 "message\n",
                                                  id,
                                                  [ masterCommit, whamCommit ]);
         const mergeSha = mergeCommit.tostrS();
@@ -1147,12 +1147,12 @@ describe("readRAST", function () {
         subCommits[fooSha] = new Commit({
             parents: [baseMasterSha],
             changes: { foo: "foo" },
-            message: "message",
+            message: "message\n",
         });
         subCommits[barSha] = new Commit({
             parents: [baseMasterSha],
             changes: { bar: "bar" },
-            message: "message",
+            message: "message\n",
         });
 
         const commits = {};
@@ -1163,22 +1163,22 @@ describe("readRAST", function () {
         commits[subSha] = new Commit({
             parents: [firstSha],
             changes: { "s": new Submodule(basePath, baseMasterSha), },
-            message: "message",
+            message: "message\n",
         });
         commits[whamSha] = new Commit({
             parents: [subSha],
             changes: { "s": new Submodule(basePath, barSha) },
-            message: "message",
+            message: "message\n",
         });
         commits[masterSha] = new Commit({
             parents: [subSha],
             changes: { "s": new Submodule(basePath, fooSha) },
-            message: "message",
+            message: "message\n",
         });
         commits[mergeSha] = new Commit({
             parents: [masterSha, whamSha],
             changes: { "s": new Submodule(basePath, barSha) },
-            message: "message",
+            message: "message\n",
         });
 
         const expected = new RepoAST({
@@ -1284,7 +1284,7 @@ describe("readRAST", function () {
                                                  "HEAD",
                                                  sig,
                                                  sig,
-                                                 "message",
+                                                 "message\n",
                                                  id,
                                                  [ masterCommit, whamCommit ]);
         const mergeSha = mergeCommit.tostrS();
@@ -1299,12 +1299,12 @@ describe("readRAST", function () {
         subCommits[fooSha] = new Commit({
             parents: [baseMasterSha],
             changes: { foo: "foo" },
-            message: "message",
+            message: "message\n",
         });
         subCommits[barSha] = new Commit({
             parents: [baseMasterSha],
             changes: { bar: "bar" },
-            message: "message",
+            message: "message\n",
         });
 
         const commits = {};
@@ -1315,22 +1315,22 @@ describe("readRAST", function () {
         commits[subSha] = new Commit({
             parents: [firstSha],
             changes: { "s": new Submodule(basePath, baseMasterSha), },
-            message: "message",
+            message: "message\n",
         });
         commits[whamSha] = new Commit({
             parents: [subSha],
             changes: { "s": new Submodule(basePath, barSha) },
-            message: "message",
+            message: "message\n",
         });
         commits[masterSha] = new Commit({
             parents: [subSha],
             changes: { "s": new Submodule(basePath, fooSha) },
-            message: "message",
+            message: "message\n",
         });
         commits[mergeSha] = new Commit({
             parents: [masterSha, whamSha],
             changes: {},
-            message: "message",
+            message: "message\n",
         });
 
         const expected = new RepoAST({
@@ -1478,14 +1478,14 @@ describe("readRAST", function () {
             changes: {
                 a: new RepoAST.Submodule(anotherUrl, anotherHeadSha),
             },
-            message: "message",
+            message: "message\n",
         });
         commits[finalSha] = new RepoAST.Commit({
             parents: [nextSha],
             changes: {
                 a: new RepoAST.Submodule(thirdUrl, anotherHeadSha),
             },
-            message: "message",
+            message: "message\n",
         });
         expected = expected.copy({
             branches: {
@@ -1576,7 +1576,7 @@ describe("readRAST", function () {
             changes: {
                 "README.md": "data",
             },
-            message: "message",
+            message: "message\n",
         });
         const ast = yield ReadRepoASTUtil.readRAST(r);
         const headId = yield r.getHeadCommit();
@@ -1612,7 +1612,6 @@ describe("readRAST", function () {
 
         const repo = yield TestUtil.createSimpleRepository();
         const repoPath = repo.workdir();
-        console.log(repoPath);
         const readmePath = path.join(repoPath, "README.md");
         const foobarPath = path.join(repoPath, "foobar");
         const bazPath    = path.join(repoPath, "baz");

--- a/node/test/util/shorthand_parser_util.js
+++ b/node/test/util/shorthand_parser_util.js
@@ -154,7 +154,7 @@ describe("ShorthandParserUtil", function () {
                     "1": new Commit({
                         parents: ["2"],
                         changes: { "1": "1"},
-                        message: "message",
+                        message: "message\n",
                     }),
                 }
             })},
@@ -163,7 +163,7 @@ describe("ShorthandParserUtil", function () {
                     "1": new Commit({
                         parents: ["2"],
                         changes: {},
-                        message: "message",
+                        message: "message\n",
                     }),
                 }
             })},
@@ -174,7 +174,7 @@ describe("ShorthandParserUtil", function () {
                         "1": new Commit({
                             parents: [],
                             changes: { y: "2" },
-                            message: "message",
+                            message: "message\n",
                         }),
                     },
                 }),
@@ -193,7 +193,7 @@ describe("ShorthandParserUtil", function () {
                     "3": new Commit({
                         parents: ["1","2"],
                         changes: { "3": "3"},
-                        message: "message",
+                        message: "message\n",
                     }),
                 },
             })},
@@ -211,7 +211,7 @@ describe("ShorthandParserUtil", function () {
                     "xxx2": new Commit({
                         parents: ["yy"],
                         changes: { "xxx2": "xxx2"},
-                        message: "message",
+                        message: "message\n",
                     }),
                 }
             })},
@@ -220,7 +220,7 @@ describe("ShorthandParserUtil", function () {
                     "1": new Commit({
                         parents: ["2"],
                         changes: { "foo": "bar"},
-                        message: "message",
+                        message: "message\n",
                     }),
                 }
             })},
@@ -229,7 +229,7 @@ describe("ShorthandParserUtil", function () {
                     "1": new Commit({
                         parents: ["2"],
                         changes: { "foo": ""},
-                        message: "message",
+                        message: "message\n",
                     }),
                 }
             })},
@@ -238,7 +238,7 @@ describe("ShorthandParserUtil", function () {
                     "1": new Commit({
                         parents: ["2"],
                         changes: { "foo": "bar", "b": "z"},
-                        message: "message",
+                        message: "message\n",
                     }),
                 }
             })},
@@ -247,7 +247,7 @@ describe("ShorthandParserUtil", function () {
                     "1": new Commit({
                         parents: ["2"],
                         changes: { "foo": "bar", "b": "z"},
-                        message: "message",
+                        message: "message\n",
                     }),
                 }
             })},
@@ -263,7 +263,7 @@ describe("ShorthandParserUtil", function () {
                         "1": new Commit({
                             parents: ["2"],
                             changes: { "1": "1"},
-                            message: "message",
+                            message: "message\n",
                     })},
                     branches: { m: null },
                 }),
@@ -276,7 +276,7 @@ describe("ShorthandParserUtil", function () {
                         "1": new Commit({
                             parents: ["2"],
                             changes: { "1": "1"},
-                            message: "message",
+                            message: "message\n",
                     })},
                     branches: { m: null },
                 }),
@@ -298,12 +298,12 @@ describe("ShorthandParserUtil", function () {
                         "1": new Commit({
                             parents: ["2"],
                             changes: { "1": "1"},
-                            message: "message",
+                            message: "message\n",
                         }),
                         "3": new Commit({
                             parents: ["4"],
                             changes: { "3": "3"},
-                            message: "message",
+                            message: "message\n",
                         }),
                     },
                 }),
@@ -378,7 +378,7 @@ describe("ShorthandParserUtil", function () {
                         "2": new Commit({
                             parents: ["1"],
                             changes: { "baz": new Submodule("/foo.git", "1") },
-                            message: "message",
+                            message: "message\n",
                         }),
                     },
                 }),
@@ -391,7 +391,7 @@ describe("ShorthandParserUtil", function () {
                         "2": new Commit({
                             parents: ["1"],
                             changes: { "baz": new Submodule("o", "1") },
-                            message: "message",
+                            message: "message\n",
                         }),
                     },
                     branches: { master: new RepoAST.Branch("2", null), },
@@ -525,7 +525,7 @@ describe("ShorthandParserUtil", function () {
                         "2": new Commit({
                             parents: ["1"],
                             changes: { "2": "2"},
-                            message: "message",
+                            message: "message\n",
                         }),
                     },
                     notes: {
@@ -543,7 +543,7 @@ describe("ShorthandParserUtil", function () {
                         "2": new Commit({
                             parents: ["1"],
                             changes: { "2": "2"},
-                            message: "message",
+                            message: "message\n",
                         }),
                     },
                     notes: {
@@ -567,7 +567,7 @@ describe("ShorthandParserUtil", function () {
                             changes: {
                                 a: new RepoAST.Submodule("a", "1"),
                             },
-                            message: "message",
+                            message: "message\n",
                         }),
                     },
                     head: "2",
@@ -665,7 +665,7 @@ describe("ShorthandParserUtil", function () {
                             changes: {
                                 "1": "1",
                             },
-                            message: "message",
+                            message: "message\n",
                         }),
                     },
                     head: "1",
@@ -690,7 +690,7 @@ describe("ShorthandParserUtil", function () {
                         "1": B.commits["1"],
                         "2": new Commit({
                             changes: { "2": "2" },
-                            message: "message",
+                            message: "message\n",
                             parents: ["1"],
                         }),
                     },
@@ -736,7 +736,7 @@ describe("ShorthandParserUtil", function () {
                         commits[2] = new Commit({
                             parents: ["1"],
                             changes: { "2": "2"},
-                            message: "message",
+                            message: "message\n",
                         });
                         return commits;
                     })(),
@@ -756,7 +756,7 @@ describe("ShorthandParserUtil", function () {
                         commits[2] = new Commit({
                             parents: ["1"],
                             changes: { "2": "2"},
-                            message: "message",
+                            message: "message\n",
                         });
                         return commits;
                     })(),
@@ -842,7 +842,7 @@ describe("ShorthandParserUtil", function () {
                             "1": B.commits["1"],
                             "2": new Commit({
                                 changes: { "2": "2" },
-                                message: "message",
+                                message: "message\n",
                                 parents: ["1"],
                             }),
                         },
@@ -997,7 +997,7 @@ describe("ShorthandParserUtil", function () {
                                     "2": new Commit({
                                         parents: ["1"],
                                         changes: { "2": "2" },
-                                        message: "message",
+                                        message: "message\n",
                                     }),
                                 },
                                 branches: {
@@ -1051,7 +1051,7 @@ describe("ShorthandParserUtil", function () {
                                 changes: {
                                     s: new Submodule("a","3"),
                                 },
-                                message: "message",
+                                message: "message\n",
                             }),
                         },
                     }),
@@ -1079,7 +1079,7 @@ describe("ShorthandParserUtil", function () {
                                 changes: {
                                     s: new Submodule("a","3"),
                                 },
-                                message: "message",
+                                message: "message\n",
                             }),
                         },
                         openSubmodules: {
@@ -1110,7 +1110,7 @@ describe("ShorthandParserUtil", function () {
                                     "2": new Commit({
                                         parents: ["1"],
                                         changes: { "2": "2" },
-                                        message: "message",
+                                        message: "message\n",
                                     }),
                                 },
                                 branches: {
@@ -1160,7 +1160,7 @@ describe("ShorthandParserUtil", function () {
                                 changes: {
                                     s: new RepoAST.Submodule("a","x"),
                                 },
-                                message: "message",
+                                message: "message\n",
                             }),
                         },
                         branches: {
@@ -1185,7 +1185,7 @@ describe("ShorthandParserUtil", function () {
                             "8": new Commit({
                                 parents: ["1"],
                                 changes: { "8": "8" },
-                                message: "message",
+                                message: "message\n",
                             }),
                         },
                         branches: {
@@ -1222,12 +1222,12 @@ x=S:Efoo,8,9`,
                             "8": new Commit({
                                 parents: ["1"],
                                 changes: { "8": "8" },
-                                message: "message",
+                                message: "message\n",
                             }),
                             "9": new Commit({
                                 parents: ["1"],
                                 changes: { "9": "9" },
-                                message: "message",
+                                message: "message\n",
                             }),
                         },
                         branches: {
@@ -1247,12 +1247,12 @@ x=S:Efoo,8,9`,
                             "8": new Commit({
                                 parents: ["1"],
                                 changes: { "8": "8" },
-                                message: "message",
+                                message: "message\n",
                             }),
                             "9": new Commit({
                                 parents: ["1"],
                                 changes: { "9": "9" },
-                                message: "message",
+                                message: "message\n",
                             }),
                         },
                         rebase: new RepoAST.Rebase("foo", "8", "9"),


### PR DESCRIPTION
I changed the default in the testing framework to reflect this, which
reverbrated through a few test drivers.

Addresses https://github.com/twosigma/git-meta/issues/346