### PR TITLE
Detect when up-to-date in `merge`

### DIFF
--- a/node/lib/util/merge_util.js
+++ b/node/lib/util/merge_util.js
@@ -349,6 +349,15 @@ running merge.`);
         return result;
     }
 
+    const upToDate  = yield NodeGit.Graph.descendantOf(repo,
+                                                       head.id().tostrS(),
+                                                       commitSha);
+
+    if (upToDate) {
+        console.log("Up-to-date.");
+        return result;
+    }
+
     const canFF = yield NodeGit.Graph.descendantOf(repo,
                                                    commitSha,
                                                    head.id().tostrS());

--- a/node/test/util/merge_util.js
+++ b/node/test/util/merge_util.js
@@ -221,6 +221,10 @@ x=U:C3-2 s=Sa:a;Bfoo=3;Os W a=b`,
                 initial: "x=S",
                 fromCommit: "1",
             },
+            "up-to-date": {
+                initial: "a=B|x=U:C3-2 t=Sa:1;Bmaster=3;Bfoo=2",
+                fromCommit: "2",
+            },
             "trivial -- nothing to do, has untracked change": {
                 initial: "a=B|x=U:Os W foo=8",
                 fromCommit: "2",


### PR DESCRIPTION
Right now it will make a new merge-commit even if the target commit
already exists in history.