### PR TITLE
Provides momre information when merge fails:

### DIFF
--- a/node/lib/util/merge_util.js
+++ b/node/lib/util/merge_util.js
@@ -778,7 +778,9 @@ exports.continue = co.wrap(function *(repo) {
         yield index.conflictRemove(subPath);
     });
     const openSubs = yield SubmoduleUtil.listOpenSubmodules(repo);
-    yield DoWorkQueue.doInParallel(openSubs, continueSub);
+    yield DoWorkQueue.doInParallel(openSubs,
+                                   continueSub,
+                                   {failMsg: "Merge in submodule failed."});
     yield SparseCheckoutUtil.writeMetaIndex(repo, index);
 
     if ("" !== errorMessage) {

--- a/node/lib/util/stitch_util.js
+++ b/node/lib/util/stitch_util.js
@@ -977,7 +977,9 @@ ${name}`;
             yield exports.fetchSubCommits(repo, url, subFetches);
             console.timeEnd(fetchTimeMessage);
         });
-        yield DoWorkQueue.doInParallel(subNames, doFetch, options.numParallel);
+        yield DoWorkQueue.doInParallel(subNames,
+                                       doFetch,
+                                       {limit: options.numParallel});
     }
 
     console.log("Now stitching");

--- a/node/test/util/do_work_queue.js
+++ b/node/test/util/do_work_queue.js
@@ -81,8 +81,30 @@ describe("DoWorkQueue", function () {
                 return i * 2;
             });
         }
-        const result = yield DoWorkQueue.doInParallel(work, getWork, 1);
+        const result = yield DoWorkQueue.doInParallel(work,
+                                                      getWork,
+                                                      {limit: 1});
         assert.equal(result.length, NUM_TO_DO);
         assert.deepEqual(result, expected);
+    }));
+
+    it("sub work failure", co.wrap(function *() {
+        let work = ["success", "fail"];
+        function getWork(name, index) {
+            if ("fail" === name) {
+                throw new Error("deliberate error");
+            }
+            return waitSomeTime(index);
+        }
+        try {
+            yield DoWorkQueue.doInParallel(
+                work,
+                getWork,
+                {limit: 1, failMsg: "getWork failed"}
+            );
+            assert.fail("should have failed");
+        } catch (error) {
+            assert.equal("deliberate error", error.message);
+        }
     }));
 });


### PR DESCRIPTION
1. do not crash even if a submodule is corruptted and its HEAD points to a nonexistent commit
2. if merge failed in a submodule, print what submodule it was
