### PR TITLE
Stop `reset --hard` if will remove dirty open subs

### DIFF
--- a/node/lib/util/cherry_pick_util.js
+++ b/node/lib/util/cherry_pick_util.js
@@ -569,7 +569,7 @@ exports.abort = co.wrap(function *(repo) {
         throw new UserError("No cherry-pick in progress.");
     }
     const commit = yield repo.getCommit(cherry.originalHead);
-    yield Reset.reset(repo, commit, Reset.TYPE.HARD);
+    yield Reset.reset(repo, commit, Reset.TYPE.MERGE);
     yield CherryPickFileUtil.cleanCherryPick(repo.path());
     console.log("Cherry-pick aborted.");
 });


### PR DESCRIPTION
In this case, libgit2 will delete the submodule's directory, throwing
away all changes.  See https://github.com/twosigma/git-meta/issues/509

I do not want to do this check when resetting to abort cherry-pick -- we
started out clean before picking and it could be pretty common that
we've added a submodule that we want to get rid of when we abort -- but
I don't want to add a weird flag that will exist just for this
workaround.  So, I went ahead and added a `MERGE` reset type, that will
eventually do a real `git reset --merge` but for the time being is just
like `HARD` except that it does not do this check.