### PR TITLE
Make push start with submodule's workdir if one exists

### DIFF
--- a/node/lib/util/push.js
+++ b/node/lib/util/push.js
@@ -236,7 +236,7 @@ exports.push = co.wrap(function *(repo, remoteName, source, target, force) {
         const sha = pushMap[subName];
         const syntheticName =
                           SyntheticBranchUtil.getSyntheticBranchForCommit(sha);
-        const subRepo = yield SubmoduleUtil.getBareRepo(repo, subName);
+        const subRepo = yield SubmoduleUtil.getRepo(repo, subName);
 
         // Resolve the submodule's URL against the URL of the meta-repo,
         // ignoring the remote that is configured in the open submodule.


### PR DESCRIPTION
This change would allow pre-push hooks using Husky to run correctly. Before this change, submodule pushes were ran from the bare repos (in meta-repo's `.git/modules`) and husky could not be found with the path (specified in .git/modules/../hooks). Making push command run from the workdir (ie. not from `.git`) makes husky run correctly.