### PR TITLE
Bump nodegit to ^0.25.0

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -208,7 +208,7 @@ exports.isValidRemoteName = co.wrap(function *(repo, name) {
     assert.instanceOf(repo, NodeGit.Repository);
     assert.isString(name);
 
-    const remotes = yield repo.getRemotes();
+    const remotes = yield repo.getRemoteNames();
     return remotes.find(x => x === name) !== undefined;
 });
 

--- a/node/lib/util/read_repo_ast_util.js
+++ b/node/lib/util/read_repo_ast_util.js
@@ -258,7 +258,7 @@ exports.readRAST = co.wrap(function *(repo, includeRefsCommits) {
         includeRefsCommits = false;
     }
     assert.instanceOf(repo, NodeGit.Repository);
-    const branches = yield repo.getReferences(NodeGit.Reference.TYPE.LISTALL);
+    const branches = yield repo.getReferences();
     let commits = {};
     let branchTargets = {};
     let refTargets = {};

--- a/node/lib/util/test_util.js
+++ b/node/lib/util/test_util.js
@@ -257,12 +257,12 @@ exports.makeBareCopy = co.wrap(function *(repo, path) {
     // Record the branches that exist in the bare repo.
 
     let existingBranches = {};
-    const bareRefs = yield bare.getReferences(NodeGit.Reference.TYPE.LISTALL);
+    const bareRefs = yield bare.getReferences();
     bareRefs.forEach(r => existingBranches[r.shorthand()] = true);
 
     // Then create all the branches that weren't copied initially.
 
-    const refs = yield repo.getReferences(NodeGit.Reference.TYPE.LISTALL);
+    const refs = yield repo.getReferences();
     const sig = yield ConfigUtil.defaultSignature(bare);
     for (let i = 0; i < refs.length; ++i) {
         const ref = refs[i];

--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -754,7 +754,7 @@ exports.writeMultiRAST = co.wrap(function *(repos, rootDirectory) {
 
         repo.detachHead();
 
-        const refs = yield repo.getReferences(NodeGit.Reference.TYPE.LISTALL);
+        const refs = yield repo.getReferences();
         for (let i = 0; i < refs.length; ++i) {
             NodeGit.Branch.delete(refs[i]);
         }

--- a/node/package.json
+++ b/node/package.json
@@ -27,7 +27,7 @@
   "preferGlobal": true,
   "homepage": "https://github.com/twosigma/git-meta#readme",
   "dependencies": {
-    "argparse": "",
+    "argparse": "^1.0.0",
     "binary-search": "",
     "chai": "",
     "child-process-promise": "",
@@ -36,7 +36,7 @@
     "deeper": "",
     "fs-promise": "",
     "group-by": "",
-    "nodegit": "^0.23.0",
+    "nodegit": "^0.25.0",
     "rimraf": "",
     "split": "",
     "walk": ""

--- a/node/test/util/bulk_notes_util.js
+++ b/node/test/util/bulk_notes_util.js
@@ -112,7 +112,7 @@ describe("readNotes", function () {
         const foo = yield repo.getBranchCommit("foo");
         const fooSha = foo.id().tostrS();
         const refName = "refs/notes/foo/bar";
-        const sig = repo.defaultSignature();
+        const sig = yield repo.defaultSignature();
         yield NodeGit.Note.create(repo, refName, sig, sig, fooSha, "foo", 1);
         yield NodeGit.Note.create(repo, refName, sig, sig, headSha, "bar", 1);
         const result = yield BulkNotesUtil.readNotes(repo, refName);

--- a/node/test/util/config_util.js
+++ b/node/test/util/config_util.js
@@ -98,8 +98,8 @@ describe("defaultSignature", function () {
     it("works", co.wrap(function *() {
         const repo = yield TestUtil.createSimpleRepository();
         const actual = yield ConfigUtil.defaultSignature(repo);
-        assert.equal(actual.toString(),
-                     repo.defaultSignature().toString());
+        const sig = yield repo.defaultSignature();
+        assert.equal(actual.toString(), sig.toString());
     }));
 });
 });

--- a/node/test/util/destitch_util.js
+++ b/node/test/util/destitch_util.js
@@ -539,7 +539,7 @@ describe("getDestitched", function () {
             metaCommit: "1",
             subCommits: {},
         };
-        const sig = repo.defaultSignature();
+        const sig = yield repo.defaultSignature();
         const refName = DestitchUtil.localReferenceNoteRef;
         const data = JSON.stringify(destitched, null, 4);
         yield NodeGit.Note.create(repo, refName, sig, sig, headSha, data, 1);
@@ -555,7 +555,7 @@ describe("getDestitched", function () {
             metaCommit: "1",
             subCommits: {},
         };
-        const sig = repo.defaultSignature();
+        const sig = yield repo.defaultSignature();
         const refName = StitchUtil.referenceNoteRef;
         const data = JSON.stringify(destitched, null, 4);
         yield NodeGit.Note.create(repo, refName, sig, sig, headSha, data, 1);

--- a/node/test/util/git_util.js
+++ b/node/test/util/git_util.js
@@ -1120,7 +1120,7 @@ describe("GitUtil", function () {
             const repo = yield TestUtil.createSimpleRepository();
             const head = yield repo.getHeadCommit();
             yield fs.appendFile(path.join(repo.workdir(), "README.md"), "foo");
-            const sig = repo.defaultSignature();
+            const sig = yield repo.defaultSignature();
             const newCommitId = yield repo.createCommitOnHead(["README.md"],
                                                               sig,
                                                               sig,

--- a/node/test/util/include.js
+++ b/node/test/util/include.js
@@ -115,10 +115,10 @@ describe("include", function () {
         }));
 
         it("should have signature of the current repo", co.wrap(function *() {
-            const repoSignature = repo.defaultSignature();
+            const repoSignature = yield repo.defaultSignature();
             const submoduleRepo = 
                 yield NodeGit.Repository.open(repo.workdir() + path);
-            const submoduleSignature = submoduleRepo.defaultSignature();
+            const submoduleSignature = yield submoduleRepo.defaultSignature();
 
             assert.equal(repoSignature.toString(), 
                 submoduleSignature.toString());

--- a/node/test/util/read_repo_ast_util.js
+++ b/node/test/util/read_repo_ast_util.js
@@ -408,7 +408,7 @@ describe("readRAST", function () {
     it("headless with a commit", co.wrap(function *() {
         const path = yield TestUtil.makeTempDir();
         const r = yield NodeGit.Repository.init(path, 1);
-        const sig = r.defaultSignature();
+        const sig = yield r.defaultSignature();
         const builder = yield NodeGit.Treebuilder.create(r, null);
         const treeObj = yield builder.write();
         const tree = yield r.getTree(treeObj.tostrS());
@@ -467,7 +467,7 @@ describe("readRAST", function () {
     it("remote with path in tracking branch", co.wrap(function *() {
         const base = yield TestUtil.createSimpleRepository();
         const headId = (yield base.getHeadCommit()).id();
-        const sig = base.defaultSignature();
+        const sig = yield base.defaultSignature();
         yield base.createBranch("foo/bar", headId, 1, sig, "branch");
         const clonePath = yield TestUtil.makeTempDir();
         const clone = yield NodeGit.Clone.clone(base.workdir(), clonePath);
@@ -1007,7 +1007,7 @@ describe("readRAST", function () {
         const workdir = repo.workdir();
         const firstCommit = yield repo.getHeadCommit();
         const firstSha = firstCommit.id().tostrS();
-        const sig = repo.defaultSignature();
+        const sig = yield repo.defaultSignature();
         yield repo.createBranch("b", firstCommit, 0, sig);
         yield repo.checkoutBranch("b");
         yield fs.writeFile(path.join(workdir, "foo"), "foo");
@@ -1060,7 +1060,7 @@ describe("readRAST", function () {
 
     it("merge commit with submodule change", co.wrap(function *() {
         const repo = yield TestUtil.createSimpleRepository();
-        const sig = repo.defaultSignature();
+        const sig = yield repo.defaultSignature();
 
         // Create the base repo for the submodule and add a couple of
         // commits.
@@ -1217,7 +1217,7 @@ describe("readRAST", function () {
 
     it("merge commit with ignored submodule change", co.wrap(function *() {
         const repo = yield TestUtil.createSimpleRepository();
-        const sig = repo.defaultSignature();
+        const sig = yield repo.defaultSignature();
 
         // Create the base repo for the submodule and add a couple of
         // commits.
@@ -1372,7 +1372,7 @@ describe("readRAST", function () {
         const head = yield r.getHeadCommit();
         const headId = head.id();
 
-        const sig = r.defaultSignature();
+        const sig = yield r.defaultSignature();
 
         yield NodeGit.Note.create(r, "refs/notes/test",
                                   sig, sig, headId, "note", 0);
@@ -1688,7 +1688,7 @@ describe("readRAST", function () {
         yield index.addByPath("foobar");
         yield index.write();
         yield NodeGit.Stash.save(repo,
-                                 repo.defaultSignature(),
+                                 yield repo.defaultSignature(),
                                  "stash",
                                  NodeGit.Stash.FLAGS.INCLUDE_UNTRACKED);
         yield ReadRepoASTUtil.readRAST(repo);

--- a/node/test/util/repo_ast_test_util.js
+++ b/node/test/util/repo_ast_test_util.js
@@ -85,7 +85,7 @@ const makeClone = co.wrap(function *(repos, maps) {
     // Test framework expects a trailing '/' to support relative paths.
 
     const b = yield NodeGit.Clone.clone(aPath, bPath);
-    const sig = b.defaultSignature();
+    const sig = yield b.defaultSignature();
     const head = yield b.getHeadCommit();
     yield b.createBranch("foo", head.id(), 1, sig, "branch commit");
     yield b.checkoutBranch("foo");
@@ -265,7 +265,7 @@ Bmaster=1 origin/master`,
                 m: co.wrap(function *(repos) {
                     const x = repos.x;
                     const head = yield x.getHeadCommit();
-                    const sig = x.defaultSignature();
+                    const sig = yield x.defaultSignature();
                     yield repos.x.createBranch("foo", head, 0, sig);
                     throw new UserError("bad bad");
                 }),
@@ -293,7 +293,7 @@ Bmaster=1 origin/master`,
                     const x = repos.x;
                     const head = yield x.getHeadCommit();
                     const headStr = head.id().tostrS();
-                    const sig = x.defaultSignature();
+                    const sig = yield x.defaultSignature();
                     yield repos.x.createBranch(`foo-${headStr}`, head, 0, sig);
                 }),
                 e: "x=S",
@@ -316,7 +316,7 @@ Bmaster=1 origin/master`,
                     const x = repos.x;
                     const head = yield x.getHeadCommit();
                     const headStr = head.id().tostrS();
-                    const sig = x.defaultSignature();
+                    const sig = yield x.defaultSignature();
                     yield repos.x.createBranch(`foo-${headStr}`, head, 0, sig);
                 }),
                 e: "x=E:Bfoo-1=1",

--- a/node/test/util/stash_util.js
+++ b/node/test/util/stash_util.js
@@ -42,7 +42,7 @@ const RepoASTTestUtil = require("../../lib/util/repo_ast_test_util");
 
 const writeLog = co.wrap(function *(repo, reverseMap, logs) {
     const log = yield NodeGit.Reflog.read(repo, "refs/meta-stash");
-    const sig = repo.defaultSignature();
+    const sig = yield repo.defaultSignature();
     for(let i = 0; i < logs.length; ++i) {
         const logSha = logs[logs.length - (i + 1)];
         const sha = reverseMap[logSha];
@@ -160,7 +160,7 @@ x=E:Ci#i foo=bar,1=1;Cw#w foo=bar,1=1;Bi=i;Bw=w`,
                     const result = yield StashUtil.stashRepo(repo,
                                                              status,
                                                              includeUntracked);
-                    const sig = repo.defaultSignature();
+                    const sig = yield repo.defaultSignature();
                     const commitMap = {};
                     const commitAndBranch = co.wrap(function *(treeId, type) {
                         const tree = yield NodeGit.Tree.lookup(repo, treeId);

--- a/node/test/util/submodule_config_util.js
+++ b/node/test/util/submodule_config_util.js
@@ -652,7 +652,7 @@ foo
                                       newHead,
                                       NodeGit.Reset.TYPE.HARD);
             yield submodule.addFinalize();
-            const sig = repo.defaultSignature();
+            const sig = yield repo.defaultSignature();
             yield repo.createCommitOnHead([".gitmodules", subName],
                                           sig,
                                           sig,
@@ -803,7 +803,7 @@ foo
                                       newHead,
                                       NodeGit.Reset.TYPE.HARD);
             yield submodule.addFinalize();
-            const sig = repo.defaultSignature();
+            const sig = yield repo.defaultSignature();
             yield repo.createCommitOnHead([".gitmodules", "foo"],
                                           sig,
                                           sig,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -72,7 +72,7 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-argparse@, argparse@^1.0.7:
+argparse@^1.0.0, argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -145,13 +145,6 @@ bl@^1.0.0:
   dependencies:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
-
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  dependencies:
-    inherits "~2.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -664,16 +657,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fstream@^1.0.0, fstream@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
-  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
-  dependencies:
-    graceful-fs "^4.1.2"
-    inherits "~2.0.0"
-    mkdirp ">=0.5 0"
-    rimraf "2"
-
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -873,7 +856,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -1080,6 +1063,11 @@ lodash@^4.17.11, lodash@~4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
+lodash@^4.17.14:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 log-symbols@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -1158,6 +1146,14 @@ minipass@^2.2.1, minipass@^2.3.5:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^2.8.6:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minizlib@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
@@ -1165,7 +1161,7 @@ minizlib@^1.2.1:
   dependencies:
     minipass "^2.2.1"
 
-mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -1235,10 +1231,10 @@ mz@^2.6.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.11.1:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+nan@^2.14.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
+  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
 needle@^2.2.1:
   version "2.4.0"
@@ -1267,12 +1263,11 @@ node-environment-flags@1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-gyp@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
-  integrity sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==
+node-gyp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-4.0.0.tgz#972654af4e5dd0cd2a19081b4b46fe0442ba6f45"
+  integrity sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==
   dependencies:
-    fstream "^1.0.0"
     glob "^7.0.3"
     graceful-fs "^4.1.2"
     mkdirp "^0.5.0"
@@ -1282,13 +1277,13 @@ node-gyp@^3.8.0:
     request "^2.87.0"
     rimraf "2"
     semver "~5.3.0"
-    tar "^2.0.0"
+    tar "^4.4.8"
     which "1"
 
-node-pre-gyp@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
-  integrity sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==
+node-pre-gyp@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz#df9ab7b68dd6498137717838e4f92a33fc9daa42"
+  integrity sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -1313,17 +1308,17 @@ nodegit-promise@~4.0.0:
   dependencies:
     asap "~2.0.3"
 
-nodegit@^0.23.0:
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/nodegit/-/nodegit-0.23.1.tgz#937c2cc998bbed3cef0b138131fee3a2672458af"
-  integrity sha512-k1bCg260yZlmfLGYPrinqAQNbQ6PnBJhKq6wWfe94yIO3WnOOyoSuweAkAGPR6FhrGq2LkCKHdJaitwhKCEGyA==
+nodegit@^0.25.0:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/nodegit/-/nodegit-0.25.1.tgz#70b9d89e62cbc1153237a10a196e3228a669895b"
+  integrity sha512-j2kEd4jTraimRPKDX31DsLcfY9fWpcYG8zT0tiLVtN5jMm9fDFgn3WOQ+Nk+3NcBqxr4p5N5pZqNrCS0nGdTbg==
   dependencies:
     fs-extra "^7.0.0"
     json5 "^2.1.0"
-    lodash "^4.17.11"
-    nan "^2.11.1"
-    node-gyp "^3.8.0"
-    node-pre-gyp "^0.11.0"
+    lodash "^4.17.14"
+    nan "^2.14.0"
+    node-gyp "^4.0.0"
+    node-pre-gyp "^0.13.0"
     promisify-node "~0.3.0"
     ramda "^0.25.0"
     request-promise-native "^1.0.5"
@@ -1920,15 +1915,6 @@ tar-stream@^1.1.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
-  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
-  dependencies:
-    block-stream "*"
-    fstream "^1.0.12"
-    inherits "2"
-
 tar@^4:
   version "4.4.9"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.9.tgz#058fbb152f6fc45733e84585a40c39e59302e1b3"
@@ -1937,6 +1923,19 @@ tar@^4:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"
     minipass "^2.3.5"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
+
+tar@^4.4.8:
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.8.6"
     minizlib "^1.2.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"


### PR DESCRIPTION
Bump to pick up a few changes:
1. https://github.com/nodegit/nodegit/commit/6f665bc5439c2e853fb48dbaadaae577949b854a, aka get rid of the dependency on system libcurl4-gnutls-dev library.
2. https://github.com/nodegit/nodegit/commit/e3c95e14e169c94d139ff27110b06a407354f42d and https://github.com/nodegit/nodegit/commit/ab3f379970dc4c070c3b10c5098be17f7dc6ad9c, yarn compartibility.