### PR TITLE
Skip url changes check in normal merge.

### DIFF
--- a/node/lib/util/merge_util.js
+++ b/node/lib/util/merge_util.js
@@ -352,8 +352,7 @@ ${colors.green(theirSha)}.`);
 /**
  * Perform preparation work before merge, including
  * 1. locate merge base
- * 2. ensureNoURLChanges see also {CherryPickUtil.ensureNoURLChanges}
- * 3. check if working dir is clean (non-bare repo)
+ * 2. check if working dir is clean (non-bare repo)
  * 3. check if two merging commits are the same or if their commit
  *    is an ancestor of ours, both cases are no-op.
  * 
@@ -385,9 +384,6 @@ const mergeStepPrepare = co.wrap(function *(context) {
     }
 
     if (!forceBare) {
-        yield CherryPickUtil.ensureNoURLChanges(metaRepo,
-                                                theirCommit,
-                                                baseCommit);
         const status = yield StatusUtil.getRepoStatus(metaRepo);
         const statusError = StatusUtil.checkReadiness(status);
         if (null !== statusError) {

--- a/node/test/util/merge_full_open.js
+++ b/node/test/util/merge_full_open.js
@@ -99,12 +99,18 @@ describe("MergeFullOpen", function () {
             "url changes": {
                 initial: "a=B|b=B|x=U:C3-2 s=Sb:1;Bfoo=3",
                 fromCommit: "3",
-                fails: true,
+                expected: "a=B|x=E:Bmaster=3",
             },
             "ancestor url changes": {
                 initial: "a=B|b=B|x=U:C4-3 q=Sa:1;C3-2 s=Sb:1;Bfoo=4",
                 fromCommit: "4",
-                fails: true,
+                expected: "a=B|x=E:Bmaster=4",
+            },
+            "genuine url merge conflicts": {
+                initial: "a=B|b=B|c=B|" + 
+                         "x=U:C3-2 s=Sc:1;C4-2 s=Sb:1;Bmaster=3;Bfoo=4",
+                fromCommit: "4",
+                fails: true
             },
             "dirty": {
                 initial: "a=B|x=U:C3-1 t=Sa:1;Bfoo=3;Os W README.md=8",

--- a/node/test/util/merge_util.js
+++ b/node/test/util/merge_util.js
@@ -166,12 +166,18 @@ x=U:C3-2 s=Sa:a;Bfoo=3;Os W a=b`,
             "url changes": {
                 initial: "a=B|b=B|x=U:C3-2 s=Sb:1;Bfoo=3",
                 fromCommit: "3",
-                fails: true,
+                expected: "a=B|x=E:Bmaster=3"
             },
             "ancestor url changes": {
                 initial: "a=B|b=B|x=U:C4-3 q=Sa:1;C3-2 s=Sb:1;Bfoo=4",
                 fromCommit: "4",
-                fails: true,
+                expected: "a=B|x=E:Bmaster=4"
+            },
+            "genuine url merge conflicts": {
+                initial: "a=B|b=B|c=B|" + 
+                         "x=U:C3-2 s=Sc:1;C4-2 s=Sb:1;Bmaster=3;Bfoo=4",
+                fromCommit: "4",
+                fails: true
             },
             "dirty": {
                 initial: "a=B|x=U:C3-1 t=Sa:1;Bfoo=3;Os W README.md=8",


### PR DESCRIPTION
After #752 merge is able to smart merge submdoule urls, but we kept url change warnings to normal merge for backward compatibility. Now it is time to lift che check and allow smart url merge for normal merge as well