### PR TITLE
Added post-rewrite hook in cmd/rebase

### DIFF
--- a/node/lib/cmd/rebase.js
+++ b/node/lib/cmd/rebase.js
@@ -30,6 +30,7 @@
  */
 
 const co = require("co");
+const Hook = require("../util/hook");
 
 /**
  * This module contains methods for implementing the `rebase` command.
@@ -120,4 +121,6 @@ exports.executeableSubcommand = co.wrap(function *(args) {
             throw new UserError(result.errorMessage);
         }
     }
+
+    yield Hook.execHook(repo, "post-rewrite", ["rebase"]);
 });


### PR DESCRIPTION
This commit:
https://github.com/twosigma/git-meta/commit/96286c209b789c70fb306bf230c6a87ec754e526

Introduced repo arg to the hooks.

In TS we execute hook in cmd/rebase.js , so adding repo arg, broke it.

Not sure if we should patch internally, or here. 
