### PR TITLE
Add a 'merge-bare' subcommand that allows for merging under bare repo…

### DIFF
--- a/node/lib/cmd/merge_bare.js
+++ b/node/lib/cmd/merge_bare.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2019, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const co = require("co");
+
+/**
+ * This module contains methods for implementing the `merge` command.
+ */
+
+/**
+ * help text for the `merge` command
+ * @property {String}
+ */
+exports.helpText = `merge two commits with no need for a working directory, \
+print resulting merged commit sha`;
+
+/**
+ * description of the `merge` command
+ * @property {String}
+ */
+exports.description =` Merge changes from two commits.  This command
+can work with or without a working tree, resulting a dangling merged commit  
+that is not pointed by any refs. It will also abort if there are merge conflicts
+ between two commits.`;
+
+exports.configureParser = function (parser) {
+    parser.addArgument(["-m", "--message"], {
+        type: "string",
+        help: "commit message",
+        required: true,
+    });
+
+    parser.addArgument(["ourCommit"], {
+        type: "string",
+        help: "our side commitish to merge",
+        nargs: 1,
+    });
+    parser.addArgument(["theirCommit"], {
+        type: "string",
+        help: "their side commitish to merge",
+        nargs: 1,
+    });
+};
+
+/**
+ * Execute the `merge_bare` command according to the specified `args`.
+ *
+ * @async
+ * @param {Object} args
+ * @param {String} args.commit
+ */
+exports.executeableSubcommand = co.wrap(function *(args) {
+    // TODO: add applicable `git merge` options.
+    // TODO: For now, we will always create a merge commit.  We should be able
+    // to control whether FF is allowed/required for meta and sub repos.
+
+    const colors = require("colors");
+
+    const MergeBareUtil  = require("../util/merge_bare_util");
+    const GitUtil        = require("../util/git_util");
+    const Hook           = require("../util/hook");
+    const UserError      = require("../util/user_error");
+
+    const repo = yield GitUtil.getCurrentRepo();
+
+    let ourCommitName = args.ourCommit;
+    let theirCommitName = args.theirCommit;
+    if (null === ourCommitName || null === theirCommitName) {
+        throw new UserError("Both two merge commits must be given.");
+    }
+    const ourCommitish = yield GitUtil.resolveCommitish(repo, ourCommitName);
+    if (null === ourCommitish) {
+        throw new UserError(`\
+Could not resolve ${colors.red(ourCommitName)} to a commit.`);
+    }
+
+    const theirCommitish 
+        = yield GitUtil.resolveCommitish(repo, theirCommitName);
+    if (null === theirCommitish) {
+        throw new UserError(`\
+Could not resolve ${colors.red(theirCommitName)} to a commit.`);
+    }
+
+    const ourCommit = yield repo.getCommit(ourCommitish.id());
+    const theirCommit = yield repo.getCommit(theirCommitish.id());
+    const result = yield MergeBareUtil.merge(repo, 
+                                             ourCommit,
+                                             theirCommit,
+                                             args.message);
+    if (null !== result.errorMessage) {
+        throw new UserError(result.errorMessage);
+    }
+
+    // Run post-merge hook if merge successfully.
+    // Fixme: --squash is not supported yet, once supported, need to parse 0/1
+    // as arg into the post-merge hook, 1 means it is a squash merge, 0 means
+    // not.
+    yield Hook.execHook(repo, "post-merge", ["0"]);
+});

--- a/node/lib/cmd/open.js
+++ b/node/lib/cmd/open.js
@@ -127,7 +127,11 @@ Opening ${colors.blue(name)} on ${colors.green(shas[index])}.`);
         // to open other (probably unaffected) repositories.
 
         try {
-            yield Open.openOnCommit(fetcher, name, shas[index], templatePath);
+            yield Open.openOnCommit(fetcher,
+                                    name,
+                                    shas[index],
+                                    templatePath,
+                                    false);
             subsOpenSuccessfully.push(name);
         }
         catch (e) {

--- a/node/lib/cmd/submodule.js
+++ b/node/lib/cmd/submodule.js
@@ -236,7 +236,7 @@ Could not find ${colors.red(metaCommittish)} in the meta-repo.`);
 
     const subName = paths[0];
     const opener = new Open.Opener(repo, null);
-    const subRepo = yield opener.getSubrepo(subName);
+    const subRepo = yield opener.getSubrepo(subName, false);
     const metaCommit = yield repo.getCommit(metaAnnotated.id());
 
     // Now that we have an open submodule, we can attempt to resolve

--- a/node/lib/git-meta.js
+++ b/node/lib/git-meta.js
@@ -47,6 +47,7 @@ const Forward      = require("./cmd/forward");
 const include      = require("./cmd/include");
 const listFiles    = require("./cmd/list_files");
 const merge        = require("./cmd/merge");
+const mergeBare    = require("./cmd/merge_bare");
 const open         = require("./cmd/open");
 const pull         = require("./cmd/pull");
 const push         = require("./cmd/push");
@@ -135,6 +136,7 @@ const commands = {
     "include": include,
     "ls-files": listFiles,
     "merge": merge,
+    "merge-bare": mergeBare,
     "add-submodule": addSubmodule,
     "open": open,
     "pull": pull,

--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -1021,7 +1021,7 @@ exports.getAmendStatus = co.wrap(function *(repo, options) {
                 old = new Submodule(commit.url, commit.sha);
             }
         }
-        const getRepo = () => opener.getSubrepo(name);
+        const getRepo = () => opener.getSubrepo(name, false);
 
         const result = yield exports.getSubmoduleAmendStatus(currentSub,
                                                              old,

--- a/node/lib/util/merge_bare_util.js
+++ b/node/lib/util/merge_bare_util.js
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2019, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert       = require("chai").assert;
+const co           = require("co");
+const colors       = require("colors");
+const NodeGit      = require("nodegit");
+
+const CherryPickUtil      = require("./cherry_pick_util");
+const ConfigUtil          = require("./config_util");
+const DoWorkQueue         = require("./do_work_queue");
+const GitUtil             = require("./git_util");
+const Open                = require("./open");
+const UserError           = require("./user_error");
+
+
+/**
+ * Update meta repo index and point the submodule to a commit sha
+ * 
+ * @param {NodeGit.Index} index
+ * @param {String} subName
+ * @param {String} sha
+ */
+const addSubmoduleCommit = co.wrap(function *(index, subName, sha) {
+    assert.instanceOf(index, NodeGit.Index);
+    assert.isString(subName);
+    assert.isString(sha);
+
+    const entry = new NodeGit.IndexEntry();
+    entry.path = subName;
+    entry.mode = NodeGit.TreeEntry.FILEMODE.COMMIT;
+    entry.id = NodeGit.Oid.fromString(sha);
+    entry.flags = entry.flagsExtended = 0;
+    yield index.add(entry);
+});
+
+/**
+ * Merge in each submodule and update in memory index accordingly.
+ * 
+ * @param {NodeGit.Repository}  repo
+ * @param {Open.Opener}         opener
+ * @param {NodeGit.Index}       mergeIndex
+ * @param {Object}              subs  map from sub name to changes
+ * @param {String}              message commit message
+ * */
+exports.mergeSubmoduleBare = co.wrap(function *(repo, 
+                                                opener,
+                                                mergeIndex,
+                                                subs,
+                                                message) {
+    assert.instanceOf(repo, NodeGit.Repository);
+    assert.instanceOf(mergeIndex, NodeGit.Index);
+    assert.isObject(subs);
+    assert.isString(message);
+
+    const result = {
+        conflicts: {},
+        commits: {},
+    };
+    const sig = yield ConfigUtil.defaultSignature(repo);
+    const fetcher = yield opener.fetcher();
+
+    const mergeSubmodule = co.wrap(function *(name) {
+
+        const subRepo = yield opener.getSubrepo(name, true);
+        const change = subs[name];
+
+        const theirSha = change.newSha;
+        const ourSha = change.ourSha;
+        yield fetcher.fetchSha(subRepo, name, theirSha);
+        yield fetcher.fetchSha(subRepo, name, ourSha);
+        const theirCommit = yield subRepo.getCommit(theirSha);
+        const ourCommit = yield subRepo.getCommit(ourSha);
+
+        // No change if ours is up-to-date
+        if (yield NodeGit.Graph.descendantOf(subRepo, ourSha, theirSha)) {
+            return result;                                            // RETURN
+        }
+
+        // use their sha if it is a fast forward merge
+        if (yield NodeGit.Graph.descendantOf(subRepo, theirSha, ourSha)) {
+            yield addSubmoduleCommit(mergeIndex, name, theirSha);
+            return result;                                            // RETURN
+        }
+
+        console.log(`Submodule ${colors.blue(name)}: merging commit ` +
+            `${colors.green(theirSha)}.`);
+
+        // Start the merge.
+        let subIndex = yield NodeGit.Merge.commits(subRepo,
+                                                   ourCommit,
+                                                   theirCommit,
+                                                   null);
+
+        // Abort if conflicted.
+        if (subIndex.hasConflicts()) {
+            result.conflicts[name] = theirSha;
+            return;                                                   // RETURN
+        }
+
+        // Otherwise, finish off the merge.
+        const treeId = yield subIndex.writeTreeTo(subRepo);
+        const mergeCommit 
+            = yield subRepo.createCommit(null,
+                                         sig,
+                                         sig,
+                                         message,
+                                         treeId,
+                                         [ourCommit, theirCommit]);
+        const mergeSha = mergeCommit.tostrS();
+        result.commits[name] = mergeSha;
+        yield addSubmoduleCommit(mergeIndex, name, mergeSha);
+    });
+    yield DoWorkQueue.doInParallel(Object.keys(subs), mergeSubmodule);
+    return result;
+});
+
+/**
+ * Return a formatted string indicating merge will abort for 
+ * irresolvable conflicts.
+ */
+function formatConflictsMessage(conflicts) {
+    let errorMessage = "CONFLICT (content): \n";
+    const names = Object.keys(conflicts).sort();
+    for (let name of names) {
+        errorMessage += `Conflicting entries for submodule: ` + 
+            `${colors.red(name)}\n`;
+    }
+    errorMessage += "Automatic merge failed\n";
+    return errorMessage;
+}
+
+/**
+ * Merge  `theirCommit` into `ourCommit` in the specified `repo` with specific
+ * commitMessage. Return `null` if there are merge conflicts and the conflicts
+ * cannot be resolved automatically. Return an object describing merge commits
+ * otherwise. Use our commit as the merged commit if our commit is up to date,
+ * use theirs if this is a fast forward merge and return a new merge commit
+ * otherwise. Throw a `UserError` if there are no commits in common between 
+ * `theirCommit` and `ourCommit`.
+ *
+ * @async
+ * @param {NodeGit.Repository} repo
+ * @param {NodeGit.Commit}     ourCommit
+ * @param {NodeGit.Commit}     theirCommit
+ * @param {String}             commitMessage
+ * @return {Object}
+ * @return {String|null} return.metaCommit
+ * @return {Object}      return.submoduleCommits  map from submodule to commit
+ * @return {String|null} return.errorMessage
+ */
+exports.merge = co.wrap(function *(repo,
+                                   ourCommit,
+                                   theirCommit,
+                                   commitMessage) {
+    assert.instanceOf(repo, NodeGit.Repository);
+    assert.instanceOf(ourCommit, NodeGit.Commit);
+    assert.instanceOf(theirCommit, NodeGit.Commit);
+    assert.isString(commitMessage);
+
+    const baseCommit = yield GitUtil.getMergeBase(repo, ourCommit, theirCommit);
+
+    if (null === baseCommit) {
+        throw new UserError(`No commits in common with `+
+            `${colors.red(GitUtil.shortSha(ourCommit.id().tostrS()))} and ` +
+            `${colors.red(GitUtil.shortSha(theirCommit.id().tostrS()))}`);
+    }
+
+    yield CherryPickUtil.ensureNoURLChanges(repo, ourCommit, theirCommit);
+
+    const result = {
+        metaCommit: null,
+        submoduleCommits: {},
+        errorMessage: null,
+    };
+
+    const ourCommitSha = ourCommit.id().tostrS();
+    const theirCommitSha = theirCommit.id().tostrS();
+    if (ourCommitSha === theirCommitSha) {
+        console.log(`Nothing to do for merging ${colors.green(ourCommitSha)}` +
+            `into itself.`);
+        result.metaCommit = ourCommitSha;
+        return result;
+    }
+
+    const upToDate  = yield NodeGit.Graph.descendantOf(repo,
+                                                       ourCommitSha,
+                                                       theirCommitSha);
+
+    if (upToDate) {
+        console.log(`${colors.green(ourCommitSha)} is up-to-date.`);
+        result.metaCommit = ourCommitSha;
+        return result;                                                // RETURN
+    }
+
+    const canFF  = yield NodeGit.Graph.descendantOf(repo,
+                                                    theirCommitSha,
+                                                    ourCommitSha);
+
+    if (canFF) {
+        console.log(`Fast-forward merge: `+
+            `${colors.green(theirCommitSha)} is a descendant of `+
+            `${colors.green(ourCommitSha)}`);
+        result.metaCommit = theirCommitSha;
+        return result;                                                // RETURN
+    }
+
+    const sig = yield ConfigUtil.defaultSignature(repo);
+
+    const changeIndex
+        = yield NodeGit.Merge.commits(repo, ourCommit, theirCommit, []);
+    const changes 
+        = yield CherryPickUtil.computeChangesBetweenTwoCommits(repo,
+                                                               changeIndex,
+                                                               ourCommit,
+                                                               theirCommit);
+    if (Object.keys(changes.conflicts).length > 0) {
+        result.errorMessage = formatConflictsMessage(changes.conflicts);
+        return result;                                                // RETURN
+    }
+    const opener = new Open.Opener(repo, null);
+
+    const makeMetaCommit = co.wrap(function *(indexToWrite) {
+        console.log(`Merging meta-repo commits ` +
+                    `${colors.green(ourCommitSha)} and ` +
+                    `${colors.green(theirCommitSha)}`);
+
+        const id = yield indexToWrite.writeTreeTo(repo);
+        // And finally, commit it.
+        const metaCommit = yield repo.createCommit(null,
+                                                   sig,
+                                                   sig,
+                                                   commitMessage,
+                                                   id,
+                                                   [ourCommit, theirCommit]);
+        result.metaCommit = metaCommit.tostrS();
+        console.log(`Merge commit created at ` +
+            `${colors.green(result.metaCommit)}.`);
+    });
+
+
+    yield CherryPickUtil.changeSubmodulesBare(repo,
+                                              opener,
+                                              changeIndex,
+                                              changes.simpleChanges);
+    const merges = yield exports.mergeSubmoduleBare(repo, 
+                                                    opener, 
+                                                    changeIndex, 
+                                                    changes.changes, 
+                                                    commitMessage);
+    if (Object.keys(merges.conflicts).length > 0) {
+        result.errorMessage = formatConflictsMessage(merges.conflicts);
+    } else {
+        yield makeMetaCommit(changeIndex);
+        result.submoduleCommits = merges.commits;    
+    }
+    return result;
+
+});

--- a/node/lib/util/merge_bare_util.js
+++ b/node/lib/util/merge_bare_util.js
@@ -269,7 +269,6 @@ exports.merge = co.wrap(function *(repo,
 
 
     yield CherryPickUtil.changeSubmodulesBare(repo,
-                                              opener,
                                               changeIndex,
                                               changes.simpleChanges);
     const merges = yield exports.mergeSubmoduleBare(repo, 

--- a/node/lib/util/merge_util.js
+++ b/node/lib/util/merge_util.js
@@ -160,7 +160,7 @@ const mergeSubmodules = co.wrap(function *(repo,
     const sig = yield ConfigUtil.defaultSignature(repo);
     const fetcher = yield opener.fetcher();
     const mergeSubmodule = co.wrap(function *(name) {
-        const subRepo = yield opener.getSubrepo(name);
+        const subRepo = yield opener.getSubrepo(name, false);
         const change = subs[name];
 
         const fromSha = change.newSha;

--- a/node/lib/util/open.js
+++ b/node/lib/util/open.js
@@ -221,18 +221,18 @@ Opener.prototype.isOpen = co.wrap(function *(subName) {
 });
 
 /**
- * Return true if the submodule is neither opened nor half opened.
+ * Return true if the submodule is opened nor half opened.
  *
  * @param {String} subName
  * @return {Boolean}
  */
-Opener.prototype.isClose = co.wrap(function *(subName) {
+Opener.prototype.isAtLeastHalfOpen = co.wrap(function *(subName) {
     if (!this.d_initialized) {
         yield this._initialize();
     }
-    return !this.d_absorbedSubs.has(subName) &&
-        !this.d_openSubs.has(subName) &&
-        !(subName in this.d_subRepos);
+    return this.d_absorbedSubs.has(subName) ||
+        this.d_openSubs.has(subName) ||
+        (subName in this.d_subRepos);
 });
 
 /**

--- a/node/lib/util/reset.js
+++ b/node/lib/util/reset.js
@@ -219,7 +219,7 @@ exports.reset = co.wrap(function *(repo, commit, type) {
         // Open the submodule and fetch the sha of the commit to which we're
         // resetting in case we don't have it.
 
-        const subRepo = yield opener.getSubrepo(name);
+        const subRepo = yield opener.getSubrepo(name, false);
 
         let subCommitSha;
 

--- a/node/lib/util/stash_util.js
+++ b/node/lib/util/stash_util.js
@@ -317,7 +317,7 @@ exports.apply = co.wrap(function *(repo, id, reinstateIndex) {
 
             return;                                                   // RETURN
         }
-        const subRepo = yield opener.getSubrepo(name);
+        const subRepo = yield opener.getSubrepo(name, false);
 
         // Try to get the comit for the stash; if it's missing, fail.
 

--- a/node/lib/util/submodule_change.js
+++ b/node/lib/util/submodule_change.js
@@ -45,11 +45,16 @@ class SubmoduleChange {
      * null `oldSha` implies that the submodule was added, a null `newSha`
      * implies that it was removed, and if neither is null, the submodule was
      * changed.
+     * 
+     * UPDATE: the change used to contain only their sha, because default our
+     * sha can be obtained from head commit. An explicit field is added for
+     * cases when our sha is not necessarily the same as the head.
      *
      * @param {String | null} oldSha
      * @param {String | null} newSha
+     * @param {String | null} ourSha
      */
-    constructor(oldSha, newSha) {
+    constructor(oldSha, newSha, ourSha) {
         assert.notEqual(oldSha, newSha);
         if (null !== oldSha) {
             assert.isString(oldSha);
@@ -57,8 +62,14 @@ class SubmoduleChange {
         if (null !== newSha) {
             assert.isString(newSha);
         }
+
+        if (null !== ourSha) {
+            assert.isString(ourSha);
+        }
+
         this.d_oldSha = oldSha;
         this.d_newSha = newSha;
+        this.d_ourSha = ourSha;
         Object.freeze(this);
     }
 
@@ -80,6 +91,18 @@ class SubmoduleChange {
      */
     get newSha() {
         return this.d_newSha;
+    }
+
+    /**
+     * This property represents the value of a sha to which a submodule change 
+     * is applying. If it is null, then the change can only be applied to the 
+     * current head. If it not null, it depends on users to choose to its value
+     * or head sha to apply submodule changes.
+     *
+     * @property {String | null} ourSha
+     */
+    get ourSha() {
+        return this.d_ourSha;
     }
 
     /**

--- a/node/lib/util/submodule_change.js
+++ b/node/lib/util/submodule_change.js
@@ -35,7 +35,8 @@ const assert  = require("chai").assert;
 /**
  * @class SubmoduleChanges.Change
  *
- * This class represents a sha change to a submodule.
+ * This class describes the changes from `oldSha` to `newSha` as well as
+ * the destination that the changes will be appliedd: `ourSha`
  */
 class SubmoduleChange {
 
@@ -44,14 +45,12 @@ class SubmoduleChange {
      * values.  The behavior is undefined if `oldSha === newSha`.  Note that a
      * null `oldSha` implies that the submodule was added, a null `newSha`
      * implies that it was removed, and if neither is null, the submodule was
-     * changed. In a 3 way merge, `oldSha` tracks the merge base, `newSha` 
-     * points to their commit and `ourSha` is usually the same as the HEAD.
-     * In case it is not or the HEAD sha is unavailable, we can explicitly
-     * point `ourSha` to a perticular target commit.
+     * changed. In a 3 way merge, `oldSha` is the merge base, `newSha` is the 
+     * right side of the merge and `ourSha` is the left side.
      *
-     * @param {String | null} oldSha
-     * @param {String | null} newSha
-     * @param {String | null} ourSha
+     * @param {String | null} oldSha sha from which changes are computed
+     * @param {String | null} newSha sha to which changes are computed
+     * @param {String | null} ourSha sha against which changes will be applied
      */
     constructor(oldSha, newSha, ourSha) {
         assert.notEqual(oldSha, newSha);

--- a/node/lib/util/submodule_change.js
+++ b/node/lib/util/submodule_change.js
@@ -44,11 +44,10 @@ class SubmoduleChange {
      * values.  The behavior is undefined if `oldSha === newSha`.  Note that a
      * null `oldSha` implies that the submodule was added, a null `newSha`
      * implies that it was removed, and if neither is null, the submodule was
-     * changed.
-     * 
-     * UPDATE: the change used to contain only their sha, because default our
-     * sha can be obtained from head commit. An explicit field is added for
-     * cases when our sha is not necessarily the same as the head.
+     * changed. In a 3 way merge, `oldSha` tracks the merge base, `newSha` 
+     * points to their commit and `ourSha` is usually the same as the HEAD.
+     * In case it is not or the HEAD sha is unavailable, we can explicitly
+     * point `ourSha` to a perticular target commit.
      *
      * @param {String | null} oldSha
      * @param {String | null} newSha

--- a/node/lib/util/submodule_util.js
+++ b/node/lib/util/submodule_util.js
@@ -427,7 +427,8 @@ exports.getSubmoduleChangesFromDiff = function (diff, allowMetaChanges) {
                 if (COMMIT === newFile.mode()) {
                     result[path] = new SubmoduleChange(
                                                  delta.oldFile().id().tostrS(),
-                                                 newFile.id().tostrS());
+                                                 newFile.id().tostrS(), 
+                                                 null);
                 } else if (!allowMetaChanges && path !== modulesFileName) {
                     throw new UserError(`\
 Modification to meta-repo file ${colors.red(path)} is not supported.`);
@@ -438,7 +439,8 @@ Modification to meta-repo file ${colors.red(path)} is not supported.`);
                 const path = newFile.path();
                 if (COMMIT === newFile.mode()) {
                     result[path] = new SubmoduleChange(null,
-                                                       newFile.id().tostrS());
+                                                       newFile.id().tostrS(),
+                                                       null);
                 } else if (!allowMetaChanges && path !== modulesFileName) {
                     throw new UserError(`\
 Addition to meta-repo of file ${colors.red(path)} is not supported.`);
@@ -449,6 +451,7 @@ Addition to meta-repo of file ${colors.red(path)} is not supported.`);
                 const path = oldFile.path();
                 if (COMMIT === oldFile.mode()) {
                     result[path] = new SubmoduleChange(oldFile.id().tostrS(),
+                                                       null,
                                                        null);
                 } else if (!allowMetaChanges && path !== modulesFileName) {
                     throw new UserError(`\

--- a/node/test/util/cherry_pick_util.js
+++ b/node/test/util/cherry_pick_util.js
@@ -252,7 +252,7 @@ describe("computeChangesFromIndex", function () {
 a=B:Ca-1;Cb-1;Ba=a;Bb=b|
 x=U:C3-2 s=Sa:a;Ct-2 s=Sa:b;Bt=t;Bmaster=3`,
             changes: {
-                "s": new SubmoduleChange("1", "b"),
+                "s": new SubmoduleChange("1", "b", null),
             },
         },
         "addition": {
@@ -360,7 +360,8 @@ x=U:C3-2 s=Sa:a;Ct-2 s;Bt=t;Bmaster=3`,
             for (let name in result.changes) {
                 const change = result.changes[name];
                 changes[name] = new SubmoduleChange(commitMap[change.oldSha],
-                                                    commitMap[change.newSha]);
+                                                    commitMap[change.newSha],
+                                                    null);
             }
             assert.deepEqual(changes, c.changes || {});
 
@@ -419,7 +420,8 @@ x=S:C2-1 s=Sa:1;C3-2 s=Sa:a;Ct-2 s=Sa:b;Bmaster=3;Bt=t`
 
         const change = result.changes.s;
         const expect = new SubmoduleChange(reverseCommitMap["1"],
-                                           reverseCommitMap.b);
+                                           reverseCommitMap.b,
+                                           reverseCommitMap.a);
         assert.deepEqual(expect, change);
     }));
 });
@@ -437,7 +439,7 @@ describe("pickSubs", function () {
         "pick a sub": {
             state: `a=B:Ca-1;Cb-1;Ba=a;Bb=b|x=U:C3-2 s=Sa:a;H=3`,
             subs: {
-                "s": new SubmoduleChange("1", "b"),
+                "s": new SubmoduleChange("1", "b", null),
             },
             expected: `x=E:Os Cbs-a b=b!H=bs;I s=Sa:bs`,
         },
@@ -447,8 +449,8 @@ a=B:Ca-1;Caa-1;Cb-1;Cc-b;Ba=a;Bb=b;Bc=c;Baa=aa|
 x=U:C3-2 s=Sa:a,t/u=Sa:a;H=3
 `,
             subs: {
-                "s": new SubmoduleChange("1", "aa"),
-                "t/u": new SubmoduleChange("1", "c"),
+                "s": new SubmoduleChange("1", "aa", null),
+                "t/u": new SubmoduleChange("1", "c", null),
             },
             expected: `
 x=E:Os Caas-a aa=aa!H=aas;Ot/u Cct/u-bt/u c=c!Cbt/u-a b=b!H=ct/u;
@@ -457,7 +459,7 @@ x=E:Os Caas-a aa=aa!H=aas;Ot/u Cct/u-bt/u c=c!Cbt/u-a b=b!H=ct/u;
         "a conflict": {
             state: `a=B:Ca-1;Cb-1 a=foo;Ba=a;Bb=b|x=U:C3-2 s=Sa:a;H=3`,
             subs: {
-                "s": new SubmoduleChange("1", "b"),
+                "s": new SubmoduleChange("1", "b", null),
             },
             conflicts: {
                 "s": "b",
@@ -475,7 +477,7 @@ foo
 a=B:Ca-1;Cb-1;Cc-b a=foo;Ba=a;Bb=b;Bc=c|
 x=U:C3-2 s=Sa:a;H=3`,
             subs: {
-                "s": new SubmoduleChange("1", "c"),
+                "s": new SubmoduleChange("1", "c", null),
             },
             conflicts: {
                 "s": "c",
@@ -501,7 +503,8 @@ foo
             Object.keys(c.subs).forEach(name => {
                 const change = c.subs[name];
                 subs[name] = new SubmoduleChange(reverseMap[change.oldSha],
-                                                 reverseMap[change.newSha]);
+                                                 reverseMap[change.newSha],
+                                                 null);
             });
             const opener = new Open.Opener(repo, null);
             const result = yield CherryPickUtil.pickSubs(repo,

--- a/node/test/util/merge_bare_util.js
+++ b/node/test/util/merge_bare_util.js
@@ -40,150 +40,173 @@ const RepoASTTestUtil   = require("../../lib/util/repo_ast_test_util");
 describe("MergeBareUtil", function () {
     describe("merge_with_all_cases", function () {
         // Similar to tests of merge, but with no need for a working directory.
+        const MODE = MergeBareUtil.MODE;
         const cases = {
             "3 way merge in bare": {
                 initial: `
 a=B:Ca-1;Cb-1;Ba=a;Bb=b|
 x=B:C2-1 s=Sa:1;C3-2 s=Sa:a;C4-2 s=Sa:b;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
-            "fast forward": {
+            "fast forward in normal mode": {
                 initial: "a=B|x=S:C2-1 s=Sa:1;Bfoo=2",
-                fromCommit: "2",
-                toCommit: "1",
+                theirCommit: "2",
+                ourCommit: "1",
+                mode: MODE.NORMAL,
                 parents: ["1"],
             },
-            "one merge_xxxx": {
+            "fast forward in no-ff mode": {
+                initial: "a=B|x=S:C2-1 s=Sa:1;Bfoo=2",
+                theirCommit: "2",
+                ourCommit: "1",
+                parents: ["1", "2"],
+            },
+            "one merge": {
                 initial: `
 a=B:Ca-1;Cb-1;Ba=a;Bb=b|
 x=U:C3-2 s=Sa:a;C4-2 s=Sa:b;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "one merge with ancestor": {
                 initial: `
 a=B:Ca-1;Cb-1;Ba=a;Bb=b|
 x=U:C3-2 s=Sa:a;C5-4 t=Sa:b;C4-2 s=Sa:b;Bmaster=3;Bfoo=5`,
-                fromCommit: "5",
-                toCommit: "3",
+                theirCommit: "5",
+                ourCommit: "3",
             },
             "non-ffmerge with trivial ffwd submodule change": {
                 initial: `
 a=Aa:Cb-a;Bb=b|
 x=U:C3-2 t=Sa:b;C4-2 s=Sa:b;Bmaster=3;Bfoo=4;Os`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "sub is same": {
                 initial: `
 a=Aa:Cb-a;Bb=b|
 x=U:C3-2 s=Sa:b;C4-2 s=Sa:b,t=Sa:b;Bmaster=3;Bfoo=4;Os`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "sub is same, closed": {
                 initial: `
 a=Aa:Cb-a;Bb=b|
 x=U:C3-2 s=Sa:b;C4-2 s=Sa:b,t=Sa:b;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "sub is behind": {
                 initial: `
 a=Aa:Cb-a;Bb=b|
 x=U:C3-2 s=Sa:b;C4-2 s=Sa:a;Bmaster=3;Bfoo=4;Os`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "sub is behind, closed": {
                 initial: `
 a=Aa:Cb-a;Bb=b|
 x=U:C3-2 s=Sa:b;C4-2 s=Sa:a;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "non-ffmerge with ffwd submodule change": {
                 initial: `
 a=Aa:Cb-a;Bb=b;Cc-b;Bc=c|
 x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "non-ffmerge with ffwd submodule change, closed": {
                 initial: `
 a=Aa:Cb-a;Bb=b;Cc-b;Bc=c|
 x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "non-ffmerge with deeper ffwd submodule change": {
                 initial: `
 a=Aa:Cb-a;Bb=b;Cc-b;Cd-c;Bd=d|
 x=U:C3-2 s=Sa:b;C5-4 s=Sa:d;C4-2 s=Sa:c;Bmaster=3;Bfoo=5`,
-                fromCommit: "5",
-                toCommit: "3",
+                theirCommit: "5",
+                ourCommit: "3",
             },
             "non-ffmerge with ffwd submodule change on lhs": {
                 initial: `
 a=Aa:Cb-a;Bb=b;Cc-b;Bc=c|
 x=U:C3-2 s=Sa:b;C4-2 q=Sa:a;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "non-ffmerge with non-ffwd submodule change": {
                 initial: `
 a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|
 x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "non-ffmerge with non-ffwd submodule change, sub already open": {
                 initial: `
 a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|
 x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "submodule commit is up-to-date": {
                 initial:`
 a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
 x=U:C3-2 s=Sa:c;C4-2 s=Sa:b,t=Sa:a;Bmaster=3;Bfoo=4;Os`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "submodule commit is up-to-date, was not open": {
                 initial:`
 a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
 x=U:C3-2 s=Sa:c;C4-2 s=Sa:b,t=Sa:a;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "submodule commit is same": {
                 initial: `
 a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
 x=U:C3-2 s=Sa:c;C4-2 s=Sa:c,q=Sa:a;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
-            "added in merge_xxxxs": {
+            "submodule commit backwards": {
+                initial:`
+a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:c;C4-2 s=Sa:b;Bmaster=3;Bfoo=4;Os`,
+                theirCommit: "4",
+                ourCommit: "3",
+            },
+            "submodule commit forwards": {
+                initial:`
+a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os`,
+                theirCommit: "4",
+                ourCommit: "3",
+            },
+
+            "added in merge": {
                 initial: `a=B|x=S:C2-1;C3-1 t=Sa:1;Bmaster=2;Bfoo=3`,
-                fromCommit: "2",
-                toCommit: "3",
+                theirCommit: "3",
+                ourCommit: "2",
             },
             "added on both sides": {
                 initial: `
 a=B|
 x=S:C2-1 s=Sa:1;C3-1 t=Sa:1;Bmaster=2;Bfoo=3`,
-                fromCommit: "2",
-                toCommit: "3",
+                theirCommit: "2",
+                ourCommit: "3",
             },
             "conflicted add": {
                 initial: `
 a=B:Ca-1;Cb-1;Ba=a;Bb=b|
 x=S:C2-1 s=Sa:a;C3-1 s=Sa:b;Bmaster=2;Bfoo=3`,
-                fromCommit: "3",
-                toCommit: "2",
+                theirCommit: "3",
+                ourCommit: "2",
                 errorMessage: `\
 CONFLICT (content): 
 Conflicting entries for submodule: ${colors.red("s")}
@@ -194,8 +217,8 @@ Automatic merge failed
                 initial: `
 a=B:Ca-1 README.md=8;Cb-1 README.md=9;Ba=a;Bb=b|
 x=U:C3-2 s=Sa:a;C4-2 s=Sa:b;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
                 errorMessage: `\
 CONFLICT (content): 
 Conflicting entries for submodule: ${colors.red("s")}
@@ -206,30 +229,30 @@ Automatic merge failed
                 initial: `
 a=B:Ca-1;Cb-1;Ba=a;Bb=b|
 x=U:C3-2 t=Sa:1;C4-3 s=Sa:a;C5-3 t=Sa:b;Bmaster=4;Bfoo=5;Os;Ot`,
-                fromCommit: "5",
-                toCommit: "4",
+                theirCommit: "5",
+                ourCommit: "4",
             },
             "new commit in sub in target branch but not in HEAD branch, closed"
             : {
                 initial: `
 a=B:Ca-1;Cb-1;Ba=a;Bb=b|
 x=U:C3-2 t=Sa:1;C4-3 s=Sa:a;C5-3 t=Sa:b;Bmaster=4;Bfoo=5`,
-                fromCommit: "5",
-                toCommit: "4",
+                theirCommit: "5",
+                ourCommit: "4",
             },
             "merge in a branch with a removed sub": {
                 initial: `
 a=B:Ca-1;Ba=a|
 x=U:C3-2 t=Sa:1;C4-2 s;Bmaster=3;Bfoo=4`,
-                fromCommit: "4",
-                toCommit: "3",
+                theirCommit: "4",
+                ourCommit: "3",
             },
             "merge to a branch with a removed sub": {
                 initial: `
 a=B:Ca-1;Ba=a|
 x=U:C3-2 t=Sa:1;C4-2 s;Bmaster=4;Bfoo=3`,
-                fromCommit: "3",
-                toCommit: "4",
+                theirCommit: "3",
+                ourCommit: "4",
             },
             "change with multiple merge bases": {
                 initial: `
@@ -240,8 +263,8 @@ x=S:C2-1 r=Sa:1,s=Sa:1,t=Sa:1;
     Cl-3,4 s,t;
     Ct-3,4 a=Sa:1,t=Sa:a;
     Bmaster=l;Bfoo=t`,
-                fromCommit: "t",
-                toCommit: "l",
+                theirCommit: "t",
+                ourCommit: "l",
             },            
         };
         Object.keys(cases).forEach(caseName => {
@@ -254,24 +277,22 @@ x=S:C2-1 r=Sa:1,s=Sa:1,t=Sa:1;
                     const upToDate = null === expected;
                     const x = repos.x;
                     const reverseCommitMap = maps.reverseCommitMap;
-                    assert.property(reverseCommitMap, c.fromCommit);
-                    const fromSha = reverseCommitMap[c.fromCommit];
-                    const fromCommit = yield x.getCommit(fromSha);
-                    const toSha = reverseCommitMap[c.toCommit];
-                    const toCommit = yield x.getCommit(toSha);
+                    assert.property(reverseCommitMap, c.theirCommit);
+                    const theirSha = reverseCommitMap[c.theirCommit];
+                    const theirCommit = yield x.getCommit(theirSha);
+                    const ourSha = reverseCommitMap[c.ourCommit];
+                    const ourCommit = yield x.getCommit(ourSha);
 
                     let message = c.message;
                     if (undefined === message) {
                         message = "message\n";
                     }
-                    const defaultEditor = function () {};
-                    const editMessage = c.editMessage || defaultEditor;
+                    const mode = !("mode" in c) ? MODE.FORCE_COMMIT : c.mode;
                     const result = yield MergeBareUtil.merge(x,
-                                                             fromCommit,
-                                                             toCommit,
-                                                             message,
-                                                             editMessage, 
-                                                             true);
+                                                             ourCommit,
+                                                             theirCommit,
+                                                             mode,
+                                                             message);
                     const errorMessage = c.errorMessage || null;
                     assert.equal(result.errorMessage, errorMessage);
                     if (upToDate) {
@@ -282,7 +303,7 @@ x=S:C2-1 r=Sa:1,s=Sa:1,t=Sa:1;
                     if (result.metaCommit) {
                         const parents = c.parents ?
                             c.parents.map(v => reverseCommitMap[v]) :
-                            [fromSha, toSha];
+                            [theirSha, ourSha];
                         const mergedCommit
                             = yield x.getCommit(result.metaCommit);
                         const mergeParents

--- a/node/test/util/merge_bare_util.js
+++ b/node/test/util/merge_bare_util.js
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2019, Two Sigma Open Source
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of git-meta nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+"use strict";
+
+const assert       = require("chai").assert;
+const co           = require("co");
+const colors       = require("colors");
+
+const MergeBareUtil     = require("../../lib//util/merge_bare_util");
+const RepoASTTestUtil   = require("../../lib/util/repo_ast_test_util");
+
+describe("MergeBareUtil", function () {
+    describe("merge_with_all_cases", function () {
+        // Similar to tests of merge, but with no need for a working directory.
+        const cases = {
+            "3 way merge in bare": {
+                initial: `
+a=B:Ca-1;Cb-1;Ba=a;Bb=b|
+x=B:C2-1 s=Sa:1;C3-2 s=Sa:a;C4-2 s=Sa:b;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "fast forward": {
+                initial: "a=B|x=S:C2-1 s=Sa:1;Bfoo=2",
+                fromCommit: "2",
+                toCommit: "1",
+                parents: ["1"],
+            },
+            "one merge_xxxx": {
+                initial: `
+a=B:Ca-1;Cb-1;Ba=a;Bb=b|
+x=U:C3-2 s=Sa:a;C4-2 s=Sa:b;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "one merge with ancestor": {
+                initial: `
+a=B:Ca-1;Cb-1;Ba=a;Bb=b|
+x=U:C3-2 s=Sa:a;C5-4 t=Sa:b;C4-2 s=Sa:b;Bmaster=3;Bfoo=5`,
+                fromCommit: "5",
+                toCommit: "3",
+            },
+            "non-ffmerge with trivial ffwd submodule change": {
+                initial: `
+a=Aa:Cb-a;Bb=b|
+x=U:C3-2 t=Sa:b;C4-2 s=Sa:b;Bmaster=3;Bfoo=4;Os`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "sub is same": {
+                initial: `
+a=Aa:Cb-a;Bb=b|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:b,t=Sa:b;Bmaster=3;Bfoo=4;Os`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "sub is same, closed": {
+                initial: `
+a=Aa:Cb-a;Bb=b|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:b,t=Sa:b;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "sub is behind": {
+                initial: `
+a=Aa:Cb-a;Bb=b|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:a;Bmaster=3;Bfoo=4;Os`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "sub is behind, closed": {
+                initial: `
+a=Aa:Cb-a;Bb=b|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:a;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "non-ffmerge with ffwd submodule change": {
+                initial: `
+a=Aa:Cb-a;Bb=b;Cc-b;Bc=c|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "non-ffmerge with ffwd submodule change, closed": {
+                initial: `
+a=Aa:Cb-a;Bb=b;Cc-b;Bc=c|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "non-ffmerge with deeper ffwd submodule change": {
+                initial: `
+a=Aa:Cb-a;Bb=b;Cc-b;Cd-c;Bd=d|
+x=U:C3-2 s=Sa:b;C5-4 s=Sa:d;C4-2 s=Sa:c;Bmaster=3;Bfoo=5`,
+                fromCommit: "5",
+                toCommit: "3",
+            },
+            "non-ffmerge with ffwd submodule change on lhs": {
+                initial: `
+a=Aa:Cb-a;Bb=b;Cc-b;Bc=c|
+x=U:C3-2 s=Sa:b;C4-2 q=Sa:a;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "non-ffmerge with non-ffwd submodule change": {
+                initial: `
+a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "non-ffmerge with non-ffwd submodule change, sub already open": {
+                initial: `
+a=Aa:Cb-a;Cc-a;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:b;C4-2 s=Sa:c;Bmaster=3;Bfoo=4;Os`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "submodule commit is up-to-date": {
+                initial:`
+a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:c;C4-2 s=Sa:b,t=Sa:a;Bmaster=3;Bfoo=4;Os`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "submodule commit is up-to-date, was not open": {
+                initial:`
+a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:c;C4-2 s=Sa:b,t=Sa:a;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "submodule commit is same": {
+                initial: `
+a=Aa:Cb-a;Cc-b;Bfoo=b;Bbar=c|
+x=U:C3-2 s=Sa:c;C4-2 s=Sa:c,q=Sa:a;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "added in merge_xxxxs": {
+                initial: `a=B|x=S:C2-1;C3-1 t=Sa:1;Bmaster=2;Bfoo=3`,
+                fromCommit: "2",
+                toCommit: "3",
+            },
+            "added on both sides": {
+                initial: `
+a=B|
+x=S:C2-1 s=Sa:1;C3-1 t=Sa:1;Bmaster=2;Bfoo=3`,
+                fromCommit: "2",
+                toCommit: "3",
+            },
+            "conflicted add": {
+                initial: `
+a=B:Ca-1;Cb-1;Ba=a;Bb=b|
+x=S:C2-1 s=Sa:a;C3-1 s=Sa:b;Bmaster=2;Bfoo=3`,
+                fromCommit: "3",
+                toCommit: "2",
+                errorMessage: `\
+CONFLICT (content): 
+Conflicting entries for submodule: ${colors.red("s")}
+Automatic merge failed
+`,
+            },
+            "conflict in submodule": {
+                initial: `
+a=B:Ca-1 README.md=8;Cb-1 README.md=9;Ba=a;Bb=b|
+x=U:C3-2 s=Sa:a;C4-2 s=Sa:b;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+                errorMessage: `\
+CONFLICT (content): 
+Conflicting entries for submodule: ${colors.red("s")}
+Automatic merge failed
+`,
+            },
+            "new commit in sub in target branch but not in HEAD branch": {
+                initial: `
+a=B:Ca-1;Cb-1;Ba=a;Bb=b|
+x=U:C3-2 t=Sa:1;C4-3 s=Sa:a;C5-3 t=Sa:b;Bmaster=4;Bfoo=5;Os;Ot`,
+                fromCommit: "5",
+                toCommit: "4",
+            },
+            "new commit in sub in target branch but not in HEAD branch, closed"
+            : {
+                initial: `
+a=B:Ca-1;Cb-1;Ba=a;Bb=b|
+x=U:C3-2 t=Sa:1;C4-3 s=Sa:a;C5-3 t=Sa:b;Bmaster=4;Bfoo=5`,
+                fromCommit: "5",
+                toCommit: "4",
+            },
+            "merge in a branch with a removed sub": {
+                initial: `
+a=B:Ca-1;Ba=a|
+x=U:C3-2 t=Sa:1;C4-2 s;Bmaster=3;Bfoo=4`,
+                fromCommit: "4",
+                toCommit: "3",
+            },
+            "merge to a branch with a removed sub": {
+                initial: `
+a=B:Ca-1;Ba=a|
+x=U:C3-2 t=Sa:1;C4-2 s;Bmaster=4;Bfoo=3`,
+                fromCommit: "3",
+                toCommit: "4",
+            },
+            "change with multiple merge bases": {
+                initial: `
+a=B:Ca-1;Ba=a|
+x=S:C2-1 r=Sa:1,s=Sa:1,t=Sa:1;
+    C3-2 s=Sa:a;
+    C4-2 t=Sa:a;
+    Cl-3,4 s,t;
+    Ct-3,4 a=Sa:1,t=Sa:a;
+    Bmaster=l;Bfoo=t`,
+                fromCommit: "t",
+                toCommit: "l",
+            },            
+        };
+        Object.keys(cases).forEach(caseName => {
+            const c = cases[caseName];
+            it(caseName, co.wrap(function *() {
+                // expect no changes to the repo
+                const expected = "x=E"; 
+
+                const doMerge = co.wrap(function *(repos, maps) {
+                    const upToDate = null === expected;
+                    const x = repos.x;
+                    const reverseCommitMap = maps.reverseCommitMap;
+                    assert.property(reverseCommitMap, c.fromCommit);
+                    const fromSha = reverseCommitMap[c.fromCommit];
+                    const fromCommit = yield x.getCommit(fromSha);
+                    const toSha = reverseCommitMap[c.toCommit];
+                    const toCommit = yield x.getCommit(toSha);
+
+                    let message = c.message;
+                    if (undefined === message) {
+                        message = "message\n";
+                    }
+                    const defaultEditor = function () {};
+                    const editMessage = c.editMessage || defaultEditor;
+                    const result = yield MergeBareUtil.merge(x,
+                                                             fromCommit,
+                                                             toCommit,
+                                                             message,
+                                                             editMessage, 
+                                                             true);
+                    const errorMessage = c.errorMessage || null;
+                    assert.equal(result.errorMessage, errorMessage);
+                    if (upToDate) {
+                        assert.isNull(result.metaCommit);
+                        return;                                       // RETURN
+                    }
+
+                    if (result.metaCommit) {
+                        const parents = c.parents ?
+                            c.parents.map(v => reverseCommitMap[v]) :
+                            [fromSha, toSha];
+                        const mergedCommit
+                            = yield x.getCommit(result.metaCommit);
+                        const mergeParents
+                            = yield mergedCommit.getParents(null, null);
+                        const mergeParentShas
+                            = new Set(mergeParents.map(c => c.sha()));
+                        const parentsMatch = parents
+                            .map(c => mergeParentShas.has(c))
+                            .reduce( (acc, curr) => acc && curr, true);
+                        assert.isTrue(
+                            parentsMatch, 
+                            "parents (" + mergeParentShas + ") " +
+                            "of created meta commit do not match expected: " +
+                            parents);
+                    }
+                    return {commitMap: {}};
+                });
+                yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,
+                                                               expected || {},
+                                                               doMerge,
+                                                               c.fails);
+            }));
+        });
+    });
+});

--- a/node/test/util/merge_util.js
+++ b/node/test/util/merge_util.js
@@ -133,7 +133,7 @@ x=U:C3-2 s=Sa:a;Bfoo=3;Os W a=b`,
         });
     });
 
-    describe("merge", function () {
+    describe("merge_xxx", function () {
         // Will do merge from repo `x`.  A merge commit in the meta-repo will
         // be named `x`; any merge commits in the sub-repos will be given the
         // name of the sub-repo in which they are made.  TODO: test for changes

--- a/node/test/util/merge_util.js
+++ b/node/test/util/merge_util.js
@@ -133,7 +133,7 @@ x=U:C3-2 s=Sa:a;Bfoo=3;Os W a=b`,
         });
     });
 
-    describe("merge_xxx", function () {
+    describe("merge", function () {
         // Will do merge from repo `x`.  A merge commit in the meta-repo will
         // be named `x`; any merge commits in the sub-repos will be given the
         // name of the sub-repo in which they are made.  TODO: test for changes

--- a/node/test/util/open.js
+++ b/node/test/util/open.js
@@ -83,7 +83,8 @@ describe("openOnCommit", function () {
                 const result = yield Open.openOnCommit(fetcher,
                                                        c.subName,
                                                        commit,
-                                                       null);
+                                                       null,
+                                                       false);
                 assert.instanceOf(result, NodeGit.Repository);
             });
             yield RepoASTTestUtil.testMultiRepoManipulator(c.initial,
@@ -103,8 +104,8 @@ describe("openOnCommit", function () {
             const w = yield RepoASTTestUtil.createMultiRepos("a=B|x=U:Os");
             const repo = w.repos.x;
             const opener = new Open.Opener(repo, null);
-            const s1 = yield opener.getSubrepo("s");
-            const s2 = yield opener.getSubrepo("s");
+            const s1 = yield opener.getSubrepo("s", false);
+            const s2 = yield opener.getSubrepo("s", false);
             const base = yield SubmoduleUtil.getRepo(repo, "s");
             assert.equal(s1, s2, "not re-opened");
             assert.equal(s1.workdir(), base.workdir(), "right path");
@@ -113,8 +114,8 @@ describe("openOnCommit", function () {
             const w = yield RepoASTTestUtil.createMultiRepos("a=B|x=U");
             const repo = w.repos.x;
             const opener = new Open.Opener(repo, null);
-            const s1 = yield opener.getSubrepo("s");
-            const s2 = yield opener.getSubrepo("s");
+            const s1 = yield opener.getSubrepo("s", false);
+            const s2 = yield opener.getSubrepo("s", false);
             const base = yield SubmoduleUtil.getRepo(repo, "s");
             assert.equal(s1, s2, "not re-opened");
             assert.equal(s1.workdir(), base.workdir(), "right path");
@@ -132,7 +133,7 @@ describe("openOnCommit", function () {
             const repo = w.repos.x;
             const commit = yield repo.getCommit(baseSha);
             const opener = new Open.Opener(repo, commit);
-            const s = yield opener.getSubrepo("s");
+            const s = yield opener.getSubrepo("s", false);
             const head = yield s.getHeadCommit();
             assert.equal(head.id().tostrS(), subSha);
         }));
@@ -157,7 +158,7 @@ describe("openOnCommit", function () {
             const w = yield RepoASTTestUtil.createMultiRepos(state);
             const repo = w.repos.x;
             const opener = new Open.Opener(repo, null);
-            yield opener.getSubrepo("s");
+            yield opener.getSubrepo("s", false);
             const open = yield opener.getOpenSubs();
             assert.deepEqual(Array.from(open), []);
         }));
@@ -182,7 +183,7 @@ describe("openOnCommit", function () {
             const w = yield RepoASTTestUtil.createMultiRepos(state);
             const repo = w.repos.x;
             const opener = new Open.Opener(repo, null);
-            yield opener.getSubrepo("s");
+            yield opener.getSubrepo("s", false);
             const opened = yield opener.getOpenedSubs();
             assert.deepEqual(opened, []);
         }));
@@ -191,7 +192,7 @@ describe("openOnCommit", function () {
             const w = yield RepoASTTestUtil.createMultiRepos(state);
             const repo = w.repos.x;
             const opener = new Open.Opener(repo, null);
-            yield opener.getSubrepo("s");
+            yield opener.getSubrepo("s", false);
             const opened = yield opener.getOpenedSubs();
             assert.deepEqual(opened, ["s"]);
         }));
@@ -208,7 +209,7 @@ describe("openOnCommit", function () {
             const w = yield RepoASTTestUtil.createMultiRepos(state);
             const repo = w.repos.x;
             const opener = new Open.Opener(repo, null);
-            const s = yield opener.getSubrepo("s");
+            const s = yield opener.getSubrepo("s", false);
             const result = yield opener.isOpen("s");
             assert.equal(true, result);
             const config = yield s.config();

--- a/node/test/util/reset.js
+++ b/node/test/util/reset.js
@@ -155,7 +155,7 @@ describe("reset", function () {
             const index = yield repo.index();
             const commit = yield repo.getCommit(rev["3"]);
             const changes = {
-                s: new SubmoduleChange(rev["1"], null),
+                s: new SubmoduleChange(rev["1"], null, null),
             };
             yield Reset.resetMetaRepo(repo, index, commit, changes);
             let exists = true;
@@ -175,7 +175,7 @@ describe("reset", function () {
             const index = yield repo.index();
             const commit = yield repo.getCommit(rev["2"]);
             const changes = {
-                s: new SubmoduleChange(null, rev["1"]),
+                s: new SubmoduleChange(null, rev["1"], null),
             };
             yield Reset.resetMetaRepo(repo, index, commit, changes);
             let exists = true;

--- a/node/test/util/stitch_util.js
+++ b/node/test/util/stitch_util.js
@@ -695,10 +695,10 @@ describe("writeSubmoduleChangeCache", function () {
         const nextSha = next.id().tostrS();
         const changes = {};
         changes[headSha] = {
-            "foo/bar": new SubmoduleChange("1", "2")
+            "foo/bar": new SubmoduleChange("1", "2", null)
         };
         changes[nextSha] = {
-            "baz/bam": new SubmoduleChange("3", "4")
+            "baz/bam": new SubmoduleChange("3", "4", null)
         };
         yield StitchUtil.writeSubmoduleChangeCache(repo, changes);
         const refName = StitchUtil.changeCacheRef;
@@ -724,10 +724,10 @@ describe("readSubmoduleChangeCache", function () {
         const nextSha = next.id().tostrS();
         const changes = {};
         changes[headSha] = {
-            "foo/bar": new SubmoduleChange("1", "2")
+            "foo/bar": new SubmoduleChange("1", "2", null)
         };
         changes[nextSha] = {
-            "baz/bam": new SubmoduleChange("3", "4")
+            "baz/bam": new SubmoduleChange("3", "4", null)
         };
         yield StitchUtil.writeSubmoduleChangeCache(repo, changes);
         const read = yield StitchUtil.readSubmoduleChangeCache(repo);
@@ -1090,7 +1090,7 @@ describe("listSubmoduleChanges", function () {
         const parent = parents[0];
         const firstSha = parent.id().tostrS();
         expected[head.id().tostrS()] = {
-            "s": new SubmoduleChange(null, firstSha),
+            "s": new SubmoduleChange(null, firstSha, null),
         };
         expected[firstSha] = {};
         const result =

--- a/node/test/util/submodule_change.js
+++ b/node/test/util/submodule_change.js
@@ -36,7 +36,7 @@ const SubmoduleChange = require("../../lib/util/submodule_change");
 
 describe("SubmoduleChange", function () {
     it("breathing", function () {
-        const change = new SubmoduleChange("old", "new");
+        const change = new SubmoduleChange("old", "new", null);
         assert.equal(change.oldSha, "old");
         assert.equal(change.newSha, "new");
     });

--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -456,7 +456,7 @@ describe("SubmoduleUtil", function () {
                 state: "S:C2-1 x=Sa:1;H=2",
                 from: "2",
                 result: {
-                    "x": new SubmoduleChange(null, "1"),
+                    "x": new SubmoduleChange(null, "1", null),
                 },
                 allowMetaChanges: false,
             },
@@ -464,8 +464,8 @@ describe("SubmoduleUtil", function () {
                 state: "S:C2-1 a=Sa:1,x=Sa:1;H=2",
                 from: "2",
                 result: {
-                    a: new SubmoduleChange(null, "1"),
-                    x: new SubmoduleChange(null, "1"),
+                    a: new SubmoduleChange(null, "1", null),
+                    x: new SubmoduleChange(null, "1", null),
                 },
                 allowMetaChanges: true,
             },
@@ -473,7 +473,7 @@ describe("SubmoduleUtil", function () {
                 state: "S:C3-2 a=Sa:2;C2-1 a=Sa:1,x=Sa:1;H=3",
                 from: "3",
                 result: {
-                    a: new SubmoduleChange("1", "2"),
+                    a: new SubmoduleChange("1", "2", null),
                 },
                 allowMetaChanges: true,
             },
@@ -487,8 +487,8 @@ describe("SubmoduleUtil", function () {
                 state: "S:C3-2 a=Sa:2,c=Sa:2;C2-1 a=Sa:1,x=Sa:1;H=3",
                 from: "3",
                 result: {
-                    a: new SubmoduleChange("1", "2"),
-                    c: new SubmoduleChange(null, "2"),
+                    a: new SubmoduleChange("1", "2", null),
+                    c: new SubmoduleChange(null, "2", null),
                 },
                 allowMetaChanges: true,
             },
@@ -496,7 +496,7 @@ describe("SubmoduleUtil", function () {
                 state: "S:C3-2 a;C2-1 a=Sa:1,x=Sa:1;H=3",
                 from: "3",
                 result: {
-                    a: new SubmoduleChange("1", null),
+                    a: new SubmoduleChange("1", null, null),
                 },
                 allowMetaChanges: false,
             },
@@ -504,8 +504,8 @@ describe("SubmoduleUtil", function () {
                 state: "S:C3-2 a,c=Sa:2;C2-1 a=Sa:1,x=Sa:1;H=3",
                 from: "3",
                 result: {
-                    c: new SubmoduleChange(null, "2"),
-                    a: new SubmoduleChange("1", null),
+                    c: new SubmoduleChange(null, "2", null),
+                    a: new SubmoduleChange("1", null, null),
                 },
                 allowMetaChanges: true,
             },
@@ -560,7 +560,7 @@ describe("SubmoduleUtil", function () {
                     assert.instanceOf(change, SubmoduleChange);
                     const oldSha = change.oldSha && commitMap[change.oldSha];
                     const newSha = change.newSha && commitMap[change.newSha];
-                    changes[name] = new SubmoduleChange(oldSha, newSha);
+                    changes[name] = new SubmoduleChange(oldSha, newSha, null);
                 });
                 assert.deepEqual(changes, c.result);
             }));
@@ -583,7 +583,7 @@ describe("SubmoduleUtil", function () {
                 state: "S:C2-1 x=Sa:1;H=2",
                 from: "2",
                 result: {
-                    "x": new SubmoduleChange(null, "1"),
+                    "x": new SubmoduleChange(null, "1", null),
                 },
                 allowMetaChanges: false,
             },
@@ -591,7 +591,7 @@ describe("SubmoduleUtil", function () {
                 state: "S:C3-2 w=Sa:1;C2-1 x=Sa:1;H=3",
                 from: "3",
                 result: {
-                    "w": new SubmoduleChange(null, "1"),
+                    "w": new SubmoduleChange(null, "1", null),
                 },
                 allowMetaChanges: false,
             },
@@ -600,8 +600,8 @@ describe("SubmoduleUtil", function () {
                 from: "3",
                 base: "1",
                 result: {
-                    "x": new SubmoduleChange(null, "1"),
-                    "w": new SubmoduleChange(null, "1"),
+                    "x": new SubmoduleChange(null, "1", null),
+                    "w": new SubmoduleChange(null, "1", null),
                 },
                 allowMetaChanges: false,
             },
@@ -652,7 +652,7 @@ describe("SubmoduleUtil", function () {
                     assert.instanceOf(change, SubmoduleChange);
                     const oldSha = change.oldSha && commitMap[change.oldSha];
                     const newSha = change.newSha && commitMap[change.newSha];
-                    changes[name] = new SubmoduleChange(oldSha, newSha);
+                    changes[name] = new SubmoduleChange(oldSha, newSha, null);
                 });
                 assert.deepEqual(changes, c.result);
             }));
@@ -663,15 +663,15 @@ describe("SubmoduleUtil", function () {
             "one": {
                 state: "S:C2-1 foo=Sa:1;H=2",
                 commit: "2",
-                expected: { foo: new Submodule("a", "1") },
+                expected: { foo: new Submodule("a", "1", null) },
                 names: null,
             },
             "two": {
                 state: "S:C2-1 foo=Sa:1,bar=Sa:1;H=2",
                 commit: "2",
                 expected: {
-                    foo: new Submodule("a", "1"),
-                    bar: new Submodule("a", "1"),
+                    foo: new Submodule("a", "1", null),
+                    bar: new Submodule("a", "1", null),
                 },
                 names: null,
             },
@@ -691,14 +691,14 @@ describe("SubmoduleUtil", function () {
                 state: "S:C2-1 foo=Sa:1,bar=Sa:1;H=2",
                 commit: "2",
                 expected: {
-                    bar: new Submodule("a", "1"),
+                    bar: new Submodule("a", "1", null),
                 },
                 names: ["bar"],
             },
             "from later commit": {
                 state: "S:C2-1 x=S/a:1;C3-2 x=S/a:2;H=3",
                 commit: "3",
-                expected: { x: new Submodule("/a", "2") },
+                expected: { x: new Submodule("/a", "2", null) },
                 names: null,
             },
              "none": {
@@ -723,7 +723,9 @@ describe("SubmoduleUtil", function () {
                 Object.keys(result).forEach((name) => {
                     const resultSub = result[name];
                     const commit = written.commitMap[resultSub.sha];
-                    mappedResult[name] = new Submodule(resultSub.url, commit);
+                    mappedResult[name] = new Submodule(resultSub.url,
+                                                       commit,
+                                                       null);
                 });
                 assert.deepEqual(mappedResult, c.expected);
             }));


### PR DESCRIPTION
#### Add a subcommand `merge-bare` that:
- can merge within a bare meta repo
- will abort merge process if conflicts cannot be resolved automatically
- create and print the resulting meta commit sha
- the meta commit is a dangling commit and subject to GC if no ref is updated to point to it later

#### How it works:
The in-memory merge has three steps: 
1. Build in memory index object from two merging commits: 
       `index <- NodeGit.Merge.commits(commit1, commit2)`
2. Save the tree to disk:
      `index.writeTreeTo(repo)`
3. Create a commit pointing to that tree:
     `repo.createCommit(...)`

The process is performed for the top repo as well as each relevant submodule. Commits of submodules are added to the meta index object through `NodeGit.Index.add(entry)` method.

At the end of the merge, a meta commit is created with two merging commits as parents. User can read the meta commit from the stdout print or with `git fsck --lost-found` command.