### PR TITLE
Turn off merge with bare in normal merge mode

### DIFF
--- a/node/lib/cmd/merge.js
+++ b/node/lib/cmd/merge.js
@@ -173,7 +173,7 @@ Merge of '${commitName}'
                                          null,
                                          commit,
                                          mode,
-                                         Open.SUB_OPEN_OPTION.ALLOW_BARE,
+                                         Open.SUB_OPEN_OPTION.FORCE_OPEN,
                                          args.message,
                                          editMessage);
     if (null !== result.errorMessage) {


### PR DESCRIPTION
Previously we turned on merge with half-open repo by default. Now we change the default option to always open subrepos. 

