### PR TITLE
use increment instead of epoch for shadow times

### DIFF
--- a/node/lib/cmd/commit-shadow.js
+++ b/node/lib/cmd/commit-shadow.js
@@ -80,7 +80,15 @@ exports.configureParser = function (parser) {
         action: "storeConst",
         constant: true,
         defaultValue: false,
-        help: "include timestamp in the shadow commit",
+        help: "deprecated, but same as '--increment-timestamp'",
+    });
+
+    parser.addArgument(["-i", "--increment-timestamp"], {
+        required: false,
+        action: "storeConst",
+        constant: true,
+        defaultValue: false,
+        help: "use timestamp of HEAD + 1 instead of current time",
     });
 };
 
@@ -96,9 +104,11 @@ exports.executeableSubcommand = co.wrap(function *(args) {
     const StashUtil = require("../util/stash_util");
 
     const repo = yield GitUtil.getCurrentRepo();
+    const incrementTimestamp =
+                              args.increment_timestamp || args.epoch_timestamp;
     const result = yield StashUtil.makeShadowCommit(repo,
                                                     args.message,
-                                                    args.epoch_timestamp,
+                                                    incrementTimestamp,
                                                     false,
                                                     args.include_untracked);
     if (null === result) {

--- a/node/test/util/stash_util.js
+++ b/node/test/util/stash_util.js
@@ -720,7 +720,7 @@ meta-stash@{1}: log of 1
                 expected: "x=E:Cfoo\n#m-1 foo/bar=2;Bm=m",
                 message: "foo",
                 includeMeta: true,
-                useEpochTimestamp: true,
+                incrementTimestamp: true,
             },
             "deleted file": {
                 state: "x=S:W README.md",
@@ -786,22 +786,23 @@ x=E:Cm-1 s=Sa:s;Bm=m;Os Cs foo=bar!Bs=s!W foo=bar`
                 const meta = c.includeMeta;
                 const includeUntracked =
                         undefined === c.includeUntracked || c.includeUntracked;
-                const useEpochTimestamp =
-                        (undefined === c.useEpochTimestamp) ?
-                        false : c.useEpochTimestamp;
+                const incrementTimestamp =
+                        (undefined === c.incrementTimestamp) ?
+                        false : c.incrementTimestamp;
                 const result = yield StashUtil.makeShadowCommit(
-                                                             repo,
-                                                             message,
-                                                             useEpochTimestamp,
-                                                             meta,
-                                                             includeUntracked);
+                                                            repo,
+                                                            message,
+                                                            incrementTimestamp,
+                                                            meta,
+                                                            includeUntracked);
 
                 const commitMap = {};
                 if (null !== result) {
                     const metaSha = result.metaCommit;
                     const commit = yield repo.getCommit(metaSha);
-                    if (useEpochTimestamp) {
-                        assert.equal(commit.time(), 0);
+                    const head = yield repo.getHeadCommit();
+                    if (incrementTimestamp) {
+                        assert.equal(commit.time(), head.time() + 1);
                     }
                     commitMap[metaSha] = "m";
                     yield NodeGit.Branch.create(repo, "m", commit, 1);


### PR DESCRIPTION
Commits with old times confuse (as in makes very expensive) Git's fetch
logic, so instead of using an epoch time to make sure subsequent shadow
commits of unchanged code have the same sha, we'll use the time of HEAD
+ 1.