### PR TITLE
Improve message for direct submodule conflicts

### DIFF
--- a/node/lib/util/merge_util.js
+++ b/node/lib/util/merge_util.js
@@ -116,7 +116,8 @@ const getBareMergeConflictsMessage = function(conflicts) {
                 errorMessage += `\tconflicted:  ${name}/${path}\n`;
             }
         } else {
-            errorMessage += `Merge conflict in submodule '${name}':\n`;
+            errorMessage += `Merge conflict in submodule '${name}' itself
+(e.g. delete/modify or add/modify)\n`;
         }
     }
     errorMessage += "\nAutomatic merge failed\n";


### PR DESCRIPTION
This turns out to be really tricky to test, because the test framework does not know how to render meta conflicts.  But we know that the existing message works, so changing it should be safe.