### PR TITLE
Fixed bug where reverted files were not committed

### DIFF
--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -1107,7 +1107,10 @@ exports.amendMetaRepo = co.wrap(function *(repo,
 
             }
             const subIndex = yield subRepo.index();
-            yield stageFiles(subRepo, staged, subIndex);
+            if (all) {
+                yield subIndex.addAll(["*"], -1);
+                yield subIndex.write();
+            }
             subCommits[subName] = yield exports.amendRepo(subRepo, subMessage);
             return;                                                   // RETURN
         }

--- a/node/test/util/commit.js
+++ b/node/test/util/commit.js
@@ -1489,6 +1489,14 @@ a=B:Ca-1;Bx=a|x=U:C3-2 s=Sa:a;Bmaster=3;Os;I foo=moo`,
                 expected: `
 x=U:Chi\n#x-2 foo=moo,s=Sa:s;Bmaster=x;Os Cmeh\n#s-1 a=a!H=s`,
             },
+            "one reverted, one not": {
+                input: `
+a=B:Cb-1 a=1,b=2;Cc-b a=2;Bc=c|
+x=U:C3-2 s=Sa:b;C4-3 s=Sa:c;Bmaster=4;Os W a=1,b=1`,
+                all: true,
+                expected: `
+x=U:C3-2 s=Sa:b;Cx-3 s=Sa:s;Bmaster=x;Os Cs-b b=1`,
+            },
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];


### PR DESCRIPTION
https://github.com/twosigma/git-meta/issues/473

When doing an amend, we generate a special 'RepoStatus' object that
describes what the resulting commit will actually look like.  This
allows us to display the right thing in the messsage prompt, and to know
when no change is being made (i.e., it's a reversion).

However, we were also staging exactly the files flagged as "staged" in
the status object.  Since reverted files are missing from this object,
they were not being staged, and thus were ignored when they shouldn't
have been -- in 'all' mode.  I changed the logic to just stage all files
when in 'all' mode.