### PR TITLE
workAroundLibgit2MergeBug to skip creating synthetic ancestor if ance…

### DIFF
--- a/node/lib/util/cherry_pick_util.js
+++ b/node/lib/util/cherry_pick_util.js
@@ -282,10 +282,12 @@ const workAroundLibgit2MergeBug = co.wrap(function *(data, repo, name,
         for (const base of mergeBases) {
             const shas = yield SubmoduleUtil.getSubmoduleShasForCommit(
                 repo, [ours.path], base);
-            if (shas[name] !== undefined) {
-
+            const sha = shas[name];
+            // Avoid creating a synthetic ancestor with the same sha as
+            // theirs. See more in `SubmoduleChange`
+            if (sha !== undefined && sha !== theirs.id.tostrS()) {
                 ancestor = new NodeGit.IndexEntry();
-                ancestor.id = NodeGit.Oid.fromString(shas[name]);
+                ancestor.id = NodeGit.Oid.fromString(sha);
                 ancestor.mode = NodeGit.TreeEntry.FILEMODE.COMMIT;
                 ancestor.path = ours.path;
                 ancestor.flags = ours.flags;


### PR DESCRIPTION
…stor has the same sha as theirs.


In the [submoudle_change.js](https://github.com/twosigma/git-meta/blob/master/node/lib/util/submodule_change.js#L56), submodule change with same sha is forbidden, as I qoute:

```
    /**
     * Creat a new `Changed` object having the specified `oldSha` and `newSha`
     * values.  The behavior is undefined if `oldSha === newSha`
    ....
     */
    constructor(oldSha, newSha, ourSha) {
        assert.notEqual(oldSha, newSha);
```

However,  workAroundLibgit2MergeBug routine  can still create this "empty" change object with same newSha as the oldSha.

Let's add a logic to exlude that edge cases
