### PR TITLE
Fix/improve error with branch importing submodule

### DIFF
--- a/node/lib/util/add_submodule.js
+++ b/node/lib/util/add_submodule.js
@@ -93,7 +93,8 @@ exports.addSubmodule = co.wrap(function *(repo, url, filename, importArg) {
                                                         importArg.branch);
     if (null === remoteBranch) {
         throw new UserError(`
-The requested branch: ${colors.red(importArg.ranch)} does not exist.`);
+The requested branch: ${colors.red(importArg.branch)} does not exist; \
+try '-b [BRANCH]' to specify a different branch.`);
     }
     const commit = yield subRepo.getCommit(remoteBranch.target());
     yield GitUtil.setHeadHard(subRepo, commit);


### PR DESCRIPTION
There was a bug in that it showed 'undefined' instead of the branch
name; also, will now suggest using the '-b [BRANCH]' option if the branch is
bad.

addresses https://github.com/twosigma/git-meta/issues/443