### PR TITLE
Improve logging to list unconverted ancestors of given commit SHA

### DIFF
--- a/node/lib/util/stitch_util.js
+++ b/node/lib/util/stitch_util.js
@@ -873,6 +873,8 @@ exports.listCommitsToStitch = co.wrap(function *(repo,
     }
     const commitShas = exports.listCommitsInOrder(commit.id().tostrS(),
                                                   allParents);
+    console.log(`listing all ${commitShas.length} unconverted ancestors of ` +
+                `${commit.id.tostrS()}: ${commitShas}`);
     return commitShas.map(sha => commitMap[sha]);
 });
 


### PR DESCRIPTION
Previously, stitch_util.js was logging the message `listing all unconverted ancestors of {commit_sha}`, but the unconverted ancestors weren't actually being logged. This PR puts the unconverted ancestors in the log and also logs how many unconverted ancestors there are.