### PR TITLE
Better error when merge invoked with no args

### DIFF
--- a/node/lib/cmd/merge.js
+++ b/node/lib/cmd/merge.js
@@ -147,7 +147,7 @@ exports.executeableSubcommand = co.wrap(function *(args) {
         commitName = yield GitUtil.getCurrentTrackingBranchName(repo);
     }
     if (null === commitName) {
-        throw new UserError("Commit required.");
+        throw new UserError("No remote for the current branch.");
     }
     const commitish = yield GitUtil.resolveCommitish(repo, commitName);
     if (null === commitish) {


### PR DESCRIPTION
... and there is no tracking info for the current branch.