### PR TITLE
Optimized getSubmoduleChanges

### DIFF
--- a/node/lib/util/cherrypick.js
+++ b/node/lib/util/cherrypick.js
@@ -129,7 +129,7 @@ ${colors.green(commitSha)}.`);
 
     // Cherry-pick each submodule changed in `commit`.
 
-    changes.changed.forEach(subName => {
+    Object.keys(changes.changed).forEach(subName => {
         const headSub = headSubs[subName];
         const commitSub = commitSubs[subName];
         const headSha = headSub.sha;

--- a/node/lib/util/synthetic_branch_util.js
+++ b/node/lib/util/synthetic_branch_util.js
@@ -134,9 +134,12 @@ function* checkSubmodules(repo, commit) {
                                                                   commit);
     const getChanges = SubmoduleUtil.getSubmoduleChanges;
     const changes = yield getChanges(repo, commit);
-    const allChanges = [changes.added, changes.changed];
+    const allChanges = [
+        Object.keys(changes.added),
+        Object.keys(changes.changed)
+    ];
     const result = allChanges.map(function *(changeSet) {
-        const result = Array.from(changeSet).map(function *(path) {
+        const result = changeSet.map(function *(path) {
             const entry = yield commit.getEntry(path);
             const submodulePath = entry.path();
             const url = submodules[submodulePath].url;


### PR DESCRIPTION
Now computes via `NodeGit.Diff`, which should be much faster than doing
it "by hand".