### PR TITLE
Consider the index when comparing the tree to worktree during a commit.

### DIFF
--- a/node/test/util/commit.js
+++ b/node/test/util/commit.js
@@ -3449,12 +3449,20 @@ describe("commit mid-merge", function() {
         const index = yield sRepo.index();
         const sEntry = index.getByIndex(1);
         const newEntry = new NodeGit.IndexEntry();
-        newEntry.flags = sEntry.flags;
+        // mask off the stage bits here, so that the new entry we write is
+        // in stage zero.
+        newEntry.flags = sEntry.flags & ~0x3000;
         newEntry.flagsExtended = sEntry.flagsExtended;
         newEntry.mode = sEntry.mode;
         newEntry.id = sEntry.id;
         newEntry.path = sEntry.path;
-
+        newEntry.fileSize = sEntry.fileSize;
+        newEntry.gid = 0;
+        newEntry.uid = 0;
+        newEntry.ino = 0;
+        newEntry.dev = 0;
+        newEntry.mtime = sEntry.mtime;
+        newEntry.ctime = sEntry.ctime;
         yield index.conflictCleanup();
         yield index.add(newEntry);
         yield index.write();

--- a/node/test/util/diff_util.js
+++ b/node/test/util/diff_util.js
@@ -375,7 +375,8 @@ x=S:C2-1 s=Sa:1;C3-2 s;Bmaster=3`,
             },
             "HEAD^ unmodified": {
                 input: `
-x=S:C2-1 README.md=3;W README.md=hello world;Bmaster=2`,
+x=S:C2-1 README.md=3;I README.md=hello world;W README.md=hello world;
+Bmaster=2`,
                 workdirToTree: true,
                 from: "HEAD^",
             },


### PR DESCRIPTION
It turns out that libgit2 has a function for that, which is good, because
the alternative involved much painful hacking of git_tree_to_workdir.