### PR TITLE
Stop using unnecessary `stateCleanup` after cherry

### DIFF
--- a/node/lib/util/cherry_pick_util.js
+++ b/node/lib/util/cherry_pick_util.js
@@ -382,7 +382,6 @@ const finish = co.wrap(function *(repo, commit) {
     assert.instanceOf(repo, NodeGit.Repository);
     assert.instanceOf(commit, NodeGit.Commit);
 
-    repo.stateCleanup();
     const defaultSig = repo.defaultSignature();
     const metaCommit = yield repo.createCommitOnHead([],
                                                      defaultSig,


### PR DESCRIPTION
Addresses: https://github.com/twosigma/git-meta/issues/224