### PR TITLE
Pull: do not check remote name

### DIFF
--- a/node/lib/util/pull.js
+++ b/node/lib/util/pull.js
@@ -55,15 +55,6 @@ exports.pull = co.wrap(function *(metaRepo, remoteName, source) {
     assert.isString(remoteName);
     assert.isString(source);
 
-    // First do some sanity checking on the repos to see if they have a remote
-    // with `remoteName` and are clean.
-
-    const validRemote = yield GitUtil.isValidRemoteName(metaRepo, remoteName);
-
-    if (!validRemote) {
-        throw new UserError(`Invalid remote name ${colors.red(remoteName)}.`);
-    }
-
     const status = yield StatusUtil.getRepoStatus(metaRepo);
 
     // Just fetch the meta-repo; rebase will trigger necessary fetches in


### PR DESCRIPTION
`We` don't care if the remote they give is a *named* remote -- we just
care if we can fetch from it.  Fetching calls out to regular git,
which knows how to handle not only remote names but also remote URLs.
And fetching is about the first thing we do, so we'll find out quickly
whether the remote is valid.