### PR TITLE
Add conflicts

### DIFF
--- a/node/lib/util/add.js
+++ b/node/lib/util/add.js
@@ -83,6 +83,16 @@ exports.stagePaths = co.wrap(function *(repo, paths, stageMetaChanges, update) {
                     return index.addByPath(filename);
                 }
             });
+
+            // Add conflicted files.
+
+            const staged = subStat.workdir.status.staged;
+            yield Object.keys(staged).map(co.wrap(function *(filename) {
+                const change = staged[filename];
+                if (change instanceof RepoStatus.Conflict) {
+                    yield index.addByPath(filename);
+                }
+            }));
             yield index.write();
         }
     }));

--- a/node/test/util/add.js
+++ b/node/test/util/add.js
@@ -146,6 +146,11 @@ a=B|x=S:C2-1 a/b=Sa:1;Oa/b W x/y/z=a,x/r/z=b;Bmaster=2`,
                 expected: "x=U:Os I README.md",
                 paths: [""],
             },
+            "sub with conflict": {
+                initial: "a=B|x=U:Os I *README.md=a*b*c!W README.md=foo",
+                paths: ["s"],
+                expected: "x=E:Os I README.md=foo",
+            },
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];


### PR DESCRIPTION
*** This PR is dependent on https://github.com/twosigma/git-meta/pull/504 for test support of conflicts.

Fix add to stage conflicted files

`git meta add` was not staging files with conflicts because they didn't
show up in my status object under the workdir.