### PR TITLE
Stop `--amend -a` from adding untracked files.

### DIFF
--- a/node/test/util/commit.js
+++ b/node/test/util/commit.js
@@ -3086,6 +3086,24 @@ x=U:C3-2 s=Sa:a;Bmaster=3;Os W README.md=8`,
                 expected: `
 x=U:Cfoo\n#x-2 s=Sa:s;Bmaster=x;Os Cfoo\n#s-1 README.md=foo!W README.md=8`
             },
+            "amend with all": {
+                initial: `
+a=B:Ca-1 README.md=foo;Bmaster=a|
+x=U:C3-2 s=Sa:a;Bmaster=3;Os W README.md=8`,
+                message: "foo",
+                all: true,
+                expected: `
+x=U:Cfoo\n#x-2 s=Sa:s;Bmaster=x;Os Cfoo\n#s-1 README.md=8`,
+            },
+            "amend with all and untracked": {
+                initial: `
+a=B:Ca-1 README.md=foo;Bmaster=a|
+x=U:C3-2 s=Sa:a;Bmaster=3;Os W README.md=8,foo=bar`,
+                message: "foo",
+                all: true,
+                expected: `
+x=U:Cfoo\n#x-2 s=Sa:s;Bmaster=x;Os Cfoo\n#s-1 README.md=8!W foo=bar`,
+            },
             "mismatch": {
                 initial: `
 a=B:Chello\n#a-1;Ba=a|x=U:Cworld\n#3-2 s=Sa:a;Bmaster=3`,


### PR DESCRIPTION
This was broken when I switched to using `NodeGit.Index.addAll` to stage everything.  Unfortunately, this method stages untracked files too.