### PR TITLE
Allow git-meta concatenating multiple --message arguments 

### DIFF
--- a/node/lib/cmd/commit-shadow.js
+++ b/node/lib/cmd/commit-shadow.js
@@ -74,6 +74,7 @@ exports.configureParser = function (parser) {
     });
     parser.addArgument(["-m", "--message"], {
         type: "string",
+        action: "append",
         required: true,
         help: "commit message for shadow commits",
     });
@@ -115,8 +116,9 @@ exports.executeableSubcommand = co.wrap(function *(args) {
     const incrementTimestamp =
                               args.increment_timestamp || args.epoch_timestamp;
     const includedSubrepos = args.include_subrepos || [];
+    const message = args.message ? args.message.join("\n\n") : null;
     const result = yield StashUtil.makeShadowCommit(repo,
-                                                    args.message,
+                                                    message,
                                                     incrementTimestamp,
                                                     false,
                                                     args.include_untracked,

--- a/node/lib/cmd/commit.js
+++ b/node/lib/cmd/commit.js
@@ -64,7 +64,7 @@ exports.configureParser = function (parser) {
     });
     parser.addArgument(["-m", "--message"], {
         type: "string",
-        defaultValue: null,
+        action: "append",
         required: false,
         help: "commit message; if not specified will prompt"
     });
@@ -119,10 +119,11 @@ const doCommit = co.wrap(function *(args) {
 
     const repo = yield GitUtil.getCurrentRepo();
     const cwd = process.cwd();
+    const message = args.message ? args.message.join("\n\n") : null;
 
     yield Commit.doCommitCommand(repo,
                                  cwd,
-                                 args.message,
+                                 message,
                                  args.all,
                                  args.file,
                                  args.interactive,
@@ -138,6 +139,7 @@ const doAmend = co.wrap(function *(args) {
     const UserError     = require("../util/user_error");
 
     const usingPaths = 0 !== args.file.length;
+    const message = args.message ? args.message.join("\n\n") : null;
 
     if (usingPaths) {
         throw new UserError("Paths not supported with amend yet.");
@@ -148,7 +150,7 @@ const doAmend = co.wrap(function *(args) {
 
     yield Commit.doAmendCommand(repo,
                                 cwd,
-                                args.message,
+                                message,
                                 args.all,
                                 args.interactive,
                                 args.no_edit ? null : GitUtil.editMessage,

--- a/node/lib/cmd/merge.js
+++ b/node/lib/cmd/merge.js
@@ -59,6 +59,7 @@ exports.configureParser = function (parser) {
     parser.addArgument(["-m", "--message"], {
         type: "string",
         help: "commit message",
+        action: "append",
         required: false,
     });
     parser.addArgument(["-F", "--message-file"], {
@@ -196,7 +197,7 @@ Merge of '${commitName}'
         doNotRecurse.push(noSlashPrefix);
     }
 
-    let message = args.message;
+    let message = args.message ? args.message.join("\n\n") : null;
     if (args.message_file) {
         message = yield fs.readFile(args.message_file, "utf8");
     }

--- a/node/lib/cmd/merge_bare.js
+++ b/node/lib/cmd/merge_bare.js
@@ -56,6 +56,7 @@ that is not pointed by any refs. It will also abort if there are merge conflicts
 exports.configureParser = function (parser) {
     parser.addArgument(["-m", "--message"], {
         type: "string",
+        action: "append",
         help: "commit message",
         required: false,
     });
@@ -143,7 +144,7 @@ Could not resolve ${colors.red(theirCommitName)} to a commit.`);
         doNotRecurse.push(noSlashPrefix);
     }
 
-    let message = args.message;
+    let message = args.message ? args.message.join("\n\n") : null;
     if (args.message_file) {
         message = yield fs.readFile(args.message_file, "utf8");
     }

--- a/node/lib/cmd/stash.js
+++ b/node/lib/cmd/stash.js
@@ -56,7 +56,7 @@ exports.configureParser = function (parser) {
 
     parser.addArgument(["-m", "--message"], {
         type: "string",
-        defaultValue: null,
+        action: "append",
         required: false,
         help: "description; if not provided one will be generated",
     });
@@ -142,10 +142,11 @@ const doSave = co.wrap(function *(args) {
         console.warn("Nothing to stash.");
         return;                                                       // RETURN
     }
+    const message = args.message ? args.message.join("\n\n") : null;
     yield StashUtil.save(repo,
                          status,
                          includeUntracked || false,
-                         args.message);
+                         message);
     console.log("Saved working directory and index state.");
 });
 


### PR DESCRIPTION
Replicate vanilla git's behavior:
> If multiple -m options are given, their values are concatenated as separate paragraphs.
