### PR TITLE
Reduce ref negotiation during stitching

### DIFF
--- a/node/lib/util/stitch_util.js
+++ b/node/lib/util/stitch_util.js
@@ -683,7 +683,7 @@ git notes --ref ${exports.allowedToFailNoteRef} add -m skip ${metaSha}`);
  * @param {String}              url
  * @param {[Object]}            subFetches
  */
-exports.fetchSubCommits = co.wrap(function *(repo, url, subFetches) {
+exports.fetchSubCommits = co.wrap(function *(repo, name, url, subFetches) {
     assert.instanceOf(repo, NodeGit.Repository);
     assert.isString(url);
     assert.isArray(subFetches);
@@ -694,7 +694,7 @@ exports.fetchSubCommits = co.wrap(function *(repo, url, subFetches) {
         const sha = fetch.sha;
         let fetched;
         try {
-            fetched = yield GitUtil.fetchSha(repo, subUrl, sha);
+            fetched = yield GitUtil.fetchSha(repo, subUrl, sha, name + "/");
         }
         catch (e) {
             console.log("Fetch of", subUrl, "failed:", e.message);
@@ -967,7 +967,7 @@ exports.stitch = co.wrap(function *(repoPath,
 (${i + 1}/${subNames.length}) -- fetched ${subFetches.length} SHAs for \
 ${name}`;
             console.time(fetchTimeMessage);
-            yield exports.fetchSubCommits(repo, url, subFetches);
+            yield exports.fetchSubCommits(repo, name, url, subFetches);
             console.timeEnd(fetchTimeMessage);
         });
         yield DoWorkQueue.doInParallel(subNames,

--- a/node/lib/util/stitch_util.js
+++ b/node/lib/util/stitch_util.js
@@ -40,7 +40,6 @@ const DoWorkQueue         = require("./do_work_queue");
 const GitUtil             = require("./git_util");
 const SubmoduleConfigUtil = require("./submodule_config_util");
 const SubmoduleUtil       = require("./submodule_util");
-const SyntheticBranchUtil = require("./synthetic_branch_util");
 const TreeUtil            = require("./tree_util");
 const UserError           = require("./user_error");
 
@@ -706,9 +705,6 @@ exports.fetchSubCommits = co.wrap(function *(repo, url, subFetches) {
 
         if (fetched) {
             console.log("Fetched:", sha, "from", subUrl);
-            const refName =
-                          SyntheticBranchUtil.getSyntheticBranchForCommit(sha);
-            yield NodeGit.Reference.create(repo, refName, sha, 1, "fetched");
         }
     }
 });

--- a/node/lib/util/stitch_util.js
+++ b/node/lib/util/stitch_util.js
@@ -399,7 +399,7 @@ exports.listSubmoduleChanges = co.wrap(function *(repo, commits) {
 });
 
 /**
- * Return a map from submodule name to shas to list of objects containing the
+ * Return a map from submodule name to list of objects containing the
  * fields:
  * - `metaSha` -- the meta-repo sha from which this subodule sha came
  * - `url`     -- url configured for the submodule
@@ -423,14 +423,12 @@ exports.listFetches = co.wrap(function *(repo,
                                          toFetch,
                                          commitChanges,
                                          keepAsSubmodule,
-                                         adjustPath,
-                                         numParallel) {
+                                         adjustPath) {
     assert.instanceOf(repo, NodeGit.Repository);
     assert.isArray(toFetch);
     assert.isObject(commitChanges);
     assert.isFunction(keepAsSubmodule);
     assert.isFunction(adjustPath);
-    assert.isNumber(numParallel);
 
     let urls = {};
 
@@ -964,8 +962,7 @@ exports.stitch = co.wrap(function *(repoPath,
                                                   commitsToStitch,
                                                   changes,
                                                   options.keepAsSubmodule,
-                                                  adjustPath,
-                                                  options.numParallel);
+                                                  adjustPath);
         console.log("Found", Object.keys(fetches).length, "subs to fetch.");
         const subNames = Object.keys(fetches);
         const doFetch = co.wrap(function *(name, i) {

--- a/node/lib/util/synthetic_branch_util.js
+++ b/node/lib/util/synthetic_branch_util.js
@@ -46,6 +46,7 @@ const assert = require("chai").assert;
 
 const NOTES_REF = "refs/notes/git-meta/subrepo-check";
 const SYNTHETIC_BRANCH_BASE = "refs/commits/";
+exports.SYNTHETIC_BRANCH_BASE = SYNTHETIC_BRANCH_BASE;
 
 /**
  * The identity function

--- a/node/test/util/stitch_util.js
+++ b/node/test/util/stitch_util.js
@@ -1105,21 +1105,18 @@ describe("listFetches", function () {
             state: "S",
             toFetch: [],
             keepAsSubmodule: () => false,
-            numParallel: 2,
             expected: {},
         },
         "a sub, not picked": {
             state: "S:C2-1 s=S/a:1;Bmaster=2",
             toFetch: ["1"],
             keepAsSubmodule: () => false,
-            numParallel: 2,
             expected: {},
         },
         "added sub": {
             state: "S:C2-1 s=S/a:1;Bmaster=2",
             toFetch: ["2"],
             keepAsSubmodule: () => false,
-            numParallel: 2,
             expected: {
                 "s": [
                     { metaSha: "2", url: "/a", sha: "1" },
@@ -1130,7 +1127,6 @@ describe("listFetches", function () {
             state: "S:C2-1 s=S/a:1;Bmaster=2",
             toFetch: ["2"],
             keepAsSubmodule: (name) => "s" === name,
-            numParallel: 2,
             expected: {},
         },
         "adjusted to null": {
@@ -1138,14 +1134,12 @@ describe("listFetches", function () {
             toFetch: ["2"],
             keepAsSubmodule: () => false,
             adjustPath: () => null,
-            numParallel: 2,
             expected: {},
         },
         "changed sub": {
             state: "S:Cx-1;Bx=x;C2-1 s=S/a:1;C3-2 s=S/a:x;Bmaster=3",
             toFetch: ["3"],
             keepAsSubmodule: () => false,
-            numParallel: 2,
             expected: {
                 "s": [
                     { metaSha: "3", url: "/a", sha: "x" },
@@ -1156,14 +1150,12 @@ describe("listFetches", function () {
             state: "S:Cx-1;Bx=x;C2-1 s=S/a:1;C3-2 s=S/a:x;Bmaster=3",
             toFetch: ["3"],
             keepAsSubmodule: (name) => "s" === name,
-            numParallel: 2,
             expected: {},
         },
         "two changes in a sub": {
             state: "S:Cx-1;Bx=x;C2-1 s=S/a:1;C3-2 s=S/a:x;Bmaster=3",
             toFetch: ["2", "3"],
             keepAsSubmodule: () => false,
-            numParallel: 2,
             expected: {
                 "s": [
                     { metaSha: "3", url: "/a", sha: "x" },
@@ -1190,8 +1182,7 @@ describe("listFetches", function () {
                                                         toFetch,
                                                         changes,
                                                         c.keepAsSubmodule,
-                                                        adjustPath,
-                                                        c.numParallel);
+                                                        adjustPath);
             function mapFetch(f) {
                 return {
                     url: f.url,

--- a/node/test/util/stitch_util.js
+++ b/node/test/util/stitch_util.js
@@ -1242,7 +1242,7 @@ describe("fetchSubCommits", function () {
                     };
                 });
                 const url = maps.reverseUrlMap[c.url];
-                yield StitchUtil.fetchSubCommits(x, url, fetches);
+                yield StitchUtil.fetchSubCommits(x, "x", url, fetches);
             });
             yield RepoASTTestUtil.testMultiRepoManipulator(c.input,
                                                            c.expected,


### PR DESCRIPTION
We turn off negotiation entirely the first time we fetch a submodule.  Thereafter, we only negotiate for refs from that submodule.

This contains two other minor changes: one removes an unused parameter and the other removes some useless code.