### PR TITLE
Address path mode changes in `TreeUtil`

### DIFF
--- a/node/lib/util/stash_util.js
+++ b/node/lib/util/stash_util.js
@@ -383,11 +383,13 @@ const getStashSha = co.wrap(function *(repo, index) {
 exports.removeStash = co.wrap(function *(repo, index) {
     assert.instanceOf(repo, NodeGit.Repository);
     assert.isNumber(index);
+
+
     const log = yield NodeGit.Reflog.read(repo, metaStashRef);
     const stashSha = yield getStashSha(repo, index);
     const count = log.entrycount();
     log.drop(index, 1 /* rewrite previous entry */);
-    log.write();
+    yield log.write();
 
     // We dropped the first element.  We need to update `refs/meta-stash`
 
@@ -403,7 +405,7 @@ exports.removeStash = co.wrap(function *(repo, index) {
             // remove the old one.
 
             log.drop(1, 1 /* rewrite previous entry */);
-            log.write();
+            yield log.write();
         }
         else {
             NodeGit.Reference.remove(repo, metaStashRef);

--- a/node/test/util/tree_util.js
+++ b/node/test/util/tree_util.js
@@ -85,6 +85,28 @@ describe("TreeUtil", function () {
                     },
                 },
             },
+            "deleted tree changed to parent": {
+                input: {
+                    "a": null,
+                    "a/b": "1",
+                },
+                expected: {
+                    "a": {
+                        "b": "1",
+                    },
+                },
+            },
+            "deleted tree changed to parent, order reversed": {
+                input: {
+                    "a/b": "1",
+                    "a": null,
+                },
+                expected: {
+                    "a": {
+                        "b": "1",
+                    },
+                },
+            },
         };
         Object.keys(cases).forEach((caseName) => {
             const c = cases[caseName];
@@ -235,6 +257,58 @@ describe("TreeUtil", function () {
             });
             const entry = yield secondTree.entryByPath("foo");
             assert.equal(entry.id().tostrS(), newId.tostrS());
+        }));
+        it("from blob to tree with blob", co.wrap(function *() {
+            const repo = yield makeRepo();
+            const id = yield hashObject(repo, "xxxxxxxh");
+            const firstTree = yield TreeUtil.writeTree(repo, null, {
+                "foo": new Change(id, FILEMODE.BLOB),
+            });
+            const secondTree = yield TreeUtil.writeTree(repo, firstTree, {
+                "foo": null,
+                "foo/bar": new Change(id, FILEMODE.BLOB),
+            });
+            const entry = yield secondTree.entryByPath("foo/bar");
+            assert.equal(entry.id().tostrS(), id.tostrS());
+        }));
+        it("from blob to tree with blob, reversed", co.wrap(function *() {
+            const repo = yield makeRepo();
+            const id = yield hashObject(repo, "xxxxxxxh");
+            const firstTree = yield TreeUtil.writeTree(repo, null, {
+                "foo": new Change(id, FILEMODE.BLOB),
+            });
+            const secondTree = yield TreeUtil.writeTree(repo, firstTree, {
+                "foo/bar": new Change(id, FILEMODE.BLOB),
+                "foo": null,
+            });
+            const entry = yield secondTree.entryByPath("foo/bar");
+            assert.equal(entry.id().tostrS(), id.tostrS());
+        }));
+        it("from tree with blob to blob", co.wrap(function *() {
+            const repo = yield makeRepo();
+            const id = yield hashObject(repo, "xxxxxxxh");
+            const firstTree = yield TreeUtil.writeTree(repo, null, {
+                "foo/bar": new Change(id, FILEMODE.BLOB),
+            });
+            const secondTree = yield TreeUtil.writeTree(repo, firstTree, {
+                "foo": new Change(id, FILEMODE.BLOB),
+                "foo/bar": null,
+            });
+            const entry = yield secondTree.entryByPath("foo");
+            assert.equal(entry.id().tostrS(), id.tostrS());
+        }));
+        it("from tree with blob to blob, reversed", co.wrap(function *() {
+            const repo = yield makeRepo();
+            const id = yield hashObject(repo, "xxxxxxxh");
+            const firstTree = yield TreeUtil.writeTree(repo, null, {
+                "foo/bar": new Change(id, FILEMODE.BLOB),
+            });
+            const secondTree = yield TreeUtil.writeTree(repo, firstTree, {
+                "foo/bar": null,
+                "foo": new Change(id, FILEMODE.BLOB),
+            });
+            const entry = yield secondTree.entryByPath("foo");
+            assert.equal(entry.id().tostrS(), id.tostrS());
         }));
     });
     describe("hashFile", function () {


### PR DESCRIPTION
Specifically, those where a "tree" (a.k.a. directory) changes into
something else and vice-versa.

Addresses: https://github.com/twosigma/git-meta/issues/562