### PR TITLE
Fix "nothing to pop" test case

### DIFF
--- a/node/test/util/stash_util.js
+++ b/node/test/util/stash_util.js
@@ -558,6 +558,7 @@ x=E:Os Bss=ss!
         const cases = {
             "nothing to pop": {
                 init: "x=S",
+                fails: true,
             },
             "failed": {
                 init: `


### PR DESCRIPTION
Previously it was warning but not throwing an exception; now it is, but
I forgot to update the test driver.