### PR TITLE
Speedup `getRepoStatus` and clients.

### DIFF
--- a/node/lib/cmd/commit.js
+++ b/node/lib/cmd/commit.js
@@ -68,14 +68,6 @@ exports.configureParser = function (parser) {
         required: false,
         help: "commit message; if not specified will prompt"
     });
-    parser.addArgument(["--meta"], {
-        required: false,
-        action: "storeConst",
-        constant: true,
-        help: `
-Include changes to the meta-repo; disabled by default to prevent mistakes.`,
-        defaultValue: false,
-    });
     parser.addArgument(["--amend"], {
         required: false,
         action: "storeConst",
@@ -123,7 +115,6 @@ const doCommit = co.wrap(function *(args) {
     yield Commit.doCommitCommand(repo,
                                  cwd,
                                  args.message,
-                                 args.meta,
                                  args.all,
                                  args.file,
                                  args.interactive,
@@ -146,7 +137,6 @@ const doAmend = co.wrap(function *(args) {
     yield Commit.doAmendCommand(repo,
                                 process.cwd(),
                                 args.message,
-                                args.meta,
                                 args.all,
                                 args.interactive,
                                 args.no_edit ? null : GitUtil.editMessage);

--- a/node/lib/cmd/status.js
+++ b/node/lib/cmd/status.js
@@ -90,12 +90,10 @@ exports.executeableSubcommand = co.wrap(function *(args) {
     const repo = yield GitUtil.getCurrentRepo();
     const workdir = repo.workdir();
     const cwd = process.cwd();
-    const paths = yield args.path.map(filename => {
-        return GitUtil.resolveRelativePath(workdir, cwd, filename);
-    });
     const repoStatus = yield StatusUtil.getRepoStatus(repo, {
         showMetaChanges: args.meta,
-        paths: paths,
+        cwd: cwd,
+        paths: args.path,
     });
 
     // Compute the current directory relative to the working directory of the

--- a/node/lib/util/cherrypick.js
+++ b/node/lib/util/cherrypick.js
@@ -129,13 +129,16 @@ ${colors.green(commitSha)}.`);
 
     // Cherry-pick each submodule changed in `commit`.
 
-    Object.keys(changes.changed).forEach(subName => {
-        const headSub = headSubs[subName];
-        const commitSub = commitSubs[subName];
-        const headSha = headSub.sha;
-        if (undefined !== commitSub &&
-            headSha !== commitSub.sha) {
-            pickers.push(picker(subName, headSha, commitSub.sha));
+    Object.keys(changes).forEach(subName => {
+        const change = changes[subName];
+        if (null !== change.oldSha && null !== change.newSha) {
+            const headSub = headSubs[subName];
+            const commitSub = commitSubs[subName];
+            const headSha = headSub.sha;
+            if (undefined !== commitSub &&
+                headSha !== commitSub.sha) {
+                pickers.push(picker(subName, headSha, commitSub.sha));
+            }
         }
     });
 

--- a/node/lib/util/submodule_change.js
+++ b/node/lib/util/submodule_change.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert  = require("chai").assert;
+
+/**
+ * @class SubmoduleChanges.Change
+ *
+ * This class represents a sha change to a submodule.
+ */
+class SubmoduleChange {
+
+    /**
+     * Creat a new `Changed` object having the specified `oldSha` and `newSha`
+     * values.  The behavior is undefined if `oldSha === newSha`.  Note that a
+     * null `oldSha` implies that the submodule was added, a null `newSha`
+     * implies that it was removed, and if neither is null, the submodule was
+     * changed.
+     *
+     * @param {String | null} oldSha
+     * @param {String | null} newSha
+     */
+    constructor(oldSha, newSha) {
+        assert.notEqual(oldSha, newSha);
+        if (null !== oldSha) {
+            assert.isString(oldSha);
+        }
+        if (null !== newSha) {
+            assert.isString(newSha);
+        }
+        this.d_oldSha = oldSha;
+        this.d_newSha = newSha;
+        Object.freeze(this);
+    }
+
+    /**
+     * This property represents the previous value of the sha for a submodule
+     * change.  If this value is null, then the submodule was added.
+     *
+     * @property {String | null} oldSha
+     */
+    get oldSha() {
+        return this.d_oldSha;
+    }
+
+    /**
+     * This property represents the new value of a sha for a submodule.  If it
+     * is null, then the submodule was removed.
+     *
+     * @property {String | null} newSha
+     */
+    get newSha() {
+        return this.d_newSha;
+    }
+}
+
+module.exports = SubmoduleChange;

--- a/node/lib/util/synthetic_branch_util.js
+++ b/node/lib/util/synthetic_branch_util.js
@@ -135,8 +135,14 @@ function* checkSubmodules(repo, commit) {
     const getChanges = SubmoduleUtil.getSubmoduleChanges;
     const changes = yield getChanges(repo, commit);
     const allChanges = [
-        Object.keys(changes.added),
-        Object.keys(changes.changed)
+        Object.keys(changes).filter(changeName => {
+            const change = changes[changeName];
+            return null === change.oldSha;
+        }),
+        Object.keys(changes).filter(changeName => {
+            const change = changes[changeName];
+            return null !== change.oldSha && null !== change.newSha;
+        }),
     ];
     const result = allChanges.map(function *(changeSet) {
         const result = changeSet.map(function *(path) {

--- a/node/test/util/print_status_util.js
+++ b/node/test/util/print_status_util.js
@@ -794,15 +794,17 @@ Changes to be committed:
     describe("printSubmoduleStatus", function () {
         const cases = {
             "empty show closed": {
-                status: new RepoStatus(),
                 relCwd: "",
+                subsToPrint: {},
+                openSubs: new Set(),
                 showClosed: true,
                 expected: `\
 ${colors.grey("All submodules:")}
 `,
             },
             "empty no show closed": {
-                status: new RepoStatus(),
+                subsToPrint: {},
+                openSubs: new Set(),
                 relCwd: "",
                 showClosed: false,
                 expected: `\
@@ -810,14 +812,8 @@ ${colors.grey("Open submodules:")}
 `,
             },
             "a closed sub, not shown": {
-                status: new RepoStatus({
-                    submodules: {
-                        foo: new Submodule({
-                            commit: new Commit("1", "/a"),
-                            index: new Index("1", "/a", RELATION.SAME),
-                        }),
-                    },
-                }),
+                subsToPrint: { foo: "1", },
+                openSubs: new Set(),
                 relCwd: "",
                 showClosed: false,
                 expected: `\
@@ -825,14 +821,8 @@ ${colors.grey("Open submodules:")}
 `,
             },
             "a closed sub, shown": {
-                status: new RepoStatus({
-                    submodules: {
-                        foo: new Submodule({
-                            commit: new Commit("1", "/a"),
-                            index: new Index("1", "/a", RELATION.SAME),
-                        }),
-                    },
-                }),
+                subsToPrint: { foo: "1", },
+                openSubs: new Set(),
                 relCwd: "",
                 showClosed: true,
                 expected: `\
@@ -841,17 +831,10 @@ ${colors.grey("All submodules:")}
 `,
             },
             "an open sub": {
-                status: new RepoStatus({
-                    submodules: {
-                        bar: new Submodule({
-                            commit: new Commit("1", "/a"),
-                            index: new Index("1", "/a", RELATION.SAME),
-                            workdir: new Workdir(new RepoStatus({
-                                headCommit: "1",
-                            }), RELATION.SAME),
-                        }),
-                    },
-                }),
+                subsToPrint: {
+                    bar: "1",
+                },
+                openSubs: new Set(["bar"]),
                 relCwd: "",
                 showClosed: true,
                 expected: `\
@@ -860,21 +843,11 @@ ${colors.grey("All submodules:")}
 `,
             },
             "an open sub and closed": {
-                status: new RepoStatus({
-                    submodules: {
-                        foo: new Submodule({
-                            commit: new Commit("1", "/a"),
-                            index: new Index("1", "/a", RELATION.SAME),
-                        }),
-                        bar: new Submodule({
-                            commit: new Commit("1", "/a"),
-                            index: new Index("1", "/a", RELATION.SAME),
-                            workdir: new Workdir(new RepoStatus({
-                                headCommit: "1",
-                            }), RELATION.SAME),
-                        }),
-                    },
-                }),
+                subsToPrint: {
+                    foo: "1",
+                    bar: "1",
+                },
+                openSubs: new Set(["bar"]),
                 relCwd: "",
                 showClosed: true,
                 expected: `\
@@ -884,17 +857,8 @@ ${colors.grey("All submodules:")}
 `,
             },
             "with relative workdir": {
-                status: new RepoStatus({
-                    submodules: {
-                        bar: new Submodule({
-                            commit: new Commit("1", "/a"),
-                            index: new Index("1", "/a", RELATION.SAME),
-                            workdir: new Workdir(new RepoStatus({
-                                headCommit: "1",
-                            }), RELATION.SAME),
-                        }),
-                    },
-                }),
+                subsToPrint: { bar: "1", },
+                openSubs: new Set(["bar"]),
                 relCwd: "q",
                 showClosed: true,
                 expected: `\
@@ -903,14 +867,8 @@ ${colors.grey("All submodules:")}
 `,
             },
             "deleted": {
-                status: new RepoStatus({
-                    submodules: {
-                        bar: new Submodule({
-                            commit: new Commit("1", "/a"),
-                            index: null,
-                        }),
-                    },
-                }),
+                subsToPrint: { bar: null },
+                openSubs: new Set(),
                 relCwd: "",
                 showClosed: true,
                 expected: `\
@@ -923,8 +881,9 @@ ${colors.grey("All submodules:")}
             const c = cases[caseName];
             it(caseName, function () {
                 const result = PrintStatusUtil.printSubmoduleStatus(
-                                                                 c.status,
                                                                  c.relCwd,
+                                                                 c.subsToPrint,
+                                                                 c.openSubs,
                                                                  c.showClosed);
                 const resultLines = result.split("\n");
                 const expectedLines = c.expected.split("\n");

--- a/node/test/util/stash_util.js
+++ b/node/test/util/stash_util.js
@@ -153,7 +153,9 @@ x=E:Ci#i foo=bar,1=1;Cw#w foo=bar,1=1;Bi=i;Bw=w`,
             it(caseName, co.wrap(function *() {
                 const stasher = co.wrap(function *(repos) {
                     const repo = repos.x;
-                    const status = yield StatusUtil.getRepoStatus(repo);
+                    const status = yield StatusUtil.getRepoStatus(repo, {
+                        showMetaChanges: true,
+                    });
                     const includeUntracked = c.includeUntracked || false;
                     const result = yield StashUtil.stashRepo(repo,
                                                              status,

--- a/node/test/util/submodule_change.js
+++ b/node/test/util/submodule_change.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert  = require("chai").assert;
+
+const SubmoduleChange = require("../../lib/util/submodule_change");
+
+describe("SubmoduleChange", function () {
+    it("breathing", function () {
+        const change = new SubmoduleChange("old", "new");
+        assert.equal(change.oldSha, "old");
+        assert.equal(change.newSha, "new");
+    });
+});


### PR DESCRIPTION
The status functions are only supposed to report changed/interesting
things, but it was loading a `RepoAST.Submodule` object for each
submodule, even those not open and unchanged.  Now, it will process open
submodules and those with changes between the index and last commit.
The latter information will be determined via `DiffUtil`.

This change propagated through several clients of `getRepoStatus` who
assumed that the `submodules` property of the returned `RepoStatus`
object contained *all* current submodules.  Now it contains only the
interesting (changed or open) submodules.