### PR TITLE
avoid exceptions from calling git-meta checkout on unopened submodules

### DIFF
--- a/node/lib/util/checkout.js
+++ b/node/lib/util/checkout.js
@@ -601,7 +601,11 @@ function noSuchFileMessage(subName, path) {
 exports.checkoutFiles = co.wrap(function*(repo, options) {
     assert.instanceOf(repo, NodeGit.Repository);
     const resolvedPaths = options.resolvedPaths;
-    const subNames = Object.keys(resolvedPaths);
+
+    // Exception is thrown if we try to get repo info from unopened submodules
+    const openSubmodules = yield SubmoduleUtil.listOpenSubmodules(repo);
+    const subNames = Object.keys(resolvedPaths).filter(
+        subName => openSubmodules.includes(subName));
 
     let subCommits;
     let stage = 0;

--- a/node/lib/util/checkout.js
+++ b/node/lib/util/checkout.js
@@ -602,10 +602,13 @@ exports.checkoutFiles = co.wrap(function*(repo, options) {
     assert.instanceOf(repo, NodeGit.Repository);
     const resolvedPaths = options.resolvedPaths;
 
-    // Exception is thrown if we try to get repo info from unopened submodules
+    // Exception is thrown if we try to get repo info from unopened submodules.
+    // TODO: handle other use cases besides when a commit is not specified.
     const openSubmodules = yield SubmoduleUtil.listOpenSubmodules(repo);
-    const subNames = Object.keys(resolvedPaths).filter(
-        subName => openSubmodules.includes(subName));
+    const submodules = Object.keys(resolvedPaths);
+    const subNames = null === options.commit ?
+        submodules.filter(submodule => openSubmodules.includes(submodule)) :
+        submodules;
 
     let subCommits;
     let stage = 0;


### PR DESCRIPTION
Running git meta checkout throws an error if it's passed a path to an unopened submodule e.g.

```
~/P/g/foo [master]× » gm checkout -- .
Error: could not find repository from '/Users/kevintsui/Projects/git-meta/foo/au/gp/unm'
```

This change avoids this error by not applying the checkout operation to unopened submodules.