### PR TITLE
Create synthetic ref for fetches in submodules

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -46,6 +46,7 @@ const path         = require("path");
 const ConfigUtil          = require("./config_util");
 const Hook                = require("./hook");
 const GitUtilFast         = require("./git_util_fast");
+const SyntheticBranchUtil = require("./synthetic_branch_util");
 const UserError           = require("./user_error");
 
 const EXEC_BUFFER = 1024*1024*100;
@@ -569,7 +570,10 @@ exports.fetchSha  = co.wrap(function *(repo, url, sha) {
     catch (e) {
     }
 
-    const execString = `git -C '${repo.path()}' fetch -q '${url}' ${sha}`;
+    const syntheticName =
+                      SyntheticBranchUtil.getSyntheticBranchForCommit(sha);
+    const execString = `git -C '${repo.path()}' fetch -q '${url}' \
+${sha}:${syntheticName}`;
     try {
         yield ChildProcess.exec(execString, {
             maxBuffer: EXEC_BUFFER

--- a/node/lib/util/repo_ast_test_util.js
+++ b/node/lib/util/repo_ast_test_util.js
@@ -215,6 +215,7 @@ exports.createMultiRepos = co.wrap(function *(input) {
  * @param {Object}         options.expectedTransformer.mapping.reverseCommitMap
  * @param {Object}         options.expectedTransformer.mapping.reverseUrlMap
  * @param {Object}               options.expectedTransformer.return
+ * @param {Boolean}              options.ignoreRefsCommits
  */
 exports.testMultiRepoManipulator =
         co.wrap(function *(input, expected, manipulator, shouldFail, options) {
@@ -245,6 +246,7 @@ exports.testMultiRepoManipulator =
     else {
         assert.isFunction(options.actualTransformer);
     }
+    const includeRefsCommits = options.includeRefsCommits || false;
     const inputASTs = createMultiRepoASTMap(input);
 
     // Write the repos in their initial states.
@@ -344,7 +346,7 @@ exports.testMultiRepoManipulator =
             const path = manipulated.urlMap[repoName];
             repo = yield NodeGit.Repository.open(path);
         }
-        const newAST = yield ReadRepoASTUtil.readRAST(repo);
+        const newAST = yield ReadRepoASTUtil.readRAST(repo, includeRefsCommits);
         const commits = RepoASTUtil.listCommits(newAST);
         Object.keys(commits).forEach(rememberCommit);
         actualASTs[repoName] = RepoASTUtil.mapCommitsAndUrls(newAST,

--- a/node/test/util/destitch_util.js
+++ b/node/test/util/destitch_util.js
@@ -753,6 +753,7 @@ b=E:Fcommits/s.x.s=s.x.s`,
                                                            c.expected,
                                                            destitcher,
                                                            c.fails, {
+                includeRefsCommits : true,
                 actualTransformer: refMapper,
             });
         }));

--- a/node/test/util/push.js
+++ b/node/test/util/push.js
@@ -323,7 +323,9 @@ x=S:B3=3;C2-1 s=Sa:1;Rorigin=a master=3;Rtarget=b;Bmaster=2 origin/master;Os`,
             yield RepoASTTestUtil.testMultiRepoManipulator(
                 c.initial,
                 expected,
-                manipulator);
+                manipulator,
+                false,
+                {includeRefsCommits : true});
         }));
     });
 
@@ -500,6 +502,7 @@ x=E:Rorigin=a foo=2`,
                                                            c.expected,
                                                            c.manipulator,
                                                            c.fails, {
+                includeRefsCommits : true,
                 expectedTransformer: refMapper,
             });
         }));

--- a/node/test/util/stitch_util.js
+++ b/node/test/util/stitch_util.js
@@ -1256,6 +1256,7 @@ describe("fetchSubCommits", function () {
                                                            c.expected,
                                                            fetcher,
                                                            c.fails, {
+                includeRefsCommits: true,
                 actualTransformer: refMapper,
             });
 


### PR DESCRIPTION
Subsequent fetches can use these for negotiation and only download new
objects instead of downloading the entire history.

The tests are changed to mostly ignore all synthetic refs, since
changing evrey test would be a nightmare.  But a few tests have to
care about synthetic refs because they are directly testing synthetic
refs.  Fortunately, there are no cases of tests that care about
some but not all such refs.