### PR TITLE
Allow checkout to work in empty/semi-empty state

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -391,7 +391,17 @@ exports.getCurrentBranchName = co.wrap(function *(repo) {
     assert.instanceOf(repo, NodeGit.Repository);
 
     if (!repo.isEmpty() && 1 !== repo.headDetached()) {
-        const branch = yield repo.getCurrentBranch();
+        let branch;
+        try {
+            branch = yield repo.getCurrentBranch();
+        } catch (e) {
+            // TODO: raise an issue with libgit2.  If your repository is in a
+            // newly initialized state, but not fully empty (e.g., it has
+            // configured remotes), this method throws an exception:
+            // "reference 'refs/heads/master' not found".  Either it should
+            // return null or `isEmpty` should return true.
+            return null;
+        }
         return branch.shorthand();
     }
     return null;

--- a/node/lib/util/submodule_fetcher.js
+++ b/node/lib/util/submodule_fetcher.js
@@ -53,17 +53,25 @@ class SubmoduleFetcher {
      * if provided, or the URL of the remote named "origin" in `repo`
      * otherwise.  If `repo` has no remote named "origin", and `fetchSha` is
      * called for a submodule that has a relativre URL, throw a `UserError`.
+     * If `null === commit`, no URLS are available.
      *
-     * @param {NodeGit.Repository} repo
-     * @param {NodeGit.Commit}     commit
+     * @param {NodeGit.Repository}  repo
+     * @param {NodeGit.Commit|null} commit
      */
     constructor(repo, commit) {
         assert.instanceOf(repo, NodeGit.Repository);
-        assert.instanceOf(commit, NodeGit.Commit);
+        if (null !== commit) {
+            assert.instanceOf(commit, NodeGit.Commit);
+        }
 
         this.d_repo   = repo;
         this.d_commit = commit;
-        this.d_urls   = null;
+
+        if (null === commit) {
+            this.d_urls = {};
+        } else {
+            this.d_urls = null;
+        }
 
         // d_metaOrigin may have three types of values:
         // 1. undefined -- we haven't tried to access it yet
@@ -81,7 +89,7 @@ class SubmoduleFetcher {
     }
 
     /**
-     * @param {NodeGit.Commit} commit commit associated with this fetcher
+     * @param {NodeGit.Commit|null} commit commit associated with this fetcher
      */
     get commit() {
         return this.d_commit;

--- a/node/test/util/checkout.js
+++ b/node/test/util/checkout.js
@@ -96,6 +96,11 @@ describe("Checkout", function () {
                 committish: "foo",
                 fails: true,
             },
+            "from empty": {
+                input: "a=B:C2 s=Sb:1;Bfoo=2|b=B|x=N:Rtrunk=a foo=2",
+                committish: "trunk/foo",
+                expected: "x=E:H=2",
+            },
             "conflict": {
                 input: `a=B:Ca-1;Ba=a|x=U:C3-2 s=Sa:a;Bfoo=3;Os I a=9`,
                 committish: "foo",

--- a/node/test/util/git_util.js
+++ b/node/test/util/git_util.js
@@ -516,6 +516,9 @@ describe("GitUtil", function () {
             "detached head": { input: "S:*=", expected: null },
             "not master": { input: "S:Bmaster=;Bfoo=1;*=foo", expected: "foo"},
             "empty": { input: new RepoAST(), expected: null },
+            "no current branch but not empty": {
+                input: "N:C2;Rtrunk=/a foo=2",
+            },
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];

--- a/node/test/util/submodule_fetcher.js
+++ b/node/test/util/submodule_fetcher.js
@@ -49,6 +49,11 @@ describe("SubmoduleFetcher", function () {
                 metaSha: "2",
                 expected: null,
             },
+            "null commit": {
+                initial: "a=B:C4-1;Bfoo=4|b=B|x=U:Os Rorigin=c",
+                metaSha: null,
+                expected: null,
+            },
             "pulled from origin": {
                 initial: "a=B:C4-1;Bfoo=4|b=B|x=Ca",
                 metaSha: "1",
@@ -62,8 +67,11 @@ describe("SubmoduleFetcher", function () {
                 const written =
                              yield RepoASTTestUtil.createMultiRepos(c.initial);
                 const repo = written.repos.x;
-                const newSha = written.reverseCommitMap[c.metaSha];
-                const commit = yield repo.getCommit(newSha);
+                let commit = null;
+                if (null !== c.metaSha) {
+                    const newSha = written.reverseCommitMap[c.metaSha];
+                    commit = yield repo.getCommit(newSha);
+                }
                 let metaUrl = c.metaOriginUrl;
                 if (null !== metaUrl) {
                     metaUrl = written.reverseUrlMap[metaUrl];


### PR DESCRIPTION
Fixed a couple of problems here:

* Allowed `SubmoduleFetcher` to accept a null commit in its constructor
  to make it possible to work with a headless repo
* Fixed `GitUtil.getCurrentBranchName` to work in a semi-empty state
  where libgit2 throws an error if you ask for the current branch.

Addresses https://github.com/twosigma/git-meta/issues/558