### PR TITLE
Do not fail to push when a changed submodule is closed

### DIFF
--- a/node/lib/util/push.js
+++ b/node/lib/util/push.js
@@ -236,7 +236,7 @@ exports.push = co.wrap(function *(repo, remoteName, source, target, force) {
         const sha = pushMap[subName];
         const syntheticName =
                           SyntheticBranchUtil.getSyntheticBranchForCommit(sha);
-        const subRepo = yield SubmoduleUtil.getRepo(repo, subName);
+        const subRepo = yield SubmoduleUtil.getBareRepo(repo, subName);
 
         // Resolve the submodule's URL against the URL of the meta-repo,
         // ignoring the remote that is configured in the open submodule.


### PR DESCRIPTION
All we need is the bare repo to push.

This bit a user inside Two Sigma, and I tested this fix in his repo and it works.