### PR TITLE
Add error message to remind user to use git meta push

### DIFF
--- a/node/lib/util/synthetic_branch_util.js
+++ b/node/lib/util/synthetic_branch_util.js
@@ -395,7 +395,12 @@ function* metaUpdateIsBad(repo, notesRepo, updates) {
     });
 
     const resolved = yield checkFailures;
-    return resolved.some(identity);
+    const isBad = resolved.some(identity);
+    if (isBad) {
+        console.error("\nPush to meta repository is incomplete, " +
+            "did you forget to use git meta push?\n");
+    }
+    return isBad;
 }
 
 /**


### PR DESCRIPTION
pre receive hook can reminder user of using `git meta push` when it deteches submodule sysnthetic branches are not updated along with the meta commit user is trying to push. 