### PR TITLE
Allow git merge reading GIT_AUTHOR_x and GIT_COMMITTER_x envs

### DIFF
--- a/node/lib/util/merge_common.js
+++ b/node/lib/util/merge_common.js
@@ -71,7 +71,11 @@ class MergeContext {
                 mode,
                 openOption,
                 commitMessage,
-                editMessage) {
+                editMessage,
+                authorName,
+                authorEmail,
+                committerName,
+                committerEmail) {
         assert.instanceOf(metaRepo, NodeGit.Repository);
         if (null !== ourCommit) {
             assert.instanceOf(ourCommit, NodeGit.Commit);
@@ -94,6 +98,10 @@ class MergeContext {
         this.d_changeIndex = null;
         this.d_changes = null;
         this.d_conflictsMessage = "";
+        this.d_authorName = authorName;
+        this.d_authorEmail = authorEmail;
+        this.d_committerName = committerName;
+        this.d_committerEmail = committerEmail;
     }
 
     /**
@@ -230,6 +238,32 @@ MergeContext.prototype.getCommitMessage = co.wrap(function *() {
  * @returns {NodeGit.Signature}
  */
 MergeContext.prototype.getSig = co.wrap(function *() {
+    return yield ConfigUtil.defaultSignature(this.d_metaRepo);
+});
+
+/**
+ * @async
+ * @returns {NodeGit.Signature} author to be set with merge commit
+ */
+MergeContext.prototype.getAuthor = co.wrap(function *() {
+    if (this.d_authorName && this.d_authorEmail) {
+        return NodeGit.Signature.now(
+            this.d_authorName,
+            this.d_authorEmail);
+    }
+    return yield ConfigUtil.defaultSignature(this.d_metaRepo);
+});
+
+/**
+ * @async
+ * @returns {NodeGit.Signature} committer to be set with merge commit
+ */
+MergeContext.prototype.getCommitter = co.wrap(function *() {
+    if (this.d_committerName && this.d_committerEmail) {
+        return NodeGit.Signature.now(
+            this.d_committerName,
+            this.d_committerEmail);
+    }
     return yield ConfigUtil.defaultSignature(this.d_metaRepo);
 });
 

--- a/node/test/util/merge_full_open.js
+++ b/node/test/util/merge_full_open.js
@@ -408,7 +408,11 @@ x=S:C2-1 r=Sa:1,s=Sa:1,t=Sa:1;
                                                          mode,
                                                          openOption,
                                                          message,
-                                                         editMessage);
+                                                         editMessage,
+                                                         null,
+                                                         null,
+                                                         null,
+                                                         null);
                     const errorMessage = c.errorMessage || null;
                     assert.equal(result.errorMessage, errorMessage);
                     if (upToDate) {

--- a/node/test/util/merge_util.js
+++ b/node/test/util/merge_util.js
@@ -476,7 +476,11 @@ x=S:C2-1 r=Sa:1,s=Sa:1,t=Sa:1;
                                                          mode,
                                                          openOption,
                                                          message,
-                                                         editMessage);
+                                                         editMessage,
+                                                         null,
+                                                         null,
+                                                         null,
+                                                         null);
                     const errorMessage = c.errorMessage || null;
                     assert.equal(result.errorMessage, errorMessage);
                     
@@ -484,7 +488,6 @@ x=S:C2-1 r=Sa:1,s=Sa:1,t=Sa:1;
                         assert.isNull(result.metaCommit);
                         return;                                       // RETURN
                     }
-
                     if (!result.metaCommit) {
                         return;
                     }


### PR DESCRIPTION
Example:

```
$  GIT_AUTHOR_NAME=alice \
    GIT_AUTHOR_EMAIL=alice@example.com \
    GIT_COMMITTER_NAME=bob \
    GIT_COMMITTER_EMAIL=bob@example.com \
    git meta merge-bare f0 f2 -m 'merge f0 f2'

Merging meta-repo commits 1d9a5eb70f2dea18fbea73f2f3ade9e1a6350d5e and 92e659eac8a80e89482e53cd1adc1817a99abf80
Merge commit created at 1c8fc2c6c9c34bf96dd243f37c6e8f45b848d159.

$ git cat-file -p 1c8fc2c6c9c34bf96dd243f37c6e8f45b848d159
tree 6e44a9a655aae4da8c96cfc48ab2fc82a1956eb2
parent 1d9a5eb70f2dea18fbea73f2f3ade9e1a6350d5e
parent 92e659eac8a80e89482e53cd1adc1817a99abf80
author alice <alice@example.com> 1578606900 -0500
committer bob <bob@example.com> 1578606900 -0500
```