### PR TITLE
Make hooks work with hooksPath config

### DIFF
--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -227,7 +227,7 @@ const runPreCommitHook = co.wrap(function *(repo, index) {
 
     let release = null;
     try {
-        if (Hook.hasHook(repo, "pre-commit")) {
+        if (yield Hook.hasHook(repo, "pre-commit")) {
             release = yield mutex.acquire();
             const isOk = yield Hook.execHook(repo, "pre-commit", [],
                                              { GIT_INDEX_FILE: tempIndexPath});

--- a/node/lib/util/git_util.js
+++ b/node/lib/util/git_util.js
@@ -805,7 +805,7 @@ Please supply the message using the -m option.`);
 
     }
 
-    if (runHooks && Hook.hasHook(repo, "commit-msg")) {
+    if (runHooks && (yield Hook.hasHook(repo, "commit-msg"))) {
         const isOk = yield Hook.execHook(repo, "commit-msg", [messagePath]);
 
         if (!isOk) {


### PR DESCRIPTION
From [git hooks](https://git-scm.com/docs/githooks) documentation:
> By default the hooks directory is `$GIT_DIR/hooks`, but that can be changed via the `core.hooksPath` configuration variable

The changes in this PR made git-meta honor the core.hooksPath variable.