### PR TITLE
Show error when committing with -i and -a flags

### DIFF
--- a/node/lib/cmd/commit.js
+++ b/node/lib/cmd/commit.js
@@ -193,8 +193,8 @@ exports.executeableSubcommand = function (args) {
         process.exit(1);
     }
     if (args.all && args.interactive) {
-      console.error("The use of '-i' and '-a' does not make sense.");
-      process.exit(1);
+        console.error("The use of '-i' and '-a' does not make sense.");
+        process.exit(1);
     }
     if (args.amend) {
         return doAmend(args);                                         // RETURN

--- a/node/lib/cmd/commit.js
+++ b/node/lib/cmd/commit.js
@@ -192,6 +192,10 @@ exports.executeableSubcommand = function (args) {
         console.error("The use of '-i' and '-m' does not make sense.");
         process.exit(1);
     }
+    if (args.all && args.interactive) {
+      console.error("The use of '-i' and '-a' does not make sense.");
+      process.exit(1);
+    }
     if (args.amend) {
         return doAmend(args);                                         // RETURN
     }


### PR DESCRIPTION
Issue #711 shows that running `git meta commit -ia --amend --no-edit` causes an unhandled error. In vanilla git, the `-i` (interactive) and `-a` (all) options are not allowed together in the first place:

```
▶ git commit -ia
fatal: Only one of --include/--only/--all/--interactive/--patch can be used.
```

This PR adds a  check to the `commit` command's argument parsing to prevent `-i` and `-a` from being used together:

```
▶ gm commit -ia
The use of '-i' and '-a' does not make sense.
```

