### PR TITLE
Forward all non-meta commands to Git.

### DIFF
--- a/node/lib/cmd/forward.js
+++ b/node/lib/cmd/forward.js
@@ -69,19 +69,6 @@ ${helpText}  See 'git ${name} --help' for more information.`,
 };
 
 /**
- * @property {Set} set of commands to forward
- */
-exports.forwardedCommands = new Set([
-    "branch",
-    "fetch",
-    "log",
-    "remote",
-    "rev-parse",
-    "show",
-    "tag",
-]);
-
-/**
  * Forward the specified `args` to the Git command having the specified `name`.
  *
  * @param {String}    name


### PR DESCRIPTION
Instead of forwarding just a whitelist.

addresses https://github.com/twosigma/git-meta/issues/451