### PR TITLE
Don't fetch submodules lacking commits

### DIFF
--- a/node/lib/util/rebase_util.js
+++ b/node/lib/util/rebase_util.js
@@ -465,7 +465,7 @@ const driveRebase = co.wrap(function *(metaRepo,
             const subRepo = yield opener.getSubrepo(name);
             const head = yield subRepo.head();
             const sha = shas[name];
-            if (head.target().tostrS() !== sha) {
+            if (undefined !== sha && head.target().tostrS() !== sha) {
                 yield fetcher.fetchSha(subRepo, name, sha);
                 yield setHead(subRepo, sha);
             }


### PR DESCRIPTION
Would lead to an error if the submodule was in an unusual state.