### PR TITLE
Allow tracking of nested remote branch names.

### DIFF
--- a/node/lib/util/checkout.js
+++ b/node/lib/util/checkout.js
@@ -471,7 +471,7 @@ Cannot setup tracking information; starting point is not a branch.`);
             // otherwise leve the remote name 'null';
 
             if (committishBranch.isRemote()) {
-                const parts = committishBranch.shorthand().split("/");
+                const parts = committishBranch.shorthand().split(/\/(.+)/);
                 tracking = {
                     remoteName: parts[0],
                     branchName: parts[1],

--- a/node/test/util/checkout.js
+++ b/node/test/util/checkout.js
@@ -405,6 +405,21 @@ a=B|x=S:C2-1 s=Sa:1;C3-2 r=Sa:1,t=Sa:1;Os;Bmaster=3;Bfoo=2;H=2`,
                 },
                 expectedSwitchBranch: "foo",
             },
+            "new branch(nested name) with remote tracking": {
+                state: "x=S:Rhar=/a managed/hey=1",
+                committish: "har/managed/hey",
+                newBranch: "foo",
+                track: true,
+                expectedSha: "1",
+                expectedNewBranch: {
+                    name: "foo",
+                    tracking: {
+                        remoteName: "har",
+                        branchName: "managed/hey",
+                    },
+                },
+                expectedSwitchBranch: "foo",
+            },
             "tracking on new branch but commit not a branch": {
                 state: "x=S",
                 committish: "1",


### PR DESCRIPTION
Currently, we assume remote/branch naming when checking whats passed to --track. 
This pr to support nested branch names.

Example:

If my branch name is `managed/lovely_branch` on my `remote`. I will get this error:

`
$ git meta checkout -b test_branch --track remote/managed/lovely_branch

Error: cannot set upstream for branch 'test_branch'
    at Error (native)
`

