### PR TITLE
Added submodule unique check in open/close after path resolution

### DIFF
--- a/node/lib/cmd/open.js
+++ b/node/lib/cmd/open.js
@@ -94,10 +94,11 @@ exports.executeableSubcommand = co.wrap(function *(args) {
     const subs = yield SubmoduleUtil.getSubmoduleNames(repo);
 
     args.path = Array.from(new Set(args.path));
-    const subsToOpen = yield SubmoduleUtil.resolveSubmoduleNames(workdir,
-                                                                 cwd,
-                                                                 subs,
-                                                                 args.path);
+    let subsToOpen = yield SubmoduleUtil.resolveSubmoduleNames(workdir,
+                                                               cwd,
+                                                               subs,
+                                                               args.path);
+    subsToOpen = Array.from(new Set(subsToOpen));
     const index      = yield repo.index();
     const shas       = yield SubmoduleUtil.getCurrentSubmoduleShas(index,
                                                                    subsToOpen);

--- a/node/lib/util/close_util.js
+++ b/node/lib/util/close_util.js
@@ -63,10 +63,11 @@ exports.close = co.wrap(function *(repo, cwd, paths, force) {
 
     const workdir = repo.workdir();
     const subs    = yield SubmoduleUtil.getSubmoduleNames(repo);
-    const subsToClose = yield SubmoduleUtil.resolveSubmoduleNames(workdir,
-                                                                  cwd,
-                                                                  subs,
-                                                                  paths);
+    let subsToClose = yield SubmoduleUtil.resolveSubmoduleNames(workdir,
+                                                                cwd,
+                                                                subs,
+                                                                paths);
+    subsToClose = Array.from(new Set(subsToClose));
 
     const repoStatus = yield StatusUtil.getRepoStatus(repo, {
         paths: subsToClose,


### PR DESCRIPTION
At this moment when user does:
`git meta open subA subB subA`
we filter out duplicates from args to open command: so it resolves to subA, subB.

when user passes:
`git meta open sub `
we resolve to: subA subB

So the problem happens when user passes:
`git meta open sub subA`
we resolve to subA subB subA

And we get all kinds of errors (mostly because file lock colision)
