### PR TITLE
Open fewer submodules in parallel

### DIFF
--- a/node/lib/cmd/open.js
+++ b/node/lib/cmd/open.js
@@ -151,7 +151,7 @@ Opening ${colors.blue(name)} on ${colors.green(shas[idx])}.`);
         }
         console.log(`Finished opening ${colors.blue(name)}.`);
     });
-    yield DoWorkQueue.doInParallel(subsToOpen, opener);
+    yield DoWorkQueue.doInParallel(subsToOpen, opener, 10);
 
     // Make sure the index entries are updated in case we're in sparse mode.
 


### PR DESCRIPTION
Unfortunately, we have http.postbuffer set to an astronomical value
due to https://gitlab.com/gitlab-org/gitlab/issues/17649.  This means
that high parallelism on open can cause OOMs.  Previous
value was the default, 20.