### PR TITLE
Added stderr and disabled buffering in hooks

### DIFF
--- a/node/test/util/hook.js
+++ b/node/test/util/hook.js
@@ -59,11 +59,14 @@ describe("Hook", function () {
             process.chdir(workDir);
             const hooksDir = path.join(workDir, ".git/hooks");
             const hookFile = path.join(hooksDir, hookName);
+            const hookOutputFile = path.join(hooksDir, "hook_test");
             yield fs.writeFile(hookFile,
-                               "#!/bin/bash \necho 'it is a test hook'\n");
+                  "#!/bin/bash \necho 'it is a test hook' >" + hookOutputFile);
             yield fs.chmod(hookFile, "755");
-            const result = yield Hook.execHook(repo, hookName);
-            assert.equal(result, "it is a test hook\n");
+            yield Hook.execHook(repo, hookName);
+            assert.ok(fs.existsSync(hookOutputFile), "File does not exists");
+            assert.equal(fs.readFileSync(hookOutputFile, "utf8"),
+                "it is a test hook\n");
         }));
     });
 });


### PR DESCRIPTION
What do you guys think about this change?

Basically, I want to see the output of a hook in real time instead of waiting till hook execution finishes. 
This is important when hooks executes long running operations like build/tests etc. to let user know what is going on.
Additionally, I want to see the stderr output.