### PR TITLE
Fix git-meta rm path overmatching issue

### DIFF
--- a/node/lib/util/merge_util.js
+++ b/node/lib/util/merge_util.js
@@ -38,7 +38,6 @@ const NodeGit      = require("nodegit");
 
 const Checkout            = require("./checkout");
 const CherryPickUtil      = require("./cherry_pick_util");
-const Commit              = require("./commit");
 const ConfigUtil          = require("./config_util");
 const DoWorkQueue         = require("./do_work_queue");
 const GitUtil             = require("./git_util");

--- a/node/lib/util/submodule_util.js
+++ b/node/lib/util/submodule_util.js
@@ -564,7 +564,7 @@ exports.getSubmodulesInPath = function (dir, indexSubNames) {
     const isParentDir = (short, long) => {
         return long.startsWith(short) && (
             short[short.length-1] === "/" ||
-            long.replace(short, "")[0] === "/"
+            long[short.length] === "/"
         );
     };
     const result = [];

--- a/node/lib/util/submodule_util.js
+++ b/node/lib/util/submodule_util.js
@@ -559,11 +559,19 @@ exports.getSubmodulesInPath = function (dir, indexSubNames) {
     if ("" === dir) {
         return indexSubNames;
     }
+
+    // test if the short path a parent dir of the long path
+    const isParentDir = (short, long) => {
+        return long.startsWith(short) && (
+            short[short.length-1] === "/" ||
+            long.replace(short, "")[0] === "/"
+        );
+    };
     const result = [];
     for (const subPath of indexSubNames) {
         if (subPath === dir) {
             return [dir];                                             // RETURN
-        } else if (subPath.startsWith(dir)) {
+        } else if (isParentDir(dir, subPath)) {
             result.push(subPath);
         }
     }

--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -781,6 +781,11 @@ describe("SubmoduleUtil", function () {
                 indexSubNames: ["q/r", "q/s", "q/t/v", "z"],
                 expected: ["q/r", "q/s", "q/t/v"],
             },
+            "does not overmatch": {
+                dir: "q",
+                indexSubNames: ["q/r", "qr", "qr/"],
+                expected: ["q/r"],
+            },
         };
         Object.keys(cases).forEach(caseName => {
             const c = cases[caseName];


### PR DESCRIPTION
Currently running `git meta rm -rf abc` matches following directories which should not have:

```
abcd/
abcd/api
abcd/service
...
```

The issue is because `getSubmodulesInPath` in the `submodule_utils.js` has a bug: it thinks if x.startsWith(y) than x must be a subdirectory of y. This is not true as `abcd/ef/` starts  with `abc`, but it is not a subdirectory of the later.

I changed to logic to:
1. If y has a trailing '/' then `startsWith` is sufficient
2. Otherwise, removing prefix `x` from y, the rest of y should starts with a leading `/`.

