### PR TITLE
in hooks, true means reject; update function names and fix bug for non-heads

### DIFF
--- a/node/lib/util/synthetic_branch_util.js
+++ b/node/lib/util/synthetic_branch_util.js
@@ -247,13 +247,14 @@ function* checkUpdate(repo, oldSha, newSha, handled) {
  * @async
  * @param {NodeGit.Repostory} repo The meta repository
  * @param [{Object}] updates. Each object has fields oldSha, newSha, and ref,
+*  @return true if the update should be rejected.
  * all strings.
  */
-function* metaUpdateCheck(repo, updates) {
+function* metaUpdateIsBad(repo, updates) {
     const handled = {};
     const checkFailures = updates.map(function*(update) {
         if (!update.ref.startsWith("refs/heads/")) {
-            return true;
+            return false;
         }
         const ok = yield checkUpdate(repo, update.oldSha, update.newSha,
                                      handled);
@@ -277,8 +278,9 @@ function* metaUpdateCheck(repo, updates) {
  * @param {NodeGit.Repostory} repo The meta repository
  * @param [{Object}] updates. Each object has fields oldSha, newSha, and ref,
  * all strings.
+ * @return true if the submodule update should be rejected
  */
-function* submoduleCheck(repo, updates) {
+function* submoduleIsBad(repo, updates) {
     const checkFailures = updates.map(function*(update) {
         /*jshint noyield:true*/
         if (!update.ref.startsWith(SYNTHETIC_BRANCH_BASE)) {
@@ -343,10 +345,10 @@ function doPreReceive(check) {
     });
 }
 
-exports.metaPreReceive = doPreReceive.bind(null, metaUpdateCheck);
-exports.submodulePreReceive = doPreReceive.bind(null, submoduleCheck);
+exports.metaPreReceive = doPreReceive.bind(null, metaUpdateIsBad);
+exports.submodulePreReceive = doPreReceive.bind(null, submoduleIsBad);
 
 exports.checkUpdate = co.wrap(checkUpdate);
-exports.submoduleCheck = co.wrap(submoduleCheck);
-exports.metaUpdateCheck = co.wrap(metaUpdateCheck);
+exports.submoduleIsBad = co.wrap(submoduleIsBad);
+exports.metaUpdateIsBad = co.wrap(metaUpdateIsBad);
 exports.initAltOdb = co.wrap(initAltOdb);

--- a/node/test/util/synthetic-branch.js
+++ b/node/test/util/synthetic-branch.js
@@ -198,11 +198,11 @@ describe("synthetic-branch-submodule-pre-receive", function () {
         const oid = yield createCommit(repo, addFile);
 
         // an empty push succeeds
-        let fail = yield SyntheticBranch.submoduleCheck(repo, []);
+        let fail = yield SyntheticBranch.submoduleIsBad(repo, []);
         assert(!fail);
 
         // a push with f to a correct branch succeeds
-        fail = yield SyntheticBranch.submoduleCheck(repo, [{
+        fail = yield SyntheticBranch.submoduleIsBad(repo, [{
             oldSha: "0000000000000000000000000000000000000000",
             newSha: oid.toString(),
             ref: "refs/commits/" + oid.toString(),
@@ -210,7 +210,7 @@ describe("synthetic-branch-submodule-pre-receive", function () {
         assert(!fail);
 
         // a push with f to a bogus branch fails
-        fail = yield SyntheticBranch.submoduleCheck(repo, [{
+        fail = yield SyntheticBranch.submoduleIsBad(repo, [{
             oldSha: "0000000000000000000000000000000000000000",
             newSha: oid.toString(),
             ref: "refs/commits/0000000000000000000000000000000000000000",


### PR DESCRIPTION
This function lacked documentation and was confusingly designed.  I haven't fully fixed the design, since I think I did it due to some node weirdness, but I've given it a name which matches its function and added doco.