### PR TITLE
Stop populating default interactive commit message

### DIFF
--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -1877,12 +1877,10 @@ exports.doCommitCommand = co.wrap(function *(repo,
         // If 'interactive' mode is requested, ask the user to specify which
         // repos are committed and with what commit messages.
 
-        const head = yield repo.getHeadCommit();
         const sig = repo.defaultSignature();
-        const headMeta = exports.getCommitMetaData(head);
         const prompt = exports.formatSplitCommitEditorPrompt(repoStatus,
                                                              sig,
-                                                             headMeta,
+                                                             null,
                                                              {});
         const userText = yield editMessage(repo, prompt);
         const userData = exports.parseSplitCommitMessages(userText);

--- a/node/test/util/commit.js
+++ b/node/test/util/commit.js
@@ -3028,6 +3028,12 @@ and for d
                 editor: () => Promise.resolve("haha"),
                 expected: "x=S:Chaha\n#x-1 a=b;Bmaster=x",
             },
+            "interactive meta commit, but do nothing": {
+                initial: "x=S:I a=b",
+                interactive: true,
+                editor: (_, content) => Promise.resolve(content),
+                fails: true,
+            },
             "no all": {
                 initial: "x=S:W README.md=2",
             },


### PR DESCRIPTION
We were showing the message from the previous commit when it should have
been blank.