### PR TITLE
#678 fix git meta creates empty commits issue

### DIFF
--- a/node/lib/util/cherry_pick_util.js
+++ b/node/lib/util/cherry_pick_util.js
@@ -550,7 +550,7 @@ exports.rewriteCommit = co.wrap(function *(repo, commit) {
     const nChanges = Object.keys(picks.commits)
         .map(name => Object.keys(
             picks.commits[name]).length + picks.ffwds[name] ? 1 : 0
-        ).reduce((acc, len) => acc+len, 0);
+        ).reduce((acc, len) => acc + len, 0);
         if ("" === errorMessage &&
         (0 !== Object.keys(changes.simpleChanges).length || 0 !== nChanges)) {
         result.newMetaCommit =

--- a/node/lib/util/submodule_rebase_util.js
+++ b/node/lib/util/submodule_rebase_util.js
@@ -157,6 +157,7 @@ exports.callNext = co.wrap(function *(rebase) {
  * @return {Object}
  * @return {Object} return.commits
  * @return {String|null} return.conflictedCommit
+ * @returns {Boolean} return.ffwd
  */
 exports.processRebase = co.wrap(function *(repo, rebase, op) {
     assert.instanceOf(repo, NodeGit.Repository);
@@ -167,6 +168,7 @@ exports.processRebase = co.wrap(function *(repo, rebase, op) {
     const result = {
         commits: {},
         conflictedCommit: null,
+        ffwd: false,
     };
     const signature = yield ConfigUtil.defaultSignature(repo);
     while (null !== op) {
@@ -206,6 +208,7 @@ exports.processRebase = co.wrap(function *(repo, rebase, op) {
  * @return {Object}
  * @return {Object}      return.commits           new sha to original sha
  * @return {String|null} return.conflictedCommit  error message if failed
+ * @return {Boolean}     return.ffwd              true if fast-forwarded
  */
 exports.rewriteCommits = co.wrap(function *(repo, branch, upstream) {
     assert.instanceOf(repo, NodeGit.Repository);
@@ -221,6 +224,7 @@ exports.rewriteCommits = co.wrap(function *(repo, branch, upstream) {
     const result = {
         commits: {},
         conflictedCommit: null,
+        ffwd: false,
     };
 
     // If we're up-to-date with the commit to be rebased onto, return
@@ -252,6 +256,7 @@ exports.rewriteCommits = co.wrap(function *(repo, branch, upstream) {
     if (null === upstream) {
         if (yield NodeGit.Graph.descendantOf(repo, branchSha, headSha)) {
             yield GitUtil.setHeadHard(repo, branch);
+            result.ffwd = true;
             return result;                                            // RETURN
         }
     }

--- a/node/test/util/cherry_pick_util.js
+++ b/node/test/util/cherry_pick_util.js
@@ -790,6 +790,13 @@ a=Ax:Cz-y;Cy-x;Bfoo=z|
 x=S:C8-3 s=Sa:z;C3-2 s=Sa:y;C2-1 s=Sa:x;Bfoo=8;Bmaster=2;Os H=x`,
             expected: "x=E:C9-2 s=Sa:zs;Bmaster=9;Os Czs-x z=z!H=zs",
         },
+        "skip duplicated cherry picks": {
+            input: `
+a=Ax:Cz-y;Cy-x;Bfoo=z|
+x=S:C8-3 s=Sa:z;C3-2 s=Sa:y;C2-1 s=Sa:x;Bfoo=8;Bmaster=2;Os H=x`,
+            expected: "x=E:C9-2 s=Sa:zs;Bmaster=9;Os Czs-x z=z!H=zs",
+            duplicate: true,
+        },
         "nothing to commit": {
             input: "a=B|x=S:C2-1;C8-1 ;Bmaster=2;B8=8",
         },
@@ -834,6 +841,10 @@ Submodule ${colors.red("s")} is conflicted.
             const eightCommit = yield x.getCommit(eightCommitSha);
             const result  = yield CherryPickUtil.cherryPick(x, eightCommit);
 
+            if(c.duplicate) {
+                const res = yield CherryPickUtil.cherryPick(x, eightCommit);
+                assert.isNull(res.newMetaCommit);
+            }
             assert.equal(result.errorMessage, c.errorMessage || null);
 
             return mapCommits(maps, result);

--- a/node/test/util/cherry_pick_util.js
+++ b/node/test/util/cherry_pick_util.js
@@ -841,7 +841,7 @@ Submodule ${colors.red("s")} is conflicted.
             const eightCommit = yield x.getCommit(eightCommitSha);
             const result  = yield CherryPickUtil.cherryPick(x, eightCommit);
 
-            if(c.duplicate) {
+            if (c.duplicate) {
                 const res = yield CherryPickUtil.cherryPick(x, eightCommit);
                 assert.isNull(res.newMetaCommit);
             }


### PR DESCRIPTION
git-meta calculates the submodule changes by checking if the submodule changes map is empty:
` 0 !== Object.keys(picks.commits).length)` 

However, there are cases (check the issue ticket for details), the commits map is not empty but is equivalent to empty because the changes within each submodule has an empty change. aka it is like the following:

```json
"commits": {
      "submodule_a": {}
 }
```

There are generally two ways to fix this, one way is to make sure submodules never report empty commits or have cherry_pick_utils smart enough not to create a new meta commit if the commit is effectively empty. 

I choose the later because the check was already in the code, this PR only makes it cover the corner cases. 