### PR TITLE
Test framework support for sparse checkout mode.

### DIFF
--- a/node/lib/util/read_repo_ast_util.js
+++ b/node/lib/util/read_repo_ast_util.js
@@ -44,6 +44,7 @@ const path     = require("path");
 
 const RepoAST             = require("./repo_ast");
 const RebaseFileUtil      = require("./rebase_file_util");
+const SparseCheckoutUtil  = require("./sparse_checkout_util");
 const SequencerStateUtil  = require("./sequencer_state_util");
 const SubmoduleConfigUtil = require("./submodule_config_util");
 
@@ -425,10 +426,17 @@ exports.readRAST = co.wrap(function *(repo) {
         headCommitId = headCommit.id().tostrS();
     }
 
+    const sparse = yield SparseCheckoutUtil.inSparseMode(repo);
+
     if (!bare) {
         const current = yield loadIndexAndWorkdir(repo, headCommit);
         index = current.index;
-        workdir = current.workdir;
+
+        // Ignore the workdir if it's sparse.
+
+        if (!sparse) {
+            workdir = current.workdir;
+        }
     }
 
     // Now we can actually build the remote objects.
@@ -564,5 +572,6 @@ exports.readRAST = co.wrap(function *(repo) {
         rebase: rebase,
         sequencerState: sequencer,
         bare: bare,
+        sparse: sparse,
     });
 });

--- a/node/lib/util/repo_ast.js
+++ b/node/lib/util/repo_ast.js
@@ -393,6 +393,7 @@ class AST {
      * @param {Object}         [args.openSubmodules]
      * @param {Rebase}         [args.rebase]
      * @param {SequencerState} [args.sequencerState]
+     * @param {Boolean}        [args.sparse]
      */
     constructor(args) {
         if (undefined === args) {
@@ -655,6 +656,13 @@ in commit ${id}.`);
                 }
             }
         }
+
+        this.d_sparse = false;
+        if ("sparse" in args) {
+            this.d_sparse = args.sparse;
+            assert.isBoolean(this.d_sparse);
+        }
+
         Object.freeze(this);
     }
 
@@ -754,6 +762,13 @@ in commit ${id}.`);
     }
 
     /**
+     * @property {Boolean} true if repo is sparse and false otherwise
+     */
+    get sparse() {
+        return this.d_sparse;
+    }
+
+    /**
      * Accumulate the specified `changes` into the specified `dest` map.  A
      * non-null value in `changes` overrides any existing value in `dest`; a
      * `null value causes the path mapped to `null` to be removed.  The
@@ -815,6 +830,7 @@ in commit ${id}.`);
             sequencerState: ("sequencerState" in args) ?
                        args.sequencerState: this.d_sequencerState,
             bare: ("bare" in args) ? args.bare : this.d_bare,
+            sparse: ("sparse" in args) ? args.sparse : this.d_sparse,
         });
     }
 

--- a/node/lib/util/repo_ast_util.js
+++ b/node/lib/util/repo_ast_util.js
@@ -495,6 +495,16 @@ Expected sequencer to be ${actual.sequencerState} but got \
 ${expected.sequencerState}`);
     }
 
+    // Check sparse
+
+    if (actual.sparse !== expected.sparse) {
+        if (expected.sparse) {
+            result.push(`Expected repository to be sparse.`);
+        }
+        else {
+            result.push(`Expected repository not to be sparse.`);
+        }
+    }
 
     return result;
 }

--- a/node/test/util/repo_ast.js
+++ b/node/test/util/repo_ast.js
@@ -275,6 +275,8 @@ const REBASE = SequencerState.TYPE.REBASE;
                     erebase: ("rebase" in expected) ?  expected.rebase : null,
                     esequencerState: ("sequencerState" in expected) ?
                         expected.sequencerState : null,
+                    esparse   : ("sparse" in expected) ?
+                                                       expected.sparse : false,
                     fails   : fails,
                 };
             }
@@ -290,6 +292,7 @@ const REBASE = SequencerState.TYPE.REBASE;
                         rebase: null,
                         sequencerState: null,
                         bare: false,
+                        sparse: false,
                     },
                     undefined,
                     false),
@@ -660,6 +663,7 @@ const REBASE = SequencerState.TYPE.REBASE;
                         currentCommit: 1,
                     }),
                 }, undefined, true),
+                "with sparse": m({ sparse: true }, { sparse: true} , false),
             };
             Object.keys(cases).forEach(caseName => {
                 it(caseName, function () {
@@ -684,6 +688,7 @@ const REBASE = SequencerState.TYPE.REBASE;
                     assert.deepEqual(obj.rebase, c.erebase);
                     assert.deepEqual(obj.sequencerState, c.esequencerState);
                     assert.equal(obj.bare, c.ebare);
+                    assert.equal(obj.sparse, c.esparse);
 
                     if (c.input) {
                         assert.notEqual(obj.commits, c.input.commits);
@@ -810,6 +815,7 @@ const REBASE = SequencerState.TYPE.REBASE;
                     currentCommit: 0,
                 }),
                 bare: false,
+                sparse: false,
             });
             const newArgs = {
                 commits: { "2": new RepoAST.Commit()},
@@ -829,6 +835,7 @@ const REBASE = SequencerState.TYPE.REBASE;
                     currentCommit: 0,
                 }),
                 bare: false,
+                sparse: false,
             };
             const cases = {
                 "trivial": {
@@ -856,6 +863,23 @@ const REBASE = SequencerState.TYPE.REBASE;
                         bare: true,
                     }),
                 },
+                "sparse": {
+                    i: {
+                        sparse: true,
+                        index: {},
+                        workdir: {},
+                        rebase: null,
+                        sequencerState: null,
+                    },
+                    e: new RepoAST({
+                        commits: { "1": new RepoAST.Commit()},
+                        branches: { "master": new RepoAST.Branch("1", null) },
+                        refs: { "a/b": "1"},
+                        head: "1",
+                        currentBranchName: "master",
+                        sparse: true,
+                    }),
+                },
             };
             Object.keys(cases).forEach(caseName => {
                 it(caseName, function () {
@@ -873,6 +897,7 @@ const REBASE = SequencerState.TYPE.REBASE;
                     assert.deepEqual(obj.rebase, c.e.rebase);
                     assert.deepEqual(obj.sequencerState, c.e.sequencerState);
                     assert.equal(obj.bare, c.e.bare);
+                    assert.equal(obj.sparse, c.e.sparse);
                 });
             });
         });

--- a/node/test/util/repo_ast_util.js
+++ b/node/test/util/repo_ast_util.js
@@ -178,6 +178,7 @@ describe("RepoAstUtil", function () {
                         currentCommit: 0,
                     }),
                     bare: false,
+                    sparse: false,
                 }),
                 expected: new AST({
                     commits: { "1": aCommit},
@@ -198,6 +199,7 @@ describe("RepoAstUtil", function () {
                         currentCommit: 0,
                     }),
                     bare: false,
+                    sparse: false,
                 }),
             },
             "bad bare": {
@@ -643,7 +645,12 @@ describe("RepoAstUtil", function () {
                 }),
                 fails: true,
             },
-        };
+             "bad sparse": {
+                actual: new AST({ sparse: true }),
+                expected: new AST({ sparse: false }),
+                fails: true,
+            },
+       };
         Object.keys(cases).forEach((caseName) => {
             const c = cases[caseName];
             it(caseName, function () {

--- a/node/test/util/shorthand_parser_util.js
+++ b/node/test/util/shorthand_parser_util.js
@@ -158,6 +158,7 @@ describe("ShorthandParserUtil", function () {
         }
         const cases = {
             "just type": { i: "S", e: m({ type: "S"})},
+            "sparse": { i: "%S", e: m({ type: "S", sparse: true}) },
             "just another type": { i: "B", e: m({ type: "B"})},
             "branch": { i: "S:Bm=2", e: m({
                 branches: { m: new RepoAST.Branch("2", null), },
@@ -739,6 +740,7 @@ describe("ShorthandParserUtil", function () {
                 assert.deepEqual(r.openSubmodules, e.openSubmodules);
                 assert.deepEqual(r.rebase, e.rebase);
                 assert.deepEqual(r.sequencerState, e.sequencerState);
+                assert.equal(r.sparse, e.sparse);
             });
         });
     });
@@ -756,6 +758,12 @@ describe("ShorthandParserUtil", function () {
             "simple": {
                 i: "S",
                 e: S
+            },
+            "sparse": {
+                i: "%S",
+                e: S.copy({
+                    sparse: true,
+                }),
             },
             "null": {
                 i: "N",


### PR DESCRIPTION
We're not trying to support general sparse checkout, just our specific
mode, and we don't really care about non-submodule changes.  Overview:

1. Added `sparse` to RepoAST and RepoASTUtil
2. Support for reading and writing repos with in sparse mode.
3. Shorthand support -- '%' prefixed to a repos base type indicates
   sparse mode.

Addresses: https://github.com/twosigma/git-meta/projects/5#card-9115833