### PR TITLE
Rewrote merge

### DIFF
--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -61,9 +61,10 @@ const UserError           = require("./user_error");
  *
  * @param {String} message
  */
-function ensureEolOnLastLine(message) {
+exports.ensureEolOnLastLine = function (message) {
+    // TODO: test independently
     return message.endsWith("\n") ? message : (message + "\n");
-}
+};
 
 /**
  * Return the `NodeGit.Tree` object for the (left) parent of the head commit
@@ -229,10 +230,11 @@ const commitRepo = co.wrap(function *(repo,
         yield index.write();
     }
     if (doCommit) {
-        return yield repo.createCommitOnHead([],
-                                             signature,
-                                             signature,
-                                             ensureEolOnLastLine(message));
+        return yield repo.createCommitOnHead(
+                                         [],
+                                         signature,
+                                         signature,
+                                         exports.ensureEolOnLastLine(message));
     }
     return null;
 });
@@ -611,15 +613,16 @@ exports.writeRepoPaths = co.wrap(function *(repo, status, message) {
 
     const sig = repo.defaultSignature();
     const parents = [headCommit];
-    const commitId = yield NodeGit.Commit.create(repo,
-                                                 0,
-                                                 sig,
-                                                 sig,
-                                                 0,
-                                                 ensureEolOnLastLine(message),
-                                                 tree,
-                                                 parents.length,
-                                                 parents);
+    const commitId = yield NodeGit.Commit.create(
+                                          repo,
+                                          0,
+                                          sig,
+                                          sig,
+                                          0,
+                                          exports.ensureEolOnLastLine(message),
+                                          tree,
+                                          parents.length,
+                                          parents);
 
     // Now we need to put the commit on head.  We need to unstage the changes
     // we've just committed, otherwise we see conflicts with the workdir.  We
@@ -998,7 +1001,7 @@ exports.amendRepo = co.wrap(function *(repo, message) {
     const index = yield repo.index();
     const treeId = yield index.writeTree();
     const tree = yield NodeGit.Tree.lookup(repo, treeId);
-    const termedMessage = ensureEolOnLastLine(message);
+    const termedMessage = exports.ensureEolOnLastLine(message);
     const id = yield head.amend("HEAD", null, null, null, termedMessage, tree);
     return id.tostrS();
 });

--- a/node/lib/util/merge_file_util.js
+++ b/node/lib/util/merge_file_util.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2017, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert = require("chai").assert;
+const co     = require("co");
+const fs     = require("fs-promise");
+const path   = require("path");
+const rimraf = require("rimraf");
+
+const Merge = require("./merge");
+
+/**
+ * This module contains methods for accessing files that pertain to in-progress
+ * merges.
+ */
+
+const metaMergeDir = "META_MERGE";
+const messageFile = "MSG";
+const originalHeadFile = "ORIG_HEAD";
+const mergeHeadFile = "MERGE_HEAD";
+
+/**
+ * Return the `Merge` object in the specified `gitDir`, if one exists, or null
+ * if there is no merge in progress.
+ *
+ * @param {String} gitDir
+ * @return {String|null}
+ */
+exports.readMerge = co.wrap(function *(gitDir) {
+    assert.isString(gitDir);
+    let message;
+    let originalHead;
+    let mergeHead;
+    const root = path.join(gitDir, metaMergeDir);
+    try {
+        message = yield fs.readFile(path.join(root, messageFile),
+                                    "utf8");
+        originalHead = yield fs.readFile(path.join(root, originalHeadFile),
+                                         "utf8");
+        mergeHead = yield fs.readFile(path.join(root, mergeHeadFile), "utf8");
+    }
+    catch (e) {
+        return null;
+    }
+    return new Merge(message,
+                     originalHead.split("\n")[0],
+                     mergeHead.split("\n")[0]);
+});
+
+/**
+ * Write the specified `merge` to the specified `gitDir`.  The behavior is
+ * undefined if there is already a merge recorded in `gitDir`.
+ *
+ * @param {String} gitDir
+ * @param {Merge}  merge
+ */
+exports.writeMerge = co.wrap(function *(gitDir, merge) {
+    assert.isString(gitDir);
+    assert.instanceOf(merge, Merge);
+
+    const root = path.join(gitDir, metaMergeDir);
+    yield fs.mkdir(root);
+    yield fs.writeFile(path.join(root, "MSG"), merge.message);
+    yield fs.writeFile(path.join(root, "ORIG_HEAD"),
+                       merge.originalHead + "\n");
+    yield fs.writeFile(path.join(root, "MERGE_HEAD"),
+                       merge.mergeHead + "\n");
+});
+
+/**
+ * Remove files related to a meta merge.
+ *
+ * @param {String} gitDir
+ */
+exports.cleanMerge = co.wrap(function *(gitDir) {
+    assert.isString(gitDir);
+    const root = path.join(gitDir, metaMergeDir);
+    const promise = new Promise(callback => {
+        return rimraf(root, {}, callback);
+    });
+    yield promise;
+});

--- a/node/lib/util/merge_util.js
+++ b/node/lib/util/merge_util.js
@@ -1,0 +1,623 @@
+/*
+ * Copyright (c) 2017, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert       = require("chai").assert;
+const ChildProcess = require("child-process-promise");
+const co           = require("co");
+const colors       = require("colors");
+const NodeGit      = require("nodegit");
+
+const Checkout            = require("./checkout");
+const Commit              = require("./commit");
+const DeinitUtil          = require("./deinit_util");
+const DoWorkQueue         = require("./do_work_queue");
+const GitUtil             = require("./git_util");
+const Merge               = require("./merge");
+const MergeFileUtil       = require("./merge_file_util");
+const Open                = require("./open");
+const RepoStatus          = require("./repo_status");
+const StatusUtil          = require("./status_util");
+const SubmoduleConfigUtil = require("./submodule_config_util");
+const SubmoduleUtil       = require("./submodule_util");
+const UserError           = require("./user_error");
+
+/**
+ * @enum {MODE}
+ * Flags to describe what type of merge to do.
+ */
+const MODE = {
+    NORMAL      : 0,  // will do a fast-forward merge when possible
+    FF_ONLY     : 1,  // will fail unless fast-forward merge is possible
+    FORCE_COMMIT: 2,  // will generate merge commit even could fast-forward
+};
+
+exports.MODE = MODE;
+
+/**
+ * Perform a fast-forward merge in the specified `repo` to the specified
+ * `commit`.  If `MODE.FORCE_COMMIT === mode`, generate a merge commit.  When
+ * generating a merge commit, use the optionally specified `message`.  The
+ * behavior is undefined unless `commit` is different from but descendant of
+ * the HEAD commit in `repo`.  If a commit is generated, return its sha;
+ * otherwise, return null.
+ *
+ * @param {NodeGit.Repository}    repo
+ * @param {MODE}                  mode
+ * @param {NodeGit.Commit}        commit
+ * @param {String|null}           message
+ * @return {String|null}
+ */
+exports.fastForwardMerge = co.wrap(function *(repo, mode, commit, message) {
+    assert.instanceOf(repo, NodeGit.Repository);
+    assert.isNumber(mode);
+    assert.instanceOf(commit, NodeGit.Commit);
+    assert.isString(message);
+
+    // Remember the current branch; the checkoutCommit function will move it.
+
+    const branch = yield repo.getCurrentBranch();
+    let result = null;
+    let newHead;
+    if (MODE.FORCE_COMMIT !== mode) {
+        // If we're not generating a commit, we just need to checkout the one
+        // we're fast-forwarding to.
+
+        yield Checkout.checkoutCommit(repo, commit, false);
+        newHead = commit;
+    }
+    else {
+        // Checkout the commit we're fast-forwarding to.
+
+        const head = yield repo.getHeadCommit();
+        yield Checkout.checkoutCommit(repo, commit, false);
+
+        // Then, generate a new commit that has the previous HEAD and commit to
+        // merge as children.
+
+        const sig = repo.defaultSignature();
+        const tree = yield commit.getTree();
+        const id = yield NodeGit.Commit.create(
+                                           repo,
+                                           0,
+                                           sig,
+                                           sig,
+                                           null,
+                                           Commit.ensureEolOnLastLine(message),
+                                           tree,
+                                           2,
+                                           [head, commit]);
+        newHead = yield repo.getCommit(id);
+        result = newHead.id().tostrS();
+
+        // Move HEAD to point to the new commit.
+
+        yield NodeGit.Reset.reset(repo,
+                                  newHead,
+                                  NodeGit.Reset.TYPE.HARD,
+                                  null,
+                                  branch.name());
+    }
+
+    // If we were on a branch, make it current again.
+
+    if (branch.isBranch()) {
+        yield branch.setTarget(newHead, "ffwd merge");
+        yield repo.setHead(branch.name());
+    }
+    return result;
+});
+
+/**
+ * Merge the specified `commit` in the specified `repo` having the specified
+ * `status`, using the specified `mode` to control whether or not a merge
+ * commit will be generated.  Return `null` if the repository is up-to-date, or
+ * an object describing generated commits otherwise.  If the optionally
+ * specified `commitMessage` is provided, use it as the commit message for any
+ * generated merge commit; otherwise, use the specified `editMessage` promise
+ * to request a message.  Throw a `UserError` exception if a fast-forward merge
+ * is requested and cannot be completed.  Throw a `UserError` if there are
+ * conflicts, or if local modifications prevent the merge from happening.
+ *
+ * @async
+ * @param {NodeGit.Repository} repo
+ * @param {NodeGit.Commit}     commit
+ * @param {MODE}               mode
+ * @param {String|null}        commitMessage
+ * @param {() -> Promise(String)} editMessage
+ * @return {Object|null}
+ * @return {String} return.metaCommit
+ * @return {Object} return.submoduleCommits  map from submodule to commit
+ */
+exports.merge = co.wrap(function *(repo,
+                                   commit,
+                                   mode,
+                                   commitMessage,
+                                   editMessage) {
+    assert.instanceOf(repo, NodeGit.Repository);
+    assert.isNumber(mode);
+    assert.instanceOf(commit, NodeGit.Commit);
+    if (null !== commitMessage) {
+        assert.isString(commitMessage);
+    }
+    assert.isFunction(editMessage);
+
+    const status = yield StatusUtil.getRepoStatus(repo, {
+        showMetaChanges: true,
+    });
+
+    // Cannot merge if there is an existing merge
+
+    if (null !== status.merge) {
+        throw new UserError(`\
+There is an existing merge in progress.  Run 'git meta merge --continue'
+to complete it, or 'git meta merge --abort' to abandon it.
+`);
+    }
+
+    // Cannot merge if any staged changes.
+
+    if (!status.isIndexDeepClean()) {
+        throw new UserError("Cannot merge due to staged changes.");
+    }
+
+    const result = {
+        metaCommit: null,
+        submoduleCommits: {},
+    };
+
+    const commitSha = commit.id().tostrS();
+
+    const head = yield repo.getHeadCommit();
+
+    if (head.id().tostrS() === commit.id().tostrS()) {
+        console.log("Nothing to do.");
+        return null;                                                  // RETURN
+    }
+
+    const canFF = yield NodeGit.Graph.descendantOf(repo,
+                                                   commitSha,
+                                                   head.id().tostrS());
+
+    let message = "";
+
+    if (!canFF || MODE.FORCE_COMMIT === mode) {
+        if (null === commitMessage) {
+            const raw = yield editMessage();
+            message = GitUtil.stripMessage(raw);
+            if ("" === message) {
+                console.log("Empty commit message.");
+                return result;
+            }
+        }
+        else {
+            message = commitMessage;
+        }
+    }
+
+    if (MODE.FF_ONLY === mode && !canFF) {
+        throw new UserError(`The meta-repository cannot be fast-forwarded to \
+${colors.red(commitSha)}.`);
+    }
+    else if (canFF) {
+        console.log(`Fast-forwarding meta-repo to ${colors.green(commitSha)}.`);
+
+
+        const sha = yield exports.fastForwardMerge(repo,
+                                                   mode,
+                                                   commit,
+                                                   message);
+        result.metaCommit = sha;
+        return result;
+    }
+
+
+    const sig = repo.defaultSignature();
+
+    // Kick off the merge.  It is important to note is that `Merge.commit` does
+    // not directly modify the working directory or index.  The `index`
+    // object it returns is magical, virtual, does not operate on HEAD or
+    // anything, has no effect.
+
+    const mergeIndex = yield SubmoduleUtil.cacheSubmodules(repo, () => {
+        return NodeGit.Merge.commits(repo, head, commit, null);
+    });
+
+    const checkoutOpts =  {
+        checkoutStrategy: NodeGit.Checkout.STRATEGY.FORCE
+    };
+    yield SubmoduleUtil.cacheSubmodules(repo, () => {
+        return NodeGit.Checkout.index(repo, mergeIndex, checkoutOpts);
+    });
+    const index = yield repo.index();
+
+    let errorMessage = "";
+
+    const subCommits = result.submoduleCommits;
+    const subUrls = yield SubmoduleConfigUtil.getSubmodulesFromCommit(repo,
+                                                                      head);
+    const headTree = yield head.getTree();
+    const opener = new Open.Opener(repo, null);
+    const subFetcher = yield opener.fetcher();
+
+    let hasModulesFile = false;
+
+    const mergeEntry = co.wrap(function *(entry) {
+        const path = entry.path;
+        const stage = RepoStatus.getStage(entry.flags);
+
+        if (path === SubmoduleConfigUtil.modulesFileName) {
+            hasModulesFile = true;
+            return;                                                   // RETURN
+        }
+
+        else if (RepoStatus.STAGE.THEIRS === stage && !(path in subUrls)) {
+            errorMessage += `Conflict in ${colors.red(path)}`;
+            return;                                                   // RETURN
+        }
+
+        // We don't need to do anything with an entry unless it is a conflicted
+        // submodule.
+
+        if (RepoStatus.STAGE.THEIRS !== stage || !(path in subUrls)) {
+            return;                                                   // RETURN
+        }
+
+        // Otherwise, we have a submodule that needs to be merged.
+
+        const subSha = entry.id.tostrS();
+        const subCommitId = NodeGit.Oid.fromString(subSha);
+        const subEntry = yield headTree.entryByPath(path);
+        const subHeadSha = subEntry.sha();
+        const subCommitSha = subCommitId.tostrS();
+        const subRepo = yield opener.getSubrepo(path);
+
+        // Fetch commit to merge.
+
+        yield subFetcher.fetchSha(subRepo, path, subSha);
+
+        const subCommit = yield subRepo.getCommit(subCommitId);
+
+        const upToDate = yield NodeGit.Graph.descendantOf(subRepo,
+                                                          subHeadSha,
+                                                          subCommitSha);
+        if (upToDate) {
+            yield index.addByPath(path);
+            return;                                                   // RETURN
+        }
+
+        // If we can fast-forward, we don't need to do a merge.
+
+        const canSubFF = yield NodeGit.Graph.descendantOf(subRepo,
+                                                          subCommitSha,
+                                                          subHeadSha);
+        if (canSubFF) {
+            console.log(`Submodule ${colors.blue(path)}: fast-forward to \
+${colors.green(subCommitSha)}.`);
+            yield NodeGit.Reset.reset(subRepo,
+                                      subCommit,
+                                      NodeGit.Reset.TYPE.HARD);
+            yield index.addByPath(path);
+            return;                                                   // RETURN
+        }
+
+        // If we already have the commit being merged in, we don't need to do
+        // anything.
+
+        console.log(`Submodule ${colors.blue(path)}: merging commit \
+${colors.green(subCommitSha)}.`);
+
+        // Start the merge.
+
+        const subHead = yield subRepo.getCommit(subHeadSha);
+        let subIndex = yield NodeGit.Merge.commits(subRepo,
+                                                   subHead,
+                                                   subCommit,
+                                                   null);
+
+        yield NodeGit.Checkout.index(subRepo, subIndex, {
+            checkoutStrategy: NodeGit.Checkout.STRATEGY.FORCE,
+        });
+
+        // Abort if conflicted.
+
+        if (subIndex.hasConflicts()) {
+            const merge = new Merge(message,
+                                    subHead.id().tostrS(),
+                                    subCommit.id().tostrS());
+            yield MergeFileUtil.writeMerge(subRepo.path(), merge);
+
+            errorMessage += `Submodule ${colors.red(path)} is conflicted:\n`;
+            const entries = subIndex.entries();
+            for (let i = 0; i < entries.length; ++i) {
+                const subEntry = entries[i];
+                const subStage = RepoStatus.getStage(subEntry.flags);
+                if (RepoStatus.STAGE.OURS === subStage) {
+                    errorMessage += `\t${colors.red(subEntry.path)}\n`;
+                }
+            }
+            return;                                                   // RETURN
+        }
+
+        // Otherwise, finish off the merge.
+
+        subIndex = yield subRepo.index();
+        const treeId = yield subIndex.writeTreeTo(subRepo);
+        const mergeCommit = yield subRepo.createCommit("HEAD",
+                                                       sig,
+                                                       sig,
+                                                       message,
+                                                       treeId,
+                                                       [subHead, subCommit]);
+        subCommits[path] = mergeCommit.tostrS();
+
+        // And add this sub-repo to the list of sub-repos that need to be added
+        // to the index later.
+
+        yield index.addByPath(path);
+    });
+
+    const entries = index.entries();
+    yield DoWorkQueue.doInParallel(entries, mergeEntry, 30);
+
+    if (hasModulesFile) {
+        const good = yield SubmoduleUtil.mergeModulesFile(repo, head, commit);
+        if (!good) {
+            errorMessage += `Conflicting submodule additions/removals.`;
+        }
+        else {
+            yield index.addByPath(SubmoduleConfigUtil.modulesFileName);
+        }
+    }
+
+    // We must write the index here or the staging we've done erlier will go
+    // away.
+    yield index.write();
+
+    if ("" !== errorMessage) {
+        // We're about to fail due to conflict.  First, record that there is a
+        // merge in progress so that we can continue or abort it later.
+
+        const merge = new Merge(message,
+                                head.id().tostrS(),
+                                commit.id().tostrS());
+        yield MergeFileUtil.writeMerge(repo.path(), merge);
+        throw new UserError(errorMessage);
+    }
+
+    // If we've made it here, it means there are no "real" conflicts, but we
+    // need to clean up the index anyway or it won't let us write a tree.
+
+    yield index.conflictCleanup();
+
+    console.log(`Merging meta-repo commit ${colors.green(commitSha)}.`);
+
+    const id = yield index.writeTreeTo(repo);
+
+    // And finally, commit it.
+
+    const metaCommit = yield repo.createCommit("HEAD",
+                                               sig,
+                                               sig,
+                                               message,
+                                               id,
+                                               [head, commit]);
+
+    result.metaCommit = metaCommit.tostrS();
+
+    // Close subs that were opened if no commits were generated to them.
+
+    const closeSub = co.wrap(function *(path) {
+        if (!(path in subCommits)) {
+            console.log(`Closing ${colors.green(path)} -- no commit created.`);
+            yield DeinitUtil.deinit(repo, path);
+        }
+    });
+    const opened = Array.from(yield opener.getOpenedSubs());
+    DoWorkQueue.doInParallel(opened, closeSub, 30);
+    return result;
+});
+
+/**
+ * Throw a `UserError` if the specified `index` has non-submodule conflicts and
+ * do nothing otherwise.
+ *
+ * @param {NodeGit.Index} index
+ */
+const checkForConflicts = function (index) {
+    assert.instanceOf(index, NodeGit.Index);
+    const entries = index.entries();
+    for (let i = 0; i < entries.length; ++i) {
+        const entry = entries[i];
+        const stage = RepoStatus.getStage(entry.flags);
+        if (RepoStatus.STAGE.OURS === stage &&
+            NodeGit.TreeEntry.FILEMODE.COMMIT !== entry.mode) {
+            throw new UserError("Meta-repo has conflicts.");
+        }
+    }
+};
+
+/**
+ * Continue the merge in the specified `repo`.  Throw a `UserError` if there is
+ * no merge in progress in `repo` or if `repo` still has outstanding conflicts.
+ * Return an object describing generated commits.
+ *
+ * @param {NodeGit.Repository} repo
+ * @return {Object|null}
+ * @return {String} return.metaCommit
+ * @return {Object} return.submoduleCommits  map from submodule to commit
+ */
+exports.continue = co.wrap(function *(repo) {
+    assert.instanceOf(repo, NodeGit.Repository);
+
+    const result = {
+        metaCommit: null,
+        submoduleCommits: {},
+    };
+    const merge = yield MergeFileUtil.readMerge(repo.path());
+    if (null === merge) {
+        throw new UserError("No merge in progress.");
+    }
+
+    const index = yield repo.index();
+
+    checkForConflicts(index);
+
+    // We have to do this because there may have been outsanding submodule
+    // conflicts.  We validated in `checkForConflicts` that there are no "real"
+    // conflicts.
+
+    console.log(`Continuing with merge of ${colors.green(merge.mergeHead)}.`);
+
+    let errorMessage = "";
+
+    const continueSub = co.wrap(function *(subPath) {
+        const subRepo = yield SubmoduleUtil.getRepo(repo, subPath);
+        const subIndex = yield subRepo.index();
+        if (subIndex.hasConflicts()) {
+            errorMessage +=
+                           `Submodule ${colors.red(subPath)} has conflicts.\n`;
+            return;                                                   // RETURN
+        }
+        const sig = subRepo.defaultSignature();
+        const subMerge = yield MergeFileUtil.readMerge(subRepo.path());
+        if (null === subMerge) {
+            // There is no merge in this submodule, but if there are staged
+            // changes we need to make a commit.
+
+            const status = yield StatusUtil.getRepoStatus(subRepo, {
+                showMeta: true,
+            });
+            if (0 !== Object.keys(status.staged)) {
+                const id = yield subRepo.createCommitOnHead([],
+                                                            sig,
+                                                            sig,
+                                                            merge.message);
+                result.submoduleCommits[subPath] = id.tostrS();
+            }
+        }
+        else {
+            // Now, we have a submodule that was in the middle of merging.
+            // Continue it and then clean up the merge.
+
+            const head = yield subRepo.getHeadCommit();
+            const mergeHead = yield subRepo.getCommit(subMerge.mergeHead);
+            const treeId = yield subIndex.writeTreeTo(subRepo);
+            const id = yield subRepo.createCommit("HEAD",
+                                                  sig,
+                                                  sig,
+                                                  subMerge.message,
+                                                  treeId,
+                                                  [head, mergeHead]);
+            yield MergeFileUtil.cleanMerge(subRepo.path());
+            result.submoduleCommits[subPath] = id.tostrS();
+        }
+        yield index.addByPath(subPath);
+    });
+    const openSubs = yield SubmoduleUtil.listOpenSubmodules(repo);
+    yield DoWorkQueue.doInParallel(openSubs, continueSub, 30);
+
+    if ("" !== errorMessage) {
+        throw new UserError(errorMessage);
+    }
+    yield index.conflictCleanup();
+    yield index.write();
+    const treeId = yield index.writeTreeTo(repo);
+
+    const sig = repo.defaultSignature();
+    const head = yield repo.getHeadCommit();
+    const mergeHead = yield repo.getCommit(merge.mergeHead);
+    const metaCommit = yield repo.createCommit("HEAD",
+                                               sig,
+                                               sig,
+                                               merge.message,
+                                               treeId,
+                                               [head, mergeHead]);
+    console.log(
+            `Finished with merge commit ${colors.green(metaCommit.tostrS())}`);
+    yield MergeFileUtil.cleanMerge(repo.path());
+    result.metaCommit = metaCommit.tostrS();
+    return result;
+});
+
+const resetMerge = co.wrap(function *(repo) {
+    // TODO: add this to libgit2
+    const execString = `git -C '${repo.workdir()}' reset --merge`;
+    yield ChildProcess.exec(execString);
+});
+
+/**
+ * Abort the merge in progress in the specified `repo`, or throw a `UserError`
+ * if no merge is in progress.
+ *
+ * @param {NodeGit.Repository} repo
+ */
+exports.abort = co.wrap(function *(repo) {
+    assert.instanceOf(repo, NodeGit.Repository);
+
+    const merge = yield MergeFileUtil.readMerge(repo.path());
+    if (null === merge) {
+        throw new UserError("No merge in progress.");
+    }
+
+    const head = yield repo.getHeadCommit(repo);
+    const openSubs = yield SubmoduleUtil.listOpenSubmodules(repo);
+    const shas = yield SubmoduleUtil.getSubmoduleShasForCommit(repo,
+                                                               openSubs,
+                                                               head);
+    const index = yield repo.index();
+    const abortSub = co.wrap(function *(subName) {
+        // Our goal here is to do a 'git reset --merge'.  Ideally, we'd do a
+        // soft reset first to put the submodule on the right sha, but you
+        // can't do a soft reset "in the middle of a merge", so we do an
+        // initial 'git reset --merge' once, then if we're not on the right sha
+        // we can do the soft reset -- the 'git reset --merge' cleans up any
+        // merge conflicts -- then do one final 'git reset --merge'.
+
+        const subRepo = yield SubmoduleUtil.getRepo(repo, subName);
+        yield resetMerge(subRepo);
+        const subHead = yield subRepo.getHeadCommit();
+        if (subHead.id().tostrS() !== shas[subName]) {
+            const commit = yield subRepo.getCommit(shas[subName]);
+            yield NodeGit.Reset.reset(subRepo,
+                                      commit,
+                                      NodeGit.Reset.TYPE.SOFT);
+            yield resetMerge(subRepo);
+        }
+        yield MergeFileUtil.cleanMerge(subRepo.path());
+        yield index.addByPath(subName);
+    });
+    yield DoWorkQueue.doInParallel(openSubs, abortSub, 30);
+    yield index.conflictCleanup();
+    yield index.write();
+    yield resetMerge(repo);
+    yield MergeFileUtil.cleanMerge(repo.path());
+});

--- a/node/lib/util/print_status_util.js
+++ b/node/lib/util/print_status_util.js
@@ -41,6 +41,7 @@ const colors  = require("colors/safe");
 const path    = require("path");
 
 const GitUtil             = require("./git_util");
+const Merge               = require("./merge");
 const Rebase              = require("./rebase");
 const RepoStatus          = require("./repo_status");
 
@@ -351,10 +352,24 @@ exports.printRebase = function (rebase) {
     return `${colors.red("rebase in progress; onto ", shortSha)}
 You are currently rebasing branch '${rebase.headName}' on '${shortSha}'.
   (fix conflicts and then run "git meta rebase --continue")
-  (use "git meta rebase --skip" to skip this patch)
   (use "git meta rebase --abort" to check out the original branch)
 `;
 };
+
+/**
+ * Return a message describing the specified `merge`.
+ *
+ * @param {Merge}
+ * @return {String}
+ */
+function printMerge(merge) {
+    assert.instanceOf(merge, Merge);
+    return `\
+A merge is in progress.
+  (fix conflicts and run "git meta merge --continue")
+  (use "git meta merge --abort" to abort the merge)
+`;
+}
 
 /**
  * Return a message describing the state of the current branch in the specified
@@ -390,6 +405,10 @@ exports.printRepoStatus = function (status, cwd) {
     }
 
     result += exports.printCurrentBranch(status);
+
+    if (null !== status.merge) {
+        result += printMerge(status.merge);
+    }
 
     let changes = "";
     const fileStatuses = exports.accumulateStatus(status);

--- a/node/lib/util/read_repo_ast_util.js
+++ b/node/lib/util/read_repo_ast_util.js
@@ -44,6 +44,7 @@ const path     = require("path");
 
 const RepoAST             = require("./repo_ast");
 const RebaseFileUtil      = require("./rebase_file_util");
+const MergeFileUtil       = require("./merge_file_util");
 const SubmoduleConfigUtil = require("./submodule_config_util");
 
 /**
@@ -503,6 +504,13 @@ exports.readRAST = co.wrap(function *(repo) {
         yield loadCommit(NodeGit.Oid.fromString(rebase.onto));
     }
 
+    const merge = yield MergeFileUtil.readMerge(repo.path());
+
+    if (null !== merge) {
+        yield loadCommit(NodeGit.Oid.fromString(merge.originalHead));
+        yield loadCommit(NodeGit.Oid.fromString(merge.mergeHead));
+    }
+
     return new RepoAST({
         commits: commits,
         branches: branchTargets,
@@ -515,6 +523,7 @@ exports.readRAST = co.wrap(function *(repo) {
         workdir: workdir,
         openSubmodules: openSubmodules,
         rebase: rebase,
+        merge: merge,
         bare: bare,
     });
 });

--- a/node/lib/util/repo_ast.js
+++ b/node/lib/util/repo_ast.js
@@ -38,6 +38,7 @@ const deeper   = require("deeper");
 const deepCopy = require("deepcopy");
 
 const Rebase = require("./rebase");
+const Merge  = require("./merge");
 
 /**
  * @class {Branch}
@@ -303,7 +304,8 @@ class AST {
      * @param {Object}      [args.workdir]
      * @param {Object}      [args.notes]
      * @param {Object}      [args.openSubmodules]
-     * @param {Rebase}      [args.Rebase]
+     * @param {Rebase}      [args.rebase]
+     * @param {Merge}       [args.merge]
      */
     constructor(args) {
         if (undefined === args) {
@@ -469,6 +471,17 @@ in commit ${id}.`);
             }
         }
 
+        this.d_merge = null;
+        if ("merge" in args) {
+            const merge = args.merge;
+            if (null !== merge) {
+                assert.instanceOf(merge, Merge);
+                assert.isFalse(this.d_bare);
+                checkAndTraverse(merge.originalHead, "original head of merge");
+                checkAndTraverse(merge.mergeHead, "merge head");
+                this.d_merge = merge;
+            }
+        }
 
         // Validate that all commits have been reached.
 
@@ -641,6 +654,13 @@ in commit ${id}.`);
     }
 
     /**
+     * @property {Merge} null unless a merge is in progress
+     */
+    get merge() {
+        return this.d_merge;
+    }
+
+    /**
      * Accumulate the specified `changes` into the specified `dest` map.  A
      * non-null value in `changes` overrides any existing value in `dest`; a
      * `null value causes the path mapped to `null` to be removed.  The
@@ -699,6 +719,7 @@ in commit ${id}.`);
             openSubmodules: ("openSubmodules" in args) ?
                 args.openSubmodules : this.d_openSubmodules,
             rebase: ("rebase" in args) ? args.rebase : this.d_rebase,
+            merge: ("merge" in args) ? args.merge : this.d_merge,
             bare: ("bare" in args) ? args.bare : this.d_bare,
         });
     }
@@ -774,6 +795,7 @@ in commit ${id}.`);
 AST.Branch = Branch;
 AST.Commit = Commit;
 AST.Rebase = Rebase;
+AST.Merge  = Merge;
 AST.Remote = Remote;
 AST.Submodule = Submodule;
 module.exports = AST;

--- a/node/lib/util/repo_ast_util.js
+++ b/node/lib/util/repo_ast_util.js
@@ -472,6 +472,32 @@ ${colorExp(expected.rebase.onto)} but got ${colorAct(actual.rebase.onto)}.`);
         }
     }
 
+    // Check merge
+
+    if (null === actual.merge && null !== expected.merge) {
+        result.push("Missing merge.");
+    }
+    else if (null !== actual.merge && null === expected.merge) {
+        result.push("Unexpected merge.");
+    }
+    else if (null !== actual.merge) {
+        if (actual.merge.message !== expected.merge.message) {
+            result.push(`Expected ${colorBad("merge message")} to be \
+${colorExp(expected.merge.message)} but got \
+${colorAct(actual.merge.message)}.`);
+        }
+        if (actual.merge.originalHead !== expected.merge.originalHead) {
+            result.push(`Expected ${colorBad("merge original head")} to be \
+${colorExp(expected.merge.originalHead)} but got \
+${colorAct(actual.merge.originalHead)}.`);
+        }
+        if (actual.merge.mergeHead !== expected.merge.mergeHead) {
+            result.push(`Expected ${colorBad("merge head")} to be \
+${colorExp(expected.merge.mergeHead)} but got \
+${colorAct(actual.merge.mergeHead)}.`);
+        }
+    }
+
     return result;
 }
 
@@ -697,6 +723,13 @@ exports.mapCommitsAndUrls = function (ast, commitMap, urlMap) {
                                     mapCommitId(rebase.onto));
     }
 
+    let merge = ast.merge;
+    if (null !== merge) {
+        merge = new RepoAST.Merge(merge.message,
+                                  mapCommitId(merge.originalHead),
+                                  mapCommitId(merge.mergeHead));
+    }
+
     return ast.copy({
         commits: commits,
         branches: branches,
@@ -709,6 +742,7 @@ exports.mapCommitsAndUrls = function (ast, commitMap, urlMap) {
         workdir: mapChanges(ast.workdir),
         openSubmodules: openSubmodules,
         rebase: rebase,
+        merge: merge,
     });
 };
 

--- a/node/lib/util/repo_status.js
+++ b/node/lib/util/repo_status.js
@@ -32,6 +32,7 @@
 const assert  = require("chai").assert;
 
 const Rebase = require("./rebase");
+const Merge  = require("./merge");
 
 /**
  * This modules defines the type `RepoStatus`, used to describe modifications
@@ -407,6 +408,7 @@ class RepoStatus {
      * @param {Object}   [args.submodules] map from name to `Submodule`
      * @param {Object}   [args.workdir] map from name to `FILESTATUS`
      * @param {Rebase}   [args.rebase] rebase, if one is in progress
+     * @param {Merge}    [args.merge] merge, if one is in progress
      */
     constructor(args) {
         if (undefined === args) {
@@ -421,6 +423,7 @@ class RepoStatus {
         this.d_workdir = {};
         this.d_submodules = {};
         this.d_rebase = null;
+        this.d_merge = null;
 
         if ("currentBranchName" in args) {
             if (null !== args.currentBranchName) {
@@ -462,6 +465,14 @@ class RepoStatus {
                 assert.instanceOf(rebase, Rebase);
             }
             this.d_rebase = rebase;
+        }
+
+        if ("merge" in args) {
+            const merge = args.merge;
+            if (null !== merge) {
+                assert.instanceOf(merge, Merge);
+            }
+            this.d_merge = merge;
         }
         Object.freeze(this);
     }
@@ -607,10 +618,17 @@ class RepoStatus {
     }
 
     /**
-     * @property {Rebase} rebase if non-null, state of in-progress rebase
+     * @property {rebase} rebase if non-null, state of in-progress rebase
      */
     get rebase() {
         return this.d_rebase;
+    }
+
+    /**
+     * @property {merge} merge if non-null, state of in-progress merge
+     */
+    get merge() {
+        return this.d_merge;
     }
 
     /**
@@ -637,6 +655,7 @@ class RepoStatus {
                 args.submodules: this.d_submodules,
             workdir: ("workdir" in args) ? args.workdir : this.d_workdir,
             rebase: ("rebase" in args) ? args.rebase : this.d_rebase,
+            merge: ("merge" in args) ? args.merge : this.d_merge,
         });
     }
 }

--- a/node/lib/util/submodule_config_util.js
+++ b/node/lib/util/submodule_config_util.js
@@ -439,6 +439,7 @@ exports.initSubmoduleAndRepo = co.wrap(function *(repoUrl,
  * dictionaries, who have the specified `mergeBase` dictionary as their merge
  * base; or, `null` if there is a conflict between the two that cannot be
  * resolved.
+ * TODO: indicate which submodules are in conflict
  *
  * @param {Object} lhs
  * @param {Object} rhs

--- a/node/lib/util/test_util.js
+++ b/node/lib/util/test_util.js
@@ -39,7 +39,7 @@ const co      = require("co");
 const fs      = require("fs-promise");
 const path    = require("path");
 const NodeGit = require("nodegit");
-const temp    = require("temp").track();
+const temp    = require("temp");
 
 /**
  * Return the path to a newly-created temporary directory.

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -46,6 +46,7 @@ const NodeGit  = require("nodegit");
 const path     = require("path");
 
 const DoWorkQueue         = require("./do_work_queue");
+const MergeFileUtil       = require("./merge_file_util");
 const RebaseFileUtil      = require("./rebase_file_util");
 const RepoAST             = require("./repo_ast");
 const RepoASTUtil         = require("./repo_ast_util");
@@ -435,6 +436,19 @@ const configureRepo = co.wrap(function *(repo, ast, commitMap, treeCache) {
             // we render against the new head, `onto`.
 
             indexHead = rebase.onto;
+        }
+
+        // Write out the merge info, if it exists.
+
+        if (null !== ast.merge) {
+            // Map commits
+
+            const originalSha = commitMap[ast.merge.originalHead];
+            const mergeSha = commitMap[ast.merge.mergeHead];
+            const merge = new RepoAST.Merge(ast.merge.message,
+                                            originalSha,
+                                            mergeSha);
+            yield MergeFileUtil.writeMerge(repo.path(), merge);
         }
 
         // Set up the index.  We render the current commit and apply the index

--- a/node/test/util/merge.js
+++ b/node/test/util/merge.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Two Sigma Open Source
+ * Copyright (c) 2017, Two Sigma Open Source
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,198 +31,16 @@
 "use strict";
 
 const assert = require("chai").assert;
-const co     = require("co");
 
-const Merge           = require("../../lib//util/merge");
-const RepoASTTestUtil = require("../../lib/util/repo_ast_test_util");
-const StatusUtil      = require("../../lib/util/status_util");
+const Merge = require("../../lib/util/merge");
 
-describe("merge", function () {
-    // Will do merge from repo `x`.  A merge commit in the meta-repo will be
-    // named `x`; any merge commits in the sub-repos will be given the name of
-    // the sub-repo in which they are made.
-    // TODO: test for changes to submodule shas, and submodule deletions
-
-    const doMerge = co.wrap(function *(upToDate,
-                                       fromCommit,
-                                       mode,
-                                       repos,
-                                       maps) {
-        const x = repos.x;
-        const status = yield StatusUtil.getRepoStatus(x);
-        const commitMap = maps.commitMap;
-        const reverseCommitMap = maps.reverseCommitMap;
-        assert.property(reverseCommitMap, fromCommit);
-        const physicalCommit = reverseCommitMap[fromCommit];
-        const commit = yield x.getCommit(physicalCommit);
-        const result = yield Merge.merge(x, status, commit, mode, "message\n");
-        if (upToDate) {
-            assert.isNull(result);
-            return;                                                   // RETURN
-        }
-        assert.isObject(result);
-        let newCommitMap = {};
-
-        // If a new commit was generated -- it wasn't a fast-forward commit --
-        // record a mapping from the new commit to it's logical name: "x".
-
-        if (!(result.metaCommit in commitMap)) {
-            newCommitMap[result.metaCommit] = "x";
-        }
-
-        // Map the new commits in submodules to the names of the submodules
-        // where they were made.
-
-        Object.keys(result.submoduleCommits).forEach(name => {
-            commitMap[result.submoduleCommits[name]] = name;
-        });
-        return {
-            commitMap: newCommitMap,
-        };
-    });
-
-    // Test plan:
-    // - basic merging with meta-repo: normal/ffw/force commit
-    // - many scenarios with submodules
-    //   - merges with open/closed unaffected submodules
-    //   - where submodules are opened and closed
-    //   - where they can and can't be fast-forwarded
-
-    const MODE = Merge.MODE;
-    const cases = {
-        "trivial": {
-            initial: "x=S",
-            fromCommit: "1",
-            expected: null,
-        },
-        "ancestor": {
-            initial: "x=S:C2-1;Bmaster=2",
-            fromCommit: "1",
-            upToDate: true,
-            expected: null,
-        },
-        "ff merge, not required": {
-            initial: "x=S:C2-1;Bfoo=2",
-            fromCommit: "2",
-            expected: "x=E:Bmaster=2",
-        },
-        "ff merge, required": {
-            initial: "x=S:C2-1;Bfoo=2",
-            fromCommit: "2",
-            mode: MODE.FF_ONLY,
-            expected: "x=E:Bmaster=2",
-        },
-        "ff merge, but disallowed": {
-            initial: "x=S:C2-1;Bfoo=2",
-            fromCommit: "2",
-            mode: MODE.FORCE_COMMIT,
-            expected: "x=E:Cx-1,2 2=2;Bmaster=x",
-        },
-        "one merge": {
-            initial: "x=S:C2-1;C3-1;Bmaster=2;Bfoo=3",
-            fromCommit: "3",
-            expected: "x=E:Cx-2,3 3=3;Bmaster=x",
-        },
-        "one merge, forced anyway": {
-            initial: "x=S:C2-1;C3-1;Bmaster=2;Bfoo=3",
-            fromCommit: "3",
-            expected: "x=E:Cx-2,3 3=3;Bmaster=x",
-            mode: MODE.FORCE_COMMIT,
-        },
-        "one merge, ff requested": {
-            initial: "x=S:C2-1;C3-1;Bmaster=2;Bfoo=3",
-            fromCommit: "3",
-            mode: MODE.FF_ONLY,
-            fails: true,
-        },
-        "ff merge adding submodule": {
-            initial: "a=S|x=U:Bfoo=1;*=foo",
-            fromCommit: "2",
-            expected: "x=E:Bfoo=2",
-        },
-        "ff merge with submodule change": {
-            initial: "a=S:C4-1;Bfoo=4|x=U:C5-2 s=Sa:4;Bfoo=5",
-            fromCommit: "5",
-            expected: "x=E:Bmaster=5;Os H=4",
-        },
-        "fforwardable but disallowed with submodule change": {
-            initial: "a=S:C4-1;Bfoo=4|x=U:C5-2 s=Sa:4;Bfoo=5",
-            fromCommit: "5",
-            mode: MODE.FORCE_COMMIT,
-            expected:
-                "x=E:Bmaster=x;Cx-2,5 s=Sa:s;Os Cs-1,4 4=4!H=s",
-        },
-        "fforwardable merge with non-ffwd submodule change": {
-            initial: "\
-a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|\
-x=U:C3-2 s=Sa:b;C4-3 s=Sa:c;Bmaster=3;Bfoo=4",
-            fromCommit: "4",
-            expected:
-                "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!H=s;Bmaster=x",
-        },
-        "fforwardable merge with non-ffwd submodule change, ff requested": {
-            initial: "\
-a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|\
-x=U:C3-2 s=Sa:b;C4-3 s=Sa:c;Bmaster=3;Bfoo=4",
-            fromCommit: "4",
-            mode: MODE.FF_ONLY,
-            expected: "x=E:Os H=b",
-            fails: true,
-        },
-        "non-ffmerge with non-ffwd submodule change": {
-            initial: "\
-a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|\
-x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4",
-            fromCommit: "4",
-            expected:
-                "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!H=s;Bmaster=x",
-        },
-        "non-ffmerge with non-ffwd submodule change, sub open": {
-            initial: "\
-a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|\
-x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os",
-            fromCommit: "4",
-            expected:
-                "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!H=s;Bmaster=x",
-        },
-        "submodule commit is up-to-date": {
-            initial: "\
-a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|\
-x=U:C3-2 s=Sa:c;C4-2 s=Sa:b,x=y;Bmaster=3;Bfoo=4",
-            fromCommit: "4",
-            expected: "x=E:Cx-3,4 x=y;Os H=c;Bmaster=x",
-        },
-        "submodule commit is same": {
-            initial: "\
-a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|\
-x=U:C3-2 s=Sa:c;C4-2 s=Sa:c,x=y;Bmaster=3;Bfoo=4",
-            fromCommit: "4",
-            expected: "x=E:Cx-3,4 x=y;Bmaster=x",
-        },
-        "otherwise ffwardable change to meta with two subs; one can't ffwd": {
-            initial: "\
-a=Aa:Cb-a;Cc-a;Cd-c;Bx=d;By=b|\
-x=U:C3-2 s=Sa:b,t=Sa:c;C4-3 s=Sa:c,t=Sa:d;Bmaster=3;Bfoo=4",
-            fromCommit: "4",
-            expected: "\
-x=E:Cx-3,4 s=Sa:s,t=Sa:d;Bmaster=x;\
-Os Cs-b,c c=c!H=s;\
-Ot H=d",
-        },
-    };
-    Object.keys(cases).forEach(caseName => {
-        const c = cases[caseName];
-        it(caseName, co.wrap(function *() {
-            const expected = c.expected;
-            function manipulator(repos, maps) {
-                const upToDate = null === expected;
-                const mode = !("mode" in c) ? MODE.NORMAL : c.mode;
-                return doMerge(upToDate, c.fromCommit, mode, repos, maps);
-            }
-            yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,
-                                                           c.expected || {},
-                                                           manipulator,
-                                                           c.fails);
-        }));
+describe("Merge", function () {
+    it("breath", function () {
+        const m = new Merge("foo", "bar", "baz");
+        assert.instanceOf(m, Merge);
+        assert.isFrozen(m);
+        assert.equal(m.message, "foo");
+        assert.equal(m.originalHead, "bar");
+        assert.equal(m.mergeHead, "baz");
     });
 });

--- a/node/test/util/merge_file_util.js
+++ b/node/test/util/merge_file_util.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert = require("chai").assert;
+const co     = require("co");
+const fs     = require("fs-promise");
+const path   = require("path");
+
+const MergeFileUtil  = require("../../lib//util/merge_file_util");
+const Merge          = require("../../lib//util/merge");
+const TestUtil       = require("../../lib/util/test_util");
+
+describe("MergeFileUtil", function () {
+    describe("readMerge", function () {
+        it("found", co.wrap(function *() {
+            const tempDir = yield TestUtil.makeTempDir();
+            const gitDir = path.join(tempDir, "META_MERGE");
+            yield fs.mkdir(gitDir);
+            yield fs.writeFile(path.join(gitDir, "MSG"), "hello world\n");
+            yield fs.writeFile(path.join(gitDir, "ORIG_HEAD"), "123\n");
+            yield fs.writeFile(path.join(gitDir, "MERGE_HEAD"), "456\n");
+            const result = yield MergeFileUtil.readMerge(tempDir);
+            assert.deepEqual(result, new Merge("hello world\n", "123", "456"));
+        }));
+        it("not found", co.wrap(function *() {
+            const tempDir = yield TestUtil.makeTempDir();
+            const gitDir = path.join(tempDir, "META_MERGE");
+            yield fs.mkdir(gitDir);
+            yield fs.writeFile(path.join(gitDir, "MSG"), "hello world\n");
+            yield fs.writeFile(path.join(gitDir, "ORIG_HEAD"), "123\n");
+            const result = yield MergeFileUtil.readMerge(tempDir);
+            assert.isNull(result);
+        }));
+    });
+    it("writeMerge", co.wrap(function *() {
+        const tempDir = yield TestUtil.makeTempDir();
+        const merge = new Merge("foo\n", "bar", "baz");
+        yield MergeFileUtil.writeMerge(tempDir, merge);
+        const root = path.join(tempDir, "META_MERGE");
+        const message = yield fs.readFile(path.join(root, "MSG"), "utf8");
+        assert.equal(message, "foo\n");
+        const originalHead = yield fs.readFile(path.join(root, "ORIG_HEAD"),
+                                         "utf8");
+        assert.equal(originalHead, "bar\n");
+        const mergeHead = yield fs.readFile(path.join(root, "MERGE_HEAD"),
+                                            "utf8");
+        assert.equal(mergeHead, "baz\n");
+    }));
+    it("cleanMerge", co.wrap(function *() {
+        const tempDir = yield TestUtil.makeTempDir();
+        yield MergeFileUtil.writeMerge(tempDir,
+                                       new Merge("hey", "there", "all"));
+        yield MergeFileUtil.cleanMerge(tempDir);
+        const result = yield MergeFileUtil.readMerge(tempDir);
+        assert.isNull(result);
+    }));
+});

--- a/node/test/util/merge_util.js
+++ b/node/test/util/merge_util.js
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2017, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert       = require("chai").assert;
+const co           = require("co");
+
+const MergeUtil       = require("../../lib//util/merge_util");
+const RepoASTTestUtil = require("../../lib/util/repo_ast_test_util");
+
+/**
+ * Return the commit map required by 'RepoASTTestUtil.testMultiRepoManipulator'
+ * from the specified 'result' returned by the 'merge' and 'continue' function,
+ * using the specified 'maps' provided to the manipulators.
+ */
+function mapReturnedCommits(result, maps) {
+    assert.isObject(result);
+    let newCommitMap = {};
+
+    // If a new commit was generated -- it wasn't a fast-forward commit --
+    // record a mapping from the new commit to it's logical name: "x".
+
+    const commitMap = maps.commitMap;
+    if (!(result.metaCommit in commitMap)) {
+        newCommitMap[result.metaCommit] = "x";
+    }
+
+    // Map the new commits in submodules to the names of the submodules where
+    // they were made.
+
+    Object.keys(result.submoduleCommits).forEach(name => {
+        commitMap[result.submoduleCommits[name]] = name;
+    });
+    return {
+        commitMap: newCommitMap,
+    };
+}
+
+describe("MergeUtil", function () {
+    describe("fastForwardMerge", function () {
+        const MODE = MergeUtil.MODE;
+        const cases = {
+            "simple": {
+                initial: "x=S:C2-1;Bfoo=2",
+                commit: "2",
+                mode: MODE.NORMAL,
+                expected: "x=E:Bmaster=2",
+            },
+            "simple, FF_ONLY": {
+                initial: "x=S:C2-1;Bfoo=2",
+                commit: "2",
+                mode: MODE.FF_ONLY,
+                expected: "x=E:Bmaster=2",
+            },
+            "simple detached": {
+                initial: "x=S:C2-1;Bfoo=2;*=",
+                commit: "2",
+                mode: MODE.NORMAL,
+                expected: "x=E:H=2",
+            },
+            "with submodule": {
+                initial: "a=B:Ca-1;Ba=a|x=U:C3-2 s=Sa:a;Bfoo=3",
+                commit: "3",
+                mode: MODE.NORMAL,
+                expected: "x=E:Bmaster=3",
+            },
+            "with open submodule": {
+                initial: "a=B:Ca-1;Ba=a|x=U:C3-2 s=Sa:a;Bfoo=3;Os",
+                commit: "3",
+                mode: MODE.NORMAL,
+                expected: "x=E:Bmaster=3;Os H=a",
+            },
+            "with open submodule and change": {
+                initial: `
+a=B:Ca-1;Ba=a|
+x=U:C3-2 s=Sa:a;Bfoo=3;Os W README.md=3`,
+                commit: "3",
+                mode: MODE.NORMAL,
+                expected: "x=E:Bmaster=3;Os H=a!W README.md=3",
+            },
+            "with open submodule and conflict": {
+                initial: `
+a=B:Ca-1;Ba=a|
+x=U:C3-2 s=Sa:a;Bfoo=3;Os W a=b`,
+                commit: "3",
+                mode: MODE.NORMAL,
+                fails: true,
+            },
+            "force commit": {
+                initial: "x=S:C2-1;Bfoo=2",
+                commit: "2",
+                mode: MODE.FORCE_COMMIT,
+                expected: "x=E:Chahaha\n#x-1,2 2=2;Bmaster=x",
+                message: "hahaha",
+            },
+            "force commit, detached": {
+                initial: "x=S:C2-1;Bfoo=2;*=",
+                commit: "2",
+                mode: MODE.FORCE_COMMIT,
+                expected: "x=E:Chahaha\n#x-1,2 2=2;H=x",
+                message: "hahaha",
+            },
+            "ff merge adding submodule": {
+                initial: "a=S|x=U:Bfoo=1;*=foo",
+                commit: "2",
+                expected: "x=E:Bfoo=2",
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            const ffwd = co.wrap(function *(repos, maps) {
+                const x = repos.x;
+                const reverseCommitMap = maps.reverseCommitMap;
+                assert.property(reverseCommitMap, c.commit);
+                const physicalCommit = reverseCommitMap[c.commit];
+                const commit = yield x.getCommit(physicalCommit);
+                const message = c.message || "message\n";
+                const mode = c.mode || MODE.NORMAL;
+                const result = yield MergeUtil.fastForwardMerge(x,
+                                                                mode,
+                                                                commit,
+                                                                message);
+                let newCommitMap = {};
+                if (null !== result) {
+                    assert.isString(result);
+                    // If a new commit was generated, map it to "x".
+
+                    newCommitMap[result] = "x";
+                }
+                return {
+                    commitMap: newCommitMap,
+                };
+            });
+            it(caseName, co.wrap(function *() {
+                yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,
+                                                               c.expected,
+                                                               ffwd,
+                                                               c.fails);
+            }));
+        });
+    });
+
+    describe("merge", function () {
+        // Will do merge from repo `x`.  A merge commit in the meta-repo will
+        // be named `x`; any merge commits in the sub-repos will be given the
+        // name of the sub-repo in which they are made.  TODO: test for changes
+        // to submodule shas, and submodule deletions
+
+        // Test plan:
+        // - basic merging with meta-repo: normal/ffw/force commit; note that
+        //   fast-forward merges are tested in the driver for
+        //   'fastForwardMerge', so we just need to validate that it works once
+        //   here
+        // - many scenarios with submodules
+        //   - merges with open/closed unaffected submodules
+        //   - where submodules are opened and closed
+        //   - where they can and can't be fast-forwarded
+
+        const MODE = MergeUtil.MODE;
+        const cases = {
+            "trivial -- nothing to do": {
+                initial: "x=S",
+                fromCommit: "1",
+                expected: null,
+            },
+            "staged change": {
+                initial: "x=S:I foo=bar",
+                fromCommit: "1",
+                fails: true,
+            },
+            "submodule commit": {
+                initial: "a=B|x=U:Os Cs-1!H=s",
+                fromCommit: "1",
+                fails: true,
+            },
+            "already a merge in progress": {
+                initial: "x=S:Mhia,1,1",
+                fromCommit: "1",
+                fails: true,
+            },
+            "one merge": {
+                initial: "x=S:C2-1;C3-1;Bmaster=2;Bfoo=3",
+                fromCommit: "3",
+                expected: "x=E:Cx-2,3 3=3;Bmaster=x",
+            },
+            "one merge with editor": {
+                initial: "x=S:C2-1;C3-1;Bmaster=2;Bfoo=3",
+                fromCommit: "3",
+                editMessage: () => Promise.resolve("foo\nbar\n# baz\n"),
+                expected: "x=E:Cfoo\nbar\n#x-2,3 3=3;Bmaster=x",
+                message: null,
+            },
+            "one merge with empty message": {
+                initial: "x=S:C2-1;C3-1;Bmaster=2;Bfoo=3",
+                fromCommit: "3",
+                editMessage: () => Promise.resolve(""),
+                message: null,
+            },
+            "non-ffmerge with ffwd submodule change": {
+                initial: `
+a=Aa:Cb-a;Bb=b;Cc-b;Bc=c|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os`,
+                fromCommit: "4",
+                expected: "x=E:Cx-3,4 s=Sa:c;Os H=c;Bmaster=x",
+            },
+            "non-ffmerge with ffwd submodule change on lhs": {
+                initial: `
+a=Aa:Cb-a;Bb=b;Cc-b;Bc=c|
+x=U:C3-2 s=Sa:b;C4-2;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                expected: "x=E:Cx-3,4 4=4;Bmaster=x",
+            },
+            "non-ffmerge with ffwd submodule change, auto-close": {
+                initial: `
+a=Aa:Cb-a;Bb=b;Cc-b;Bc=c|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                expected: "x=E:Cx-3,4 s=Sa:c;Bmaster=x",
+            },
+            "non-ffmerge with ffwd submodule change, doesn't auto-close": {
+                initial: `
+a=Aa:Cb-a;Bb=b;Cc-b;Bc=c|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os`,
+                fromCommit: "4",
+                expected: "x=E:Cx-3,4 s=Sa:c;Bmaster=x;Os",
+            },
+            "non-ffmerge with non-ffwd submodule change": {
+                initial: `
+a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                expected: "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!H=s;Bmaster=x",
+            },
+            "non-ffmerge with non-ffwd submodule change, sub already open": {
+                initial: `
+a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os`,
+                fromCommit: "4",
+                expected: "x=E:Cx-3,4 s=Sa:s;Os Cs-b,c c=c!H=s;Bmaster=x",
+            },
+            "submodule commit is up-to-date": {
+                initial:`
+a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:c;C4-2 s=Sa:b,x=y;Bmaster=3;Bfoo=4;Os`,
+                fromCommit: "4",
+                expected: "x=E:Cx-3,4 x=y;Os H=c;Bmaster=x",
+            },
+            "submodule commit is up-to-date, was not open": {
+                initial:`
+a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:c;C4-2 s=Sa:b,x=y;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                expected: "x=E:Cx-3,4 x=y;Bmaster=x",
+            },
+            "submodule commit is same": {
+                initial: `
+a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:c;C4-2 s=Sa:c,x=y;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                expected: "x=E:Cx-3,4 x=y;Bmaster=x",
+            },
+            "added in merge": {
+                initial: `
+a=B|
+x=S:C2-1;C3-1 t=Sa:1;Bmaster=2;Bfoo=3`,
+                fromCommit: "3",
+                expected: "x=E:Cx-2,3 t=Sa:1;Bmaster=x",
+            },
+            "added on both sides": {
+                initial: `
+a=B|
+x=S:C2-1 s=Sa:1;C3-1 t=Sa:1;Bmaster=2;Bfoo=3`,
+                fromCommit: "3",
+                expected: "x=E:Cx-2,3 t=Sa:1;Bmaster=x",
+            },
+            "conflicted add": {
+                initial: `
+a=B|b=B|
+x=S:C2-1 s=Sa:1;C3-1 s=Sb:1;Bmaster=2;Bfoo=3`,
+                fromCommit: "3",
+                expected: "x=E:Mmessage\n,2,3",
+                fails: true,
+            },
+            "conflict in meta": {
+                initial: "x=S:C2-1 foo=bar;C3-1 foo=baz;Bmaster=2;Bfoo=3",
+                fromCommit: "3",
+                expected: "x=E:Mmessage\n,2,3",
+                fails: true,
+            },
+            "conflict in submodule": {
+                initial: `
+a=B:Ca-1 README.md=8;Cb-1 README.md=9;Ba=a;Bb=b|
+x=U:C3-2 s=Sa:a;C4-2 s=Sa:b;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                expected: "x=E:Mmessage\n,3,4;Os Mmessage\n,a,b",
+                fails: true,
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                const expected = c.expected;
+
+                const doMerge = co.wrap(function *(repos, maps) {
+                    const upToDate = null === expected;
+                    const mode = !("mode" in c) ? MODE.NORMAL : c.mode;
+                    const x = repos.x;
+                    const reverseCommitMap = maps.reverseCommitMap;
+                    assert.property(reverseCommitMap, c.fromCommit);
+                    const physicalCommit = reverseCommitMap[c.fromCommit];
+                    const commit = yield x.getCommit(physicalCommit);
+                    let message = c.message;
+                    if (undefined === message) {
+                        message = "message\n";
+                    }
+                    const defaultEditor = function () {};
+                    const editMessage = c.editMessage || defaultEditor;
+                    const result = yield MergeUtil.merge(x,
+                                                         commit,
+                                                         mode,
+                                                         message,
+                                                         editMessage);
+                    if (upToDate) {
+                        assert.isNull(result);
+                        return;                                       // RETURN
+                    }
+                    return mapReturnedCommits(result, maps);
+                });
+                yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,
+                                                               expected || {},
+                                                               doMerge,
+                                                               c.fails);
+            }));
+        });
+    });
+    describe("continue", function () {
+        // TODO: test abort from conflicts.  Need conflict support to make this
+        // work.
+
+        const cases = {
+            "no merge": {
+                initial: "x=S",
+                fails: true,
+            },
+            "continue in meta": {
+                initial: "x=S:C2-1;C3-1;Bmaster=2;I baz=bam;Mhi\n,2,3;Bfoo=3",
+                expected: "x=E:Chi\n#x-2,3 baz=bam;Bmaster=x;M;I baz=~",
+            },
+            "cheap continue in meta": {
+                initial: "x=S:C2;Mhi\n,1,2;B2=2",
+                expected: "x=E:Chi\n#x-1,2 ;Bmaster=x;M",
+            },
+            "continue with extra in non-continue sub": {
+                initial: `
+a=B|
+x=U:C3-1;Mhi\n,2,3;B3=3;Os I README.md=8`,
+                expected: `
+x=E:Chi\n#x-2,3 s=Sa:s;Bmaster=x;M;Os Chi\n#s-1 README.md=8!H=s`,
+            },
+            "continue in a sub": {
+                initial: `
+a=B:Ca;Ba=a|
+x=U:C3-1;Mhi\n,2,3;B3=3;Os I README.md=8!Myo\n,1,a!Ba=a`,
+                expected: `
+x=E:Chi\n#x-2,3 s=Sa:s;Bmaster=x;M;Os Cyo\n#s-1,a README.md=8!H=s!Ba=a`,
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            const doContinue = co.wrap(function *(repos, maps) {
+                const repo = repos.x;
+                const result = yield MergeUtil.continue(repo);
+                return mapReturnedCommits(result, maps);
+            });
+            it(caseName, co.wrap(function *() {
+                yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,
+                                                               c.expected,
+                                                               doContinue,
+                                                               c.fails);
+            }));
+        });
+    });
+    describe("abort", function() {
+        const cases = {
+            "no merge": {
+                initial: "x=S",
+                fails: true,
+            },
+            "noop": {
+                initial: "x=S:Mfoo,1,1",
+                expected: "x=E:M",
+            },
+            "noop with sub": {
+                initial: "a=B|x=U:Mfoo,1,1;Os Mfoo,1,1",
+                expected: "x=E:M;Os M",
+            },
+            "moved back a sub": {
+                initial: `
+a=B|
+x=U:Mx,1,1;Os Cs-1!H=s!Bs=s`,
+                expected: `x=E:M;Os H=1!Cs-1!Bs=s`,
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            const doAbort = co.wrap(function *(repos) {
+                const repo = repos.x;
+                yield MergeUtil.abort(repo);
+            });
+            it(caseName, co.wrap(function *() {
+                yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,
+                                                               c.expected,
+                                                               doAbort,
+                                                               c.fails);
+            }));
+        });
+    });
+});

--- a/node/test/util/print_status_util.js
+++ b/node/test/util/print_status_util.js
@@ -34,6 +34,7 @@ const assert  = require("chai").assert;
 const colors  = require("colors");
 
 const Rebase              = require("../../lib/util/rebase");
+const Merge               = require("../../lib/util/merge");
 const RepoStatus          = require("../../lib/util/repo_status");
 const PrintStatusUtil     = require("../../lib/util/print_status_util");
 
@@ -687,7 +688,23 @@ describe("PrintStatusUtil", function () {
                 input: new RepoStatus({
                     currentBranchName: "master",
                 }),
-                regex: /On branch.*master.*\n.*nothing to commit.*/,
+                exact: `\
+On branch ${colors.green("master")}.
+nothing to commit, working tree clean
+`,
+            },
+            "merge": {
+                input: new RepoStatus({
+                    currentBranchName: "master",
+                    merge: new Merge("hello", "1", "1"),
+                }),
+                exact: `\
+On branch ${colors.green("master")}.
+A merge is in progress.
+  (fix conflicts and run "git meta merge --continue")
+  (use "git meta merge --abort" to abort the merge)
+nothing to commit, working tree clean
+`,
             },
             "rebase": {
                 input: new RepoStatus({

--- a/node/test/util/repo_ast.js
+++ b/node/test/util/repo_ast.js
@@ -165,6 +165,7 @@ describe("RepoAST", function () {
 
             const Commit = RepoAST.Commit;
             const Rebase = RepoAST.Rebase;
+            const Merge  = RepoAST.Merge;
             const Remote = RepoAST.Remote;
 
             const c1       = new Commit();
@@ -192,8 +193,8 @@ describe("RepoAST", function () {
                     eworkdir: ("workdir" in expected) ? expected.workdir : {},
                     eopenSubmodules: ("openSubmodules" in expected) ?
                                                   expected.openSubmodules : {},
-                    erebase: ("rebase" in expected) ?
-                        expected.rebase : null,
+                    erebase: ("rebase" in expected) ?  expected.rebase : null,
+                    emerge: ("merge" in expected) ? expected.merge : null,
                     fails   : fails,
                 };
             }
@@ -207,6 +208,7 @@ describe("RepoAST", function () {
                         head: null,
                         currentBranchName: null,
                         rebase: null,
+                        merge: null,
                         bare: false,
                     },
                     undefined,
@@ -227,6 +229,12 @@ describe("RepoAST", function () {
                 "bad bare with rebase": m({
                     bare: true,
                     rebase: new Rebase("foo", "1", "1"),
+                    commits: {"1": c1 },
+                    head: "1",
+                }, undefined, true),
+                "bad bare with merge": m({
+                    bare: true,
+                    merge: new Merge("foo", "1", "1"),
                     commits: {"1": c1 },
                     head: "1",
                 }, undefined, true),
@@ -488,6 +496,37 @@ describe("RepoAST", function () {
                 "bad rebase": m({
                     rebase: new Rebase("fff", "1", "1"),
                 }, undefined, true),
+                "with merge": m({
+                    commits: {
+                        "1": new Commit(),
+                    },
+                    head: "1",
+                    merge: new Merge("fff", "1", "1"),
+                }, {
+                    commits: {
+                        "1": new Commit(),
+                    },
+                    head: "1",
+                    merge: new Merge("fff", "1", "1"),
+                }),
+                "with merge specific commits": m({
+                    commits: {
+                        "1": new Commit(),
+                        "2": new Commit(),
+                    },
+                    head: "1",
+                    merge: new Merge("fff", "2", "2"),
+                }, {
+                    commits: {
+                        "1": new Commit(),
+                        "2": new Commit(),
+                    },
+                    head: "1",
+                    merge: new Merge("fff", "2", "2"),
+                }),
+                "bad merge": m({
+                    merge: new Merge("fff", "1", "1"),
+                }, undefined, true),
             };
             Object.keys(cases).forEach(caseName => {
                 it(caseName, function () {
@@ -510,6 +549,7 @@ describe("RepoAST", function () {
                     assert.deepEqual(obj.workdir, c.eworkdir);
                     assert.deepEqual(obj.openSubmodules, c.eopenSubmodules);
                     assert.deepEqual(obj.rebase, c.erebase);
+                    assert.deepEqual(obj.merge, c.emerge);
                     assert.equal(obj.bare, c.ebare);
 
                     if (c.input) {
@@ -648,6 +688,7 @@ describe("RepoAST", function () {
 
         describe("AST.copy", function () {
             const Rebase = RepoAST.Rebase;
+            const Merge  = RepoAST.Merge;
             const base = new RepoAST({
                 commits: { "1": new RepoAST.Commit()},
                 branches: { "master": new RepoAST.Branch("1", null) },
@@ -657,6 +698,7 @@ describe("RepoAST", function () {
                 index: { foo: "bar" },
                 workdir: { foo: "bar" },
                 rebase: new Rebase("hello", "1", "1"),
+                merge: new Merge("hello", "1", "1"),
                 bare: false,
             });
             const newArgs = {
@@ -669,6 +711,7 @@ describe("RepoAST", function () {
                 index: { foo: "bar" },
                 workdir: { foo: "bar" },
                 rebase: new Rebase("hello world", "2", "2"),
+                merge: new Merge("hello world", "2", "2"),
                 bare: false,
             };
             const cases = {
@@ -686,6 +729,7 @@ describe("RepoAST", function () {
                         index: {},
                         workdir: {},
                         rebase: null,
+                        merge: null,
                     },
                     e: new RepoAST({
                         commits: { "1": new RepoAST.Commit()},
@@ -711,6 +755,7 @@ describe("RepoAST", function () {
                     assert.deepEqual(obj.workdir, c.e.workdir);
                     assert.deepEqual(obj.openSubmodules, c.e.openSubmodules);
                     assert.deepEqual(obj.rebase, c.e.rebase);
+                    assert.deepEqual(obj.merge, c.e.merge);
                     assert.equal(obj.bare, c.e.bare);
                 });
             });

--- a/node/test/util/repo_status.js
+++ b/node/test/util/repo_status.js
@@ -32,6 +32,7 @@
 
 const assert = require("chai").assert;
 
+const Merge      = require("../../lib/util/merge");
 const Rebase     = require("../../lib/util/rebase");
 const RepoStatus = require("../../lib/util/repo_status");
 
@@ -475,6 +476,7 @@ describe("RepoStatus", function () {
                 workdir: {},
                 submodules: {},
                 rebase: null,
+                merge: null,
             };
             return Object.assign(result, args);
         }
@@ -500,6 +502,7 @@ describe("RepoStatus", function () {
                         }),
                     },
                     rebase: new Rebase("foo", "1", "2"),
+                    merge: new Merge("baz", "2", "1"),
                 },
                 e: m({
                     currentBranchName: "foo",
@@ -513,6 +516,7 @@ describe("RepoStatus", function () {
                         }),
                     },
                     rebase: new Rebase("foo", "1", "2"),
+                    merge: new Merge("baz", "2", "1"),
                 }),
             }
         };
@@ -528,6 +532,7 @@ describe("RepoStatus", function () {
             assert.deepEqual(result.workdir, c.e.workdir);
             assert.deepEqual(result.submodules, c.e.submodules);
             assert.deepEqual(result.rebase, c.e.rebase);
+            assert.deepEqual(result.merge, c.e.merge);
         });
     });
 
@@ -957,6 +962,7 @@ describe("RepoStatus", function () {
             },
             workdir: { x: FILESTATUS.MODIFIED },
             rebase: new Rebase("2", "4", "b"),
+            merge: new Merge("hah", "1", "1"),
         });
         const anotherStat = new RepoStatus({
             currentBranchName: "fo",
@@ -967,6 +973,7 @@ describe("RepoStatus", function () {
             },
             workdir: { x: FILESTATUS.ADDED },
             rebase: new Rebase("a", "4", "b"),
+            merge: new Merge("a", "2", "2"),
         });
         it("simple, no args", function () {
             const newStat = stat.copy();
@@ -984,6 +991,7 @@ describe("RepoStatus", function () {
                 submodules: anotherStat.submodules,
                 workdir: anotherStat.workdir,
                 rebase: anotherStat.rebase,
+                merge: anotherStat.merge,
             });
             assert.deepEqual(newStat, anotherStat);
         });

--- a/node/test/util/shorthand_parser_util.js
+++ b/node/test/util/shorthand_parser_util.js
@@ -599,6 +599,20 @@ describe("ShorthandParserUtil", function () {
                     rebase: null,
                 }),
             },
+            "merge": {
+                i: "S:Mhi,1,2",
+                e: m({
+                    type: "S",
+                    merge: new RepoAST.Merge("hi", "1", "2"),
+                }),
+            },
+            "merge null": {
+                i: "S:M",
+                e: m({
+                    type: "S",
+                    merge: null,
+                }),
+            },
             "new submodule": {
                 i: "S:I x=Sfoo:;Ox",
                 e: m({
@@ -635,6 +649,7 @@ describe("ShorthandParserUtil", function () {
                 assert.equal(r.currentBranchName, e.currentBranchName);
                 assert.deepEqual(r.openSubmodules, e.openSubmodules);
                 assert.deepEqual(r.rebase, e.rebase);
+                assert.deepEqual(r.merge, e.merge);
             });
         });
     });
@@ -804,6 +819,12 @@ describe("ShorthandParserUtil", function () {
                 i: "S:Efoo,1,1",
                 e: S.copy({
                     rebase: new RepoAST.Rebase("foo", "1", "1"),
+                }),
+            },
+            "merge": {
+                i: "S:Mfoo,1,1",
+                e: S.copy({
+                    merge: new RepoAST.Merge("foo", "1", "1"),
                 }),
             },
         };
@@ -1272,6 +1293,59 @@ x=S:Efoo,8,9`,
                             }),
                         },
                         rebase: new RepoAST.Rebase("foo", "8", "9"),
+                    }),
+                }
+            },
+            "missing commits in merge": {
+                i: `
+a=B:C8-1;C9-1;Bmaster=8;Bfoo=9|
+x=S:Mfoo,8,9`,
+                e: {
+                    a: B.copy({
+                        commits: {
+                            "1": new Commit({
+                                changes: {
+                                    "README.md": "hello world"
+                                },
+                                message: "the first commit",
+                            }),
+                            "8": new Commit({
+                                parents: ["1"],
+                                changes: { "8": "8" },
+                                message: "message\n",
+                            }),
+                            "9": new Commit({
+                                parents: ["1"],
+                                changes: { "9": "9" },
+                                message: "message\n",
+                            }),
+                        },
+                        branches: {
+                            master: new RepoAST.Branch("8", null),
+                            foo: new RepoAST.Branch("9", null),
+                        },
+                        head: "8",
+                    }),
+                    x: S.copy({
+                        commits: {
+                            "1": new Commit({
+                                changes: {
+                                    "README.md": "hello world"
+                                },
+                                message: "the first commit",
+                            }),
+                            "8": new Commit({
+                                parents: ["1"],
+                                changes: { "8": "8" },
+                                message: "message\n",
+                            }),
+                            "9": new Commit({
+                                parents: ["1"],
+                                changes: { "9": "9" },
+                                message: "message\n",
+                            }),
+                        },
+                        merge: new RepoAST.Merge("foo", "8", "9"),
                     }),
                 }
             },

--- a/node/test/util/status_util.js
+++ b/node/test/util/status_util.js
@@ -34,6 +34,7 @@ const assert  = require("chai").assert;
 const co      = require("co");
 const path    = require("path");
 
+const Merge               = require("../../lib/util/merge");
 const Rebase              = require("../../lib/util/rebase");
 const RepoAST             = require("../../lib/util/repo_ast");
 const RepoASTTestUtil     = require("../../lib/util/repo_ast_test_util");
@@ -105,6 +106,7 @@ describe("StatusUtil", function () {
                     staged: { x: RepoStatus.FILESTATUS.ADDED },
                     workdir: { y: RepoStatus.FILESTATUS.ADDED },
                     rebase: new Rebase("foo", "1", "1"),
+                    merge: new Merge("foo", "1", "1"),
                 }),
                 commitMap: { "1": "3"},
                 urlMap: {},
@@ -114,6 +116,7 @@ describe("StatusUtil", function () {
                     staged: { x: RepoStatus.FILESTATUS.ADDED },
                     workdir: { y: RepoStatus.FILESTATUS.ADDED },
                     rebase: new Rebase("foo", "3", "3"),
+                    merge: new Merge("foo", "3", "3"),
                 }),
             },
             "with a sub": {
@@ -499,6 +502,14 @@ x=S:C2-1 s=Sa:a;I s=Sa:b;Bmaster=2;Os H=1`,
                 expected: new RepoStatus({
                     headCommit: "3",
                     rebase: new Rebase("master", "2", "3"),
+                }),
+            },
+            "merge": {
+                state: "x=S:C2-1;C3-1;Bfoo=3;Bmaster=2;Mhi\n,2,3",
+                expected: new RepoStatus({
+                    headCommit: "2",
+                    currentBranchName: "master",
+                    merge: new Merge("hi\n", "2", "3"),
                 }),
             },
             "staged change": {

--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -32,6 +32,7 @@
 
 const assert  = require("chai").assert;
 const co      = require("co");
+const fs      = require("fs-promise");
 const NodeGit = require("nodegit");
 const path    = require("path");
 
@@ -772,5 +773,67 @@ describe("SubmoduleUtil", function () {
             }
             assert(false, "should have thrown");
         }));
+    });
+    describe("mergeModulesFile", function () {
+        // This is largely tested in
+        // `SubmoduleConfigUtil.mergeSubmoduleConfigs`.
+        const cases = {
+            "trivial": {
+                input: "S:Cx-1;Bx=x;Cy-1;By=y",
+                expected: {},
+                result: true,
+            },
+            "one left": {
+                input: "S:Cx-1 s=Sa:1;Bx=x;Cy-1;By=y",
+                expected: {
+                    s: "a",
+                },
+                result: true,
+            },
+            "one right": {
+                input: "S:Cx-1;Bx=x;Cy-1 s=Sa:1;By=y",
+                expected: {
+                    s: "a",
+                },
+                result: true,
+            },
+            "one each": {
+                input: "S:Cx-1 s=Sa:1;Cy-1 t=Sa:1;By=y;Bx=x",
+                expected: {
+                    s: "a",
+                    t: "a",
+                },
+                result: true,
+            },
+            "conflict": {
+                input: `
+S:Cx-1 s=Sa:1;Cy-1 s=Sb:1;By=y;Bx=x;Cz-1 z=Sq:1;Bmaster=z`,
+                expected: {
+                    z: "q",
+                },
+                result: false,
+            },
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                const written = yield RepoASTTestUtil.createRepo(c.input);
+                const repo = written.repo;
+                const fromSha = written.oldCommitMap.x;
+                const ontoSha = written.oldCommitMap.y;
+                const from = yield repo.getCommit(fromSha);
+                const onto = yield repo.getCommit(ontoSha);
+                const result = yield SubmoduleUtil.mergeModulesFile(repo,
+                                                                    from,
+                                                                    onto);
+                assert.equal(result, c.result);
+                const configPath = path.join(
+                                          repo.workdir(),
+                                          SubmoduleConfigUtil.modulesFileName);
+                const data = yield fs.readFile(configPath, "utf8");
+                const onDisk = SubmoduleConfigUtil.parseSubmoduleConfig(data);
+                assert.deepEqual(c.expected, onDisk);
+            }));
+        });
     });
 });

--- a/node/test/util/write_repo_ast_util.js
+++ b/node/test/util/write_repo_ast_util.js
@@ -342,6 +342,7 @@ S:C2-1 x=y;C3-1 x=z;Bmaster=2;Bfoo=3;Erefs/heads/master,2,3;I x=q",
                 expected: "\
 S:C2-1 x=y;C3-1 x=z;Bmaster=2;Bfoo=3;Erefs/heads/master,2,3;I x=q;H=3",
             },
+            "with in-progress merge": "S:Mhello,1,1",
             "headless": {
                 input: new RepoAST(),
                 expected: new RepoAST(),


### PR DESCRIPTION
It had many problems, all of which should be fixed now:

1. Didn't support editors
2. Opened all submodules referenced on either side even if not necessary
3. Did not close opened submodules even if no commit was generated
4. Yielded on all entries, causing potential memory problems
5. Had convoluted and completely unnecessary/wrong logic mapping
   requests for FFWD/NOFFWD into the submodules.
6. Didn't handle conflicts in the .gitmodules file the way rebase did.
7. no --continue or --abort