### PR TITLE
Fix hook chdir race

### DIFF
--- a/node/lib/util/hook.js
+++ b/node/lib/util/hook.js
@@ -73,11 +73,11 @@ exports.execHook = co.wrap(function*(repo, name, args=[], env={}) {
     }
 
     try {
-        process.chdir(repo.workdir());
         const subEnv = {};
         Object.assign(subEnv, process.env);
         Object.assign(subEnv, env);
-        yield spawn(absPath, args, { stdio: "inherit", env: subEnv });
+        yield spawn(absPath, args, { stdio: "inherit", env: subEnv,
+                                     cwd: repo.workdir()});
         return true;
     } catch (e) {
         if (e.code === "EACCES") {


### PR DESCRIPTION
Instead of running chdir in the parent process before running the
hooks, pass the cwd arg to spawn.  This eliminates a race condition
where perhaps one chdir happens, and then a different submodule's
chdir happens, and then the first submodule's hooks get run out of the
second submodule.