### PR TITLE
Adjust git-meta status output to be closer to regular git output:

### DIFF
--- a/node/lib/util/commit.js
+++ b/node/lib/util/commit.js
@@ -290,10 +290,11 @@ with '#' will be ignored, and an empty message aborts the commit.
 `;
 
 function branchStatusLine(status) {
+    // Simulate some of what base git's wt-status.c does
     if (null !== status.currentBranchName) {
-        return `On branch ${status.currentBranchName}.\n`;
+        return `On branch ${status.currentBranchName}\n`;
     }
-    return `On detached head ${GitUtil.shortSha(status.headCommit)}.\n`;
+    return `HEAD detached at ${GitUtil.shortSha(status.headCommit)}\n`;
 }
 
 /**

--- a/node/lib/util/print_status_util.js
+++ b/node/lib/util/print_status_util.js
@@ -384,14 +384,15 @@ A ${command} is in progress.
  * @return {String>
  */
 exports.printCurrentBranch = function (status) {
+    // Simulate some of what base git's wt-status.c does
     if (null !== status.currentBranchName) {
-        return `On branch ${colors.green(status.currentBranchName)}.\n`;
+        return `On branch ${colors.green(status.currentBranchName)}\n`;
     }
     if (status.headCommit === null) {
         return `No commits yet\n`;
     }
     return `\
-On detached head ${colors.red(GitUtil.shortSha(status.headCommit))}.\n`;
+HEAD detached at ${colors.red(GitUtil.shortSha(status.headCommit))}\n`;
 };
 
 /**

--- a/node/test/util/commit.js
+++ b/node/test/util/commit.js
@@ -328,7 +328,7 @@ Untracked files:
 
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
-# On branch master.
+# On branch master
 # Changes to be committed:
 # \tnew file:     foo
 #
@@ -346,7 +346,7 @@ Untracked files:
 
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
-# On detached head afafaf.
+# HEAD detached at afafaf
 # Changes to be committed:
 # \tnew file:     foo
 #
@@ -1725,7 +1725,7 @@ my message
 #
 # Date:      12/31/1969, 23:00:03 -100
 #
-# On branch a-branch.
+# On branch a-branch
 # Changes to be committed:
 # \tnew file:     bam/baz
 #
@@ -1748,7 +1748,7 @@ my message
 #
 # Date:      12/31/1969, 23:00:03 -100
 #
-# On branch a-branch.
+# On branch a-branch
 # Changes to be committed:
 # \tnew file:     baz
 #
@@ -2644,7 +2644,7 @@ x=S:C2-1 q/r/s=Sa:1;Bmaster=2;Oq/r/s H=a`,
 
 # <*> enter meta-repo message above this line; delete this line to commit \
 only submodules
-# On branch master.
+# On branch master
 #
 # Please enter the commit message(s) for your changes.  The message for a
 # repo will be composed of all lines not beginning with '#' that come before
@@ -2666,7 +2666,7 @@ hiya
 only submodules
 # Date:      12/31/1969, 23:00:03 -100
 #
-# On branch master.
+# On branch master
 #
 # Please enter the commit message(s) for your changes.  The message for a
 # repo will be composed of all lines not beginning with '#' that come before
@@ -2688,7 +2688,7 @@ only submodules
 
 # <*> enter meta-repo message above this line; delete this line to commit \
 only submodules
-# On branch foo.
+# On branch foo
 # Changes to be committed:
 # \tnew file:     baz
 #
@@ -2717,7 +2717,7 @@ only submodules
 
 # <*> enter meta-repo message above this line; delete this line to commit \
 only submodules
-# On branch foo.
+# On branch foo
 # Changes to be committed:
 # \tmodified:     bar (submodule, new commits)
 #
@@ -2755,7 +2755,7 @@ only submodules
 
 # <*> enter meta-repo message above this line; delete this line to commit \
 only submodules
-# On branch foo.
+# On branch foo
 #
 # Please enter the commit message(s) for your changes.  The message for a
 # repo will be composed of all lines not beginning with '#' that come before
@@ -2791,7 +2791,7 @@ only submodules
 
 # <*> enter meta-repo message above this line; delete this line to commit \
 only submodules
-# On branch foo.
+# On branch foo
 # -----------------------------------------------------------------------------
 
 # <bar> enter message for 'bar' above this line; delete this line to skip \
@@ -2836,7 +2836,7 @@ committing 'bar'
 
 # <*> enter meta-repo message above this line; delete this line to commit \
 only submodules
-# On branch foo.
+# On branch foo
 # -----------------------------------------------------------------------------
 yoyoyo
 # <bar> enter message for 'bar' above this line; delete this line to skip \
@@ -2888,7 +2888,7 @@ yoyoyo
 only submodules
 # Date:      12/31/1969, 23:00:03 -100
 #
-# On branch foo.
+# On branch foo
 # -----------------------------------------------------------------------------
 
 # <bar> enter message for 'bar' above this line; delete this line to skip \

--- a/node/test/util/print_status_util.js
+++ b/node/test/util/print_status_util.js
@@ -724,7 +724,7 @@ A merge is in progress.
                     currentBranchName: "master",
                 }),
                 exact: `\
-On branch ${colors.green("master")}.
+On branch ${colors.green("master")}
 nothing to commit, working tree clean
 `,
                 shortExact: "\n",
@@ -741,7 +741,7 @@ nothing to commit, working tree clean
                     }),
                 }),
                 exact: `\
-On branch ${colors.green("master")}.
+On branch ${colors.green("master")}
 A rebase is in progress.
   (after resolving conflicts mark the corrected paths
    with 'git meta add', then run "git meta rebase --continue")
@@ -827,7 +827,7 @@ ${colors.green("M")}${colors.red("M")} qrst/x/y/z
                     workdir: { foo: FILESTATUS.ADDED },
                 }),
                 exact: `\
-On branch ${colors.green("master")}.
+On branch ${colors.green("master")}
 Untracked files:
   (use "git meta add <file>..." to include in what will be committed)
 
@@ -848,7 +848,7 @@ Untracked files:
                     },
                 }),
                 exact: `\
-On branch ${colors.green("master")}.
+On branch ${colors.green("master")}
 Changes to be committed:
   (use "git meta reset HEAD <file>..." to unstage)
 


### PR DESCRIPTION
Drop trailing period for "On branch foo", and use "HEAD detached at foo" phrasing.