### PR TITLE
Fix flaky `StashUtil.removeStash`

### DIFF
--- a/node/lib/util/stash_util.js
+++ b/node/lib/util/stash_util.js
@@ -390,11 +390,16 @@ exports.removeStash = co.wrap(function *(repo, index) {
     if (0 === index) {
         if (count > 1) {
             const entry = log.entryByIndex(0);
-            NodeGit.Reference.create(repo,
-                                     metaStashRef,
-                                     entry.idNew(),
-                                     1,
-                                     "removeStash");
+            yield NodeGit.Reference.create(repo,
+                                           metaStashRef,
+                                           entry.idNew(),
+                                           1,
+                                           "removeStash");
+            // But then in doing so, we've written a new entry for the ref,
+            // remove the old one.
+
+            log.drop(1, 1 /* rewrite previous entry */);
+            log.write();
         }
         else {
             NodeGit.Reference.remove(repo, metaStashRef);


### PR DESCRIPTION
It was missing a yield statement to where I was pointing the stash
reference to a new commit.  When the yield is added, the test failed
because we ended up with a duplicate entry in the reflog.  I believe
that what was happening when the test succeeded was that the reference
itself was updated but that the program exited before the reflog entry
was added.

After adding the `yield`, I had to add another statement to remove the
duplicate entry.

I validated that the test no longer flaked by running it in a loop in
bash.  Previously it would fail every second or third time.