### PR TITLE
in open.js, get list of all submodules from index instead of commit

### DIFF
--- a/node/lib/cmd/open.js
+++ b/node/lib/cmd/open.js
@@ -187,7 +187,7 @@ exports.executeableSubcommand = co.wrap(function *(args) {
 
     const {commit, index} = yield getCommitAndIndex(repo, args.c);
     
-    const subs = yield SubmoduleUtil.getSubmoduleNamesForCommit(repo, commit);
+    const subs = yield SubmoduleConfigUtil.getSubmodulesFromIndex(repo, index);
     
     const paths = yield parseArgs(repo, args, commit);
     const subsToOpen = yield SubmoduleUtil.resolveSubmodules(workdir,


### PR DESCRIPTION
this is to be consistent with previous behavior. 

When a submodule is created:
1. get list of subs from index can contain the new submodule
2. get the list from HEAD commit won't include the submodule

