### PR TITLE
Use libgit2 to compute submodule tree changes

### DIFF
--- a/node/lib/util/merge_util.js
+++ b/node/lib/util/merge_util.js
@@ -395,7 +395,9 @@ ${colors.red(commitSha)}.`);
 
     const sig = repo.defaultSignature();
 
-    const changes = yield CherryPickUtil.computeChanges(repo, commit, true);
+    const changeIndex = yield NodeGit.Merge.commits(repo, head, commit, []);
+    const changes =
+        yield CherryPickUtil.computeChanges(repo, changeIndex, commit);
     const index = yield repo.index();
     const opener = new Open.Opener(repo, null);
 

--- a/node/test/util/merge_util.js
+++ b/node/test/util/merge_util.js
@@ -468,6 +468,18 @@ x=U:C3-2 t=Sa:1;C4-2 s;Bmaster=4;Bfoo=3`,
                 fromCommit: "3",
                 expected: `x=E:Cx-4,3 t=Sa:1;Bmaster=x`,
             },
+            "change with multiple merge bases": {
+                initial: `
+a=B:Ca-1;Ba=a|
+x=S:C2-1 r=Sa:1,s=Sa:1,t=Sa:1;
+    C3-2 s=Sa:a;
+    C4-2 t=Sa:a;
+    Cl-3,4 s,t;
+    Ct-3,4 a=Sa:1,t=Sa:a;
+    Bmaster=l;Bfoo=t`,
+                fromCommit: "t",
+                expected: "x=E:Cx-l,t a=Sa:1;Bmaster=x",
+            },
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];


### PR DESCRIPTION
Addresses: https://github.com/twosigma/git-meta/issues/595

Previously, I was manually computing what submodule changes and
conflicts would result from a merge or cherry-pick (rebase uses
cherry-pick).  In the case of a merge, I used "the" merge base between
the head and target commits -- however, there may be many merge bases,
and the logic used to determine what to do is beyond the scope of
git-meta.  I started doing this instead of the obvious `Merge.merge` or
`CherryPick.cherryPick` command due to the littany of problems I have
using libgit2 in the workdir of the meta-repo (performance, correctness
e.g., with sparse-checkouts, etc.).

With this change, I go back to using libgit2 to do this computation, but
I'm using the "commits" versions of these commands -- `Merge.commits`
and `CherryPick.commits` -- which do not touch the worktree, but work
only on commits.  Now, the only manual deduction I do is to determine
which submodule conflicts flagged by libgit2 are candidates for
resolution (via merge/cherry-pick in the affected submodule).

As can be seen from the test case added to `merge`, it does solve the
problem.