### PR TITLE
Removed failing "bare" case for getRepoStatus

### DIFF
--- a/node/test/util/status_util.js
+++ b/node/test/util/status_util.js
@@ -494,13 +494,6 @@ x=S:C2-1 s=Sa:a;I s=Sa:b;Bmaster=2;Os H=1`,
                     headCommit: "1",
                 }),
             },
-            "bare": {
-                state: "x=B",
-                expected: new RepoStatus({
-                    currentBranchName: "master",
-                    headCommit: "1",
-                }),
-            },
             "empty": {
                 state: { x: new RepoAST()},
                 expected: new RepoStatus(),


### PR DESCRIPTION
No longer works since we're looking at the worktree .gitmodules file.
Note that `git status` will not run in a bare repo, so I think this is
reasonable.