### PR TITLE
Fix broken test on newer Node.js versions

### DIFF
--- a/node/test/util/submodule_util.js
+++ b/node/test/util/submodule_util.js
@@ -368,7 +368,7 @@ describe("SubmoduleUtil", function () {
             const repo = yield TestUtil.createSimpleRepository();
             const url =
                       "/Users/peabody/repos/git-meta-demo/scripts/demo/z-bare";
-            SubmoduleConfigUtil.initSubmodule(repo.workdir(), "z", url);
+            SubmoduleConfigUtil.initSubmodule(repo.path(), "z", url);
             const openSubs = yield SubmoduleUtil.listOpenSubmodules(repo);
             assert.deepEqual(openSubs, []);
         }));


### PR DESCRIPTION
This test has always been broken, but in older versions of Node, it didn't report a failure, because unhandled promise rejections didn't cause a test failure:

```
  SubmoduleUtil
    listOpenSubmodules
      ✓ listOpenSubmodules-missing (59ms)
(node:1506) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open '/tmp/git-meta-test202231-1506-r2maox.wm1g/config'
    at Object.fs.openSync (fs.js:646:18)
    at Object.fs.readFileSync (fs.js:551:33)
    at Object.<anonymous> (/root/git-meta2/node/lib/util/submodule_config_util.js:102:27)
    at Generator.next (<anonymous>)
    at onFulfilled (/root/git-meta2/node/node_modules/co/index.js:65:19)
    at /root/git-meta2/node/node_modules/co/index.js:54:5
    at new Promise (<anonymous>)
    at Object.co (/root/git-meta2/node/node_modules/co/index.js:50:10)
    at Object.createPromise [as clearSubmoduleConfigEntry] (/root/git-meta2/node/node_modules/co/index.js:30:15)
    at Object.<anonymous> (/root/git-meta2/node/lib/util/submodule_config_util.js:494:19)
    at Generator.next (<anonymous>)
    at onFulfilled (/root/git-meta2/node/node_modules/co/index.js:65:19)
    at /root/git-meta2/node/node_modules/co/index.js:54:5
    at new Promise (<anonymous>)
    at Object.co (/root/git-meta2/node/node_modules/co/index.js:50:10)
    at Object.createPromise [as initSubmodule] (/root/git-meta2/node/node_modules/co/index.js:30:15)
    at Context.<anonymous> (/root/git-meta2/node/test/util/submodule_util.js:371:33)
    at Generator.next (<anonymous>)
    at onFulfilled (/root/git-meta2/node/node_modules/co/index.js:65:19)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
(node:1506) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:1506) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Since Node.js v15 this causes an actual test failure. GitHub CI uses Node.js v16.