### PR TITLE
Stop calling NodeGit.Branch.upstream on non-branches

### DIFF
--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -107,6 +107,9 @@ exports.findBranch = co.wrap(function *(repo, branchName) {
 exports.getTrackingInfo = co.wrap(function *(repo, branch) {
     assert.instanceOf(repo, NodeGit.Repository);
     assert.instanceOf(branch, NodeGit.Reference);
+    if (!branch.isBranch()) {
+        return null;
+    }
     let upstream;
     try {
         upstream = yield NodeGit.Branch.upstream(branch);


### PR DESCRIPTION
 (e.g. detached HEAD).  This apparently occasionally segfaults.