### PR TITLE
sync sparse-checkout & index after open/close

### DIFF
--- a/node/lib/cmd/open.js
+++ b/node/lib/cmd/open.js
@@ -82,6 +82,7 @@ exports.executeableSubcommand = co.wrap(function *(args) {
     const DoWorkQueue         = require("../util/do_work_queue");
     const GitUtil             = require("../util/git_util");
     const Open                = require("../util/open");
+    const SparseCheckoutUtil  = require("../util/sparse_checkout_util");
     const SubmoduleConfigUtil = require("../util/submodule_config_util");
     const SubmoduleFetcher    = require("../util/submodule_fetcher");
     const SubmoduleUtil       = require("../util/submodule_util");
@@ -140,6 +141,10 @@ Opening ${colors.blue(name)} on ${colors.green(shas[index])}.`);
         console.log(`Finished opening ${colors.blue(name)}.`);
     });
     yield DoWorkQueue.doInParallel(subsToOpen, opener);
+
+    // Make sure the index entries are updated in case we're in sparse mode.
+
+    yield SparseCheckoutUtil.writeMetaIndex(repo, index);
 
     // Run post-open-submodule hook with submodules which opened successfully.
     yield Hook.execHook("post-open-submodule", subsOpenSuccessfully);

--- a/node/lib/util/add.js
+++ b/node/lib/util/add.js
@@ -37,11 +37,11 @@ const fs        = require("fs-promise");
 const NodeGit   = require("nodegit");
 const path      = require("path");
 
-const GitUtil       = require("./git_util");
-const RepoStatus    = require("./repo_status");
-const StatusUtil    = require("./status_util");
-const SubmoduleUtil = require("./submodule_util");
-const UserError     = require("./user_error");
+const RepoStatus         = require("./repo_status");
+const SparseCheckoutUtil = require("./sparse_checkout_util");
+const StatusUtil         = require("./status_util");
+const SubmoduleUtil      = require("./submodule_util");
+const UserError          = require("./user_error");
 
 /**
  * Stage modified content at the specified `paths` in the specified `repo`.  If
@@ -116,6 +116,6 @@ exports.stagePaths = co.wrap(function *(repo, paths, stageMetaChanges, update) {
     if (0 !== toAdd.length) {
         const index = yield repo.index();
         yield toAdd.map(filename => index.addByPath(filename));
-        yield GitUtil.writeMetaIndex(repo, index);
+        yield SparseCheckoutUtil.writeMetaIndex(repo, index);
     }
 });

--- a/node/lib/util/add_submodule.js
+++ b/node/lib/util/add_submodule.js
@@ -36,6 +36,7 @@ const colors    = require("colors");
 const NodeGit   = require("nodegit");
 
 const GitUtil             = require("./git_util");
+const SparseCheckoutUtil  = require("./sparse_checkout_util");
 const SubmoduleConfigUtil = require("./submodule_config_util");
 const UserError           = require("./user_error");
 
@@ -65,7 +66,7 @@ exports.addSubmodule = co.wrap(function *(repo, url, filename, importArg) {
     const urls = yield SubmoduleConfigUtil.getSubmodulesFromIndex(repo, index);
     urls[filename] = url;
     yield SubmoduleConfigUtil.writeUrls(repo, index, urls);
-    yield GitUtil.writeMetaIndex(repo, index);
+    yield SparseCheckoutUtil.writeMetaIndex(repo, index);
 
     const metaUrl = yield GitUtil.getOriginUrl(repo);
     const templatePath = yield SubmoduleConfigUtil.getTemplatePath(repo);

--- a/node/lib/util/checkout.js
+++ b/node/lib/util/checkout.js
@@ -38,14 +38,15 @@ const co      = require("co");
 const colors  = require("colors");
 const NodeGit = require("nodegit");
 
-const DoWorkQueue      = require("../util/do_work_queue");
-const GitUtil          = require("./git_util");
-const SubmoduleFetcher = require("./submodule_fetcher");
-const Reset            = require("./reset");
-const RepoStatus       = require("./repo_status");
-const StatusUtil       = require("./status_util");
-const SubmoduleUtil    = require("./submodule_util");
-const UserError        = require("./user_error");
+const DoWorkQueue        = require("../util/do_work_queue");
+const GitUtil            = require("./git_util");
+const Reset              = require("./reset");
+const RepoStatus         = require("./repo_status");
+const SparseCheckoutUtil = require("./sparse_checkout_util");
+const StatusUtil         = require("./status_util");
+const SubmoduleFetcher   = require("./submodule_fetcher");
+const SubmoduleUtil      = require("./submodule_util");
+const UserError          = require("./user_error");
 
 /**
  * If the specified `name` matches the tracking branch for one and only one
@@ -234,7 +235,7 @@ exports.checkoutCommit = co.wrap(function *(repo, commit, force) {
         repo.setHeadDetached(commit);
     });
     yield DoWorkQueue.doInParallel(Object.keys(subs), doCheckout);
-    yield GitUtil.writeMetaIndex(repo, index);
+    yield SparseCheckoutUtil.writeMetaIndex(repo, index);
 });
 
 /**

--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -50,6 +50,7 @@ const GitUtil             = require("./git_util");
 const Open                = require("./open");
 const RepoStatus          = require("./repo_status");
 const PrintStatusUtil     = require("./print_status_util");
+const SparseCheckoutUtil  = require("./sparse_checkout_util");
 const StatusUtil          = require("./status_util");
 const Submodule           = require("./submodule");
 const SubmoduleConfigUtil = require("./submodule_config_util");
@@ -366,7 +367,7 @@ const stageOpenSubmodules = co.wrap(function *(repo, index, submodules) {
             yield index.addByPath(name);
         }
     }));
-    yield GitUtil.writeMetaIndex(repo, index);
+    yield SparseCheckoutUtil.writeMetaIndex(repo, index);
 });
 
 /**
@@ -628,7 +629,7 @@ exports.writeRepoPaths = co.wrap(function *(repo, status, message) {
         }
     }
 
-    yield GitUtil.writeMetaIndex(repo, index);
+    yield SparseCheckoutUtil.writeMetaIndex(repo, index);
 
     // Use 'TreeUtil' to create a new tree having the required paths.
 

--- a/node/lib/util/merge_util.js
+++ b/node/lib/util/merge_util.js
@@ -45,6 +45,7 @@ const Open                = require("./open");
 const RepoStatus          = require("./repo_status");
 const SequencerState      = require("./sequencer_state");
 const SequencerStateUtil  = require("./sequencer_state_util");
+const SparseCheckoutUtil  = require("./sparse_checkout_util");
 const StatusUtil          = require("./status_util");
 const SubmoduleRebaseUtil = require("./submodule_rebase_util");
 const SubmoduleUtil       = require("./submodule_util");
@@ -424,9 +425,9 @@ ${colors.red(commitSha)}.`);
         errorMessage += SubmoduleRebaseUtil.subConflictErrorMessage(name);
     });
 
-    // We must write the index here or the staging we've done erlier will go
+    // We must write the index here or the staging we've done earlier will go
     // away.
-    yield GitUtil.writeMetaIndex(repo, index);
+    yield SparseCheckoutUtil.writeMetaIndex(repo, index);
 
     if ("" !== errorMessage) {
         // We're about to fail due to conflict.  First, record that there is a
@@ -556,7 +557,7 @@ exports.continue = co.wrap(function *(repo) {
     });
     const openSubs = yield SubmoduleUtil.listOpenSubmodules(repo);
     yield DoWorkQueue.doInParallel(openSubs, continueSub);
-    yield GitUtil.writeMetaIndex(repo, index);
+    yield SparseCheckoutUtil.writeMetaIndex(repo, index);
 
     if ("" !== errorMessage) {
         throw new UserError(errorMessage);
@@ -625,7 +626,7 @@ exports.abort = co.wrap(function *(repo) {
     });
     yield DoWorkQueue.doInParallel(openSubs, abortSub);
     yield index.conflictCleanup();
-    yield GitUtil.writeMetaIndex(repo, index);
+    yield SparseCheckoutUtil.writeMetaIndex(repo, index);
     yield resetMerge(repo);
     yield SequencerStateUtil.cleanSequencerState(repo.path());
 });

--- a/node/lib/util/reset.js
+++ b/node/lib/util/reset.js
@@ -248,7 +248,7 @@ exports.reset = co.wrap(function *(repo, commit, type) {
 
     // Write the index in case we've had to stage submodule changes.
 
-    yield GitUtil.writeMetaIndex(repo, index);
+    yield SparseCheckoutUtil.writeMetaIndex(repo, index);
 });
 
 /**

--- a/node/lib/util/rm.js
+++ b/node/lib/util/rm.js
@@ -38,8 +38,8 @@ const groupBy      = require("group-by");
 const path         = require("path");
 const NodeGit      = require("nodegit");
 
-const GitUtil             = require("./git_util");
 const CloseUtil           = require("./close_util");
+const SparseCheckoutUtil  = require("./sparse_checkout_util");
 const SubmoduleUtil       = require("./submodule_util");
 const SubmoduleConfigUtil = require("./submodule_config_util");
 const TextUtil            = require("./text_util");
@@ -425,7 +425,7 @@ exports.rmPaths = co.wrap(function *(repo, paths, options) {
     // https://github.com/nodegit/nodegit/issues/1487
     if (toRemove.length !== 0) {
         yield index.removeAll(toRemove);
-        yield GitUtil.writeMetaIndex(repo, index);
+        yield SparseCheckoutUtil.writeMetaIndex(repo, index);
     }
 
     // close to-be-deleted submodules

--- a/node/lib/util/stash_util.js
+++ b/node/lib/util/stash_util.js
@@ -35,14 +35,15 @@ const co      = require("co");
 const colors  = require("colors");
 const NodeGit = require("nodegit");
 
-const GitUtil         = require("./git_util");
-const Open            = require("./open");
-const PrintStatusUtil = require("./print_status_util");
-const RepoStatus      = require("./repo_status");
-const StatusUtil      = require("./status_util");
-const SubmoduleUtil   = require("./submodule_util");
-const TreeUtil        = require("./tree_util");
-const UserError       = require("./user_error");
+const GitUtil            = require("./git_util");
+const Open               = require("./open");
+const PrintStatusUtil    = require("./print_status_util");
+const RepoStatus         = require("./repo_status");
+const SparseCheckoutUtil = require("./sparse_checkout_util");
+const StatusUtil         = require("./status_util");
+const SubmoduleUtil      = require("./submodule_util");
+const TreeUtil           = require("./tree_util");
+const UserError          = require("./user_error");
 
 /**
  * Return the IDs of tress reflecting the current state of the index and
@@ -349,6 +350,7 @@ ${colors.red(name)}`);
             result[name] = stashSha;
         }
     }));
+    yield SparseCheckoutUtil.writeMetaIndex(repo, yield repo.index());
     return result;
 });
 

--- a/node/lib/util/submodule_rebase_util.js
+++ b/node/lib/util/submodule_rebase_util.js
@@ -41,6 +41,7 @@ const GitUtil             = require("./git_util");
 const DoWorkQueue         = require("./do_work_queue");
 const RebaseFileUtil      = require("./rebase_file_util");
 const RepoStatus          = require("./repo_status");
+const SparseCheckoutUtil  = require("./sparse_checkout_util");
 const SubmoduleUtil       = require("./submodule_util");
 
 /**
@@ -360,7 +361,7 @@ ${colors.green(rebaseInfo.onto)}.`);
         }
     });
     yield DoWorkQueue.doInParallel(Object.keys(subs), continueSub);
-    yield GitUtil.writeMetaIndex(repo, index);
+    yield SparseCheckoutUtil.writeMetaIndex(repo, index);
     const result = {
         errorMessage: "" === errorMessage ? null : errorMessage,
         commits: commits,

--- a/node/lib/util/test_util.js
+++ b/node/lib/util/test_util.js
@@ -39,7 +39,7 @@ const co      = require("co");
 const fs      = require("fs-promise");
 const path    = require("path");
 const NodeGit = require("nodegit");
-const temp    = require("temp").track();
+const temp    = require("temp");
 
 /**
  * Return the path to a newly-created temporary directory.

--- a/node/test/util/push.js
+++ b/node/test/util/push.js
@@ -301,9 +301,7 @@ describe("getPushMap", function () {
             for (const closeSubs of [false, true]) {
                 if (closeSubs) {
                     const subs = yield SubmoduleUtil.listOpenSubmodules(repo);
-                    for (const sub of subs) {
-                        yield SubmoduleConfigUtil.deinit(repo, sub);
-                    }
+                    yield SubmoduleConfigUtil.deinit(repo, subs);
                 }
 
                 const pushMap = yield Push.getPushMap(repo, "origin", source,

--- a/node/test/util/read_repo_ast_util.js
+++ b/node/test/util/read_repo_ast_util.js
@@ -540,7 +540,7 @@ describe("readRAST", function () {
 
         const commit = yield TestUtil.makeCommit(repo,
                                                  ["x/y", ".gitmodules"]);
-        yield SubmoduleConfigUtil.deinit(repo, "x/y");
+        yield SubmoduleConfigUtil.deinit(repo, ["x/y"]);
         let commits = {};
         commits[headCommit.id().tostrS()] = new Commit({
             changes: { "README.md": new File("", false)},
@@ -588,7 +588,7 @@ describe("readRAST", function () {
         const index = yield repo.index();
         yield index.addByPath(".gitmodules");
         yield index.write();
-        yield SubmoduleConfigUtil.deinit(repo, "x/y");
+        yield SubmoduleConfigUtil.deinit(repo, ["x/y"]);
         let commits = {};
         commits[headCommit.id().tostrS()] = new Commit({
             changes: { "README.md": new File("", false)},
@@ -639,7 +639,7 @@ describe("readRAST", function () {
         const subRepo = yield submodule.open();
         const anotherSubCommit = yield TestUtil.generateCommit(subRepo);
         const lastCommit = yield TestUtil.makeCommit(repo, ["x/y"]);
-        yield SubmoduleConfigUtil.deinit(repo, "x/y");
+        yield SubmoduleConfigUtil.deinit(repo, ["x/y"]);
 
         let commits = {};
         commits[headCommit.id().tostrS()] = new Commit({
@@ -800,7 +800,7 @@ describe("readRAST", function () {
                            baseSubPath,
                            "x/y",
                            subHead.id().tostrS());
-        yield SubmoduleConfigUtil.deinit(repo, "x/y");
+        yield SubmoduleConfigUtil.deinit(repo, ["x/y"]);
 
         let commits = {};
         commits[headCommit.id().tostrS()] = new Commit({
@@ -845,7 +845,7 @@ describe("readRAST", function () {
         const nextSubCommit = yield TestUtil.generateCommit(subRepo);
         const index = yield repo.index();
         yield index.addAll("x/y", -1);
-        yield SubmoduleConfigUtil.deinit(repo, "x/y");
+        yield SubmoduleConfigUtil.deinit(repo, ["x/y"]);
 
         let commits = {};
         commits[headCommit.id().tostrS()] = new Commit({
@@ -1523,7 +1523,7 @@ describe("readRAST", function () {
         const modules = ".gitmodules";
         const nextCommit = yield TestUtil.makeCommit(repo, ["a", modules]);
         const nextSha = nextCommit.id().tostrS();
-        yield SubmoduleConfigUtil.deinit(repo, "a");
+        yield SubmoduleConfigUtil.deinit(repo, ["a"]);
 
         yield fs.writeFile(path.join(repo.workdir(),
                                      modules),

--- a/node/test/util/submodule_config_util.js
+++ b/node/test/util/submodule_config_util.js
@@ -116,7 +116,7 @@ describe("SubmoduleConfigUtil", function () {
 
             // Then close it and recheck status.
 
-            yield SubmoduleConfigUtil.deinit(repo, "x/y");
+            yield SubmoduleConfigUtil.deinit(repo, ["x/y"]);
             const closedStatus =
                                 yield NodeGit.Submodule.status(repo, "x/y", 0);
             assert(closedStatus & WD_UNINITIALIZED);
@@ -151,7 +151,7 @@ describe("SubmoduleConfigUtil", function () {
             yield TestUtil.makeCommit(repo, ["x/y", ".gitmodules"]);
 
             yield SparseCheckoutUtil.setSparseMode(repo);
-            yield SubmoduleConfigUtil.deinit(repo, "x/y");
+            yield SubmoduleConfigUtil.deinit(repo, ["x/y"]);
 
             // Verify that directory for sub is gone
 
@@ -166,7 +166,7 @@ describe("SubmoduleConfigUtil", function () {
             // verify we clean the root when all is gone
 
             failed = false;
-            yield SubmoduleConfigUtil.deinit(repo, "x/z");
+            yield SubmoduleConfigUtil.deinit(repo, ["x/z"]);
             try {
                 yield fs.readdir(path.join(repo.workdir(), "x"));
             } catch (e) {
@@ -665,7 +665,7 @@ foo
                                           sig,
                                           sig,
                                           "my message");
-            yield SubmoduleConfigUtil.deinit(repo, subName);
+            yield SubmoduleConfigUtil.deinit(repo, [subName]);
             const repoPath = repo.workdir();
             const result = yield SubmoduleConfigUtil.initSubmoduleAndRepo(
                                                                      originUrl,
@@ -708,7 +708,7 @@ foo
             const sub = yield NodeGit.Submodule.lookup(repo, "foo");
             const subRepo = yield sub.open();
             NodeGit.Remote.setUrl(subRepo, "origin", "/bar");
-            yield SubmoduleConfigUtil.deinit(repo, "foo");
+            yield SubmoduleConfigUtil.deinit(repo, ["foo"]);
             const newSub =
                 yield SubmoduleConfigUtil.initSubmoduleAndRepo("",
                                                                repo,
@@ -776,7 +776,7 @@ foo
                                           sig,
                                           sig,
                                           "my message");
-            yield SubmoduleConfigUtil.deinit(repo, "foo");
+            yield SubmoduleConfigUtil.deinit(repo, ["foo"]);
 
             // Remove `foo` dir, otherwise, we will not need to re-init the
             // repo and the template will not be executed.

--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -322,9 +322,7 @@ describe("SubmoduleUtil", function () {
                 for (const closeSubs of [false, true]) {
                     if (closeSubs) {
                         const subs = yield SubmoduleUtil.listOpenSubmodules(x);
-                        for (const sub of subs) {
-                            yield SubmoduleConfigUtil.deinit(x, sub);
-                        }
+                        yield SubmoduleConfigUtil.deinit(x, subs);
                     }
                     const dut = SubmoduleUtil;
                     const result = yield dut.listAbsorbedSubmodules(x);


### PR DESCRIPTION
The current strategy for sparse mode was to exclude in the
sparse-checkout file and index all files besides `.gitmodules`.  This
strategy was fine as far as `git-meta` was concerned generally, but it
confused Git; since `git-meta` defers to Git for many commands (e.g.,
`diff`), and since we generally want to allow people to use normal Git
commands and maintain our repo in a recognizable state, the current
strategy is not sufficient.

Instead, we need to maintain the invarian that "open" submodules are
seen as visible in the sparse mode (not skipped) and "closed" submodules
are seen as invisible (skipped).

Severl changes were needed to make this happen:

* We now consider a repo to be "inSparseMode" if the config is set and
  don't also check to see if `".gitmodules\n"` is the contents of the
  `sparse-checkout` file.  It was a little pedantic to add that to the
  check to begin with, and now we're going to have an arbitrary set of
  paths.
* When opening a submodule, we add its path to `sparse-checkout`.
* `SubmoduleConfigUtil.deinit` now removes submodules from
  `sparse-checkout`.  Since this would be O(N^2) (e.g. if you're closing
  all submodules) and in all cases we generally know up front the list
  of subs to remove, `deinit` now takes a list of subs to deinitialize.
* Opening and closing subs now requires an update to the index, since
  libgit2 (and I'm guessing not even Git) will do what we need by
  default.  To facilitate this, I updated the contracts of the
  open/close methods, and moved `writeMetaIndex` down into
  `SparseCheckoutUtil`.
* Call `writeMetaIndex` from stash_util, which didn't need to update the
  index previously
* And also from `CloseUtil`.