### PR TITLE
Fix rebase deduction logic in pull.

### DIFF
--- a/node/lib/util/pull.js
+++ b/node/lib/util/pull.js
@@ -100,7 +100,7 @@ ${colors.red(source)} in the remote ${colors.yellow(remoteName)}.`);
  * @return bool
  */
 exports.userWantsRebase = co.wrap(function*(args, repo, branch) {
-    if (args.rebase !== undefined) {
+    if (args.rebase !== undefined && args.rebase !== null) {
         return args.rebase;
     }
 

--- a/node/test/util/pull.js
+++ b/node/test/util/pull.js
@@ -132,6 +132,10 @@ describe("userWantsRebase", function () {
                                                       null,
                                                       null));
 
+        assert.equal(false, yield Pull.userWantsRebase({"rebase": null},
+                                                       repo,
+                                                       master));
+
         assert.equal(false, yield Pull.userWantsRebase({},
                                                        repo,
                                                        master));


### PR DESCRIPTION
I think there must have been a change in the way argparse handles
defaults, and where previously we were getting an `undefined` we are now
getting a `null`.