### PR TITLE
If our sha is a descendant of their sha, we need to make sure that our

### DIFF
--- a/node/lib/util/merge_util.js
+++ b/node/lib/util/merge_util.js
@@ -255,6 +255,7 @@ exports.mergeSubmodule = co.wrap(function *(metaIndex,
 
     // See if up-to-date
     if (yield NodeGit.Graph.descendantOf(subRepo, ourSha, theirSha)) {
+        yield CherryPickUtil.addSubmoduleCommit(metaIndex, subName, ourSha);
         return result;                                                // RETURN
     }
 


### PR DESCRIPTION
sha gets added to the index.  This is handled elsewhere in non-bare merges,
but in bare merges, we need to manually handle it.