### PR TITLE
Stop listing misconfigured submodules as open.

### DIFF
--- a/node/lib/util/submodule_config_util.js
+++ b/node/lib/util/submodule_config_util.js
@@ -258,6 +258,31 @@ exports.getSubmodulesFromIndex = co.wrap(function *(repo, index) {
 });
 
 /**
+ * Return a map from submodule name to url in the specified `repo`.
+ *
+ * @private
+ * @async
+ * @param {NodeGit.Repository} repo
+ * @return {Object} map from name to url
+ */
+exports.getSubmodulesFromWorkdir = function (repo) {
+    assert.instanceOf(repo, NodeGit.Repository);
+
+    const modulesPath = path.join(repo.workdir(), exports.modulesFileName);
+    let data;
+    try {
+        data = fs.readFileSync(modulesPath, "utf8");
+    }
+    catch (e) {
+        // File doesn't exist, no submodules configured.
+    }
+    if (undefined === data) {
+        return {};
+    }
+    return exports.parseSubmoduleConfig(data);
+};
+
+/**
  * Return the path to the config file for the specified `repo`.
  *
  * @param {NodeGit.Repository}

--- a/node/test/util/submodule_config_util.js
+++ b/node/test/util/submodule_config_util.js
@@ -406,6 +406,36 @@ describe("SubmoduleConfigUtil", function () {
         }));
     });
 
+    describe("getSubmodulesFromWorkdir", function () {
+        // We know that the actual parsing is done by `parseSubmoduleConfig`;
+        // we just need to check that the parsing happens and that it works in
+        // the case where there is no `.gitmodules` file.
+
+        it("no gitmodules", co.wrap(function *() {
+            const repo = yield TestUtil.createSimpleRepository();
+            const result = SubmoduleConfigUtil.getSubmodulesFromWorkdir(repo);
+            assert.deepEqual(result, {});
+        }));
+
+        it("with gitmodules", co.wrap(function *() {
+            const repo = yield TestUtil.createSimpleRepository();
+            const modulesPath = path.join(repo.workdir(),
+                                          SubmoduleConfigUtil.modulesFileName);
+
+            yield fs.writeFile(modulesPath, `\
+[submodule "x/y"]
+    path = x/y
+[submodule "x/y"]
+    url = /foo/bar/baz
+`
+                              );
+            const result = SubmoduleConfigUtil.getSubmodulesFromWorkdir(repo);
+            assert.deepEqual(result, {
+                "x/y": "/foo/bar/baz",
+            });
+        }));
+    });
+
     describe("getConfigPath", function () {
         it("breathing", co.wrap(function *() {
             const repo = yield TestUtil.createSimpleRepository();

--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -338,6 +338,17 @@ describe("SubmoduleUtil", function () {
             const openSubs = yield SubmoduleUtil.listOpenSubmodules(repo);
             assert.deepEqual(openSubs, []);
         }));
+
+        it("missing from .gitmodules", co.wrap(function *() {
+            const input = "a=B|x=U:Os";
+            const written = yield RepoASTTestUtil.createMultiRepos(input);
+            const x = written.repos.x;
+            const modulesPath = path.join(x.workdir(),
+                                          SubmoduleConfigUtil.modulesFileName);
+            yield fs.unlink(modulesPath);
+            const result = yield SubmoduleUtil.listOpenSubmodules(x);
+            assert.deepEqual(result, []);
+        }));
     });
 
     describe("getSubmoduleRepos", function () {


### PR DESCRIPTION
If a submodule is in `.git/config` but not in `.gitmodules`, don't list
it as being open.  This will prevent us from trying to perform
operations on the submodules that will fail in unusual ways.