### PR TITLE
Do not GC repos under test (fixes #864)

### DIFF
--- a/node/lib/util/write_repo_ast_util.js
+++ b/node/lib/util/write_repo_ast_util.js
@@ -773,11 +773,6 @@ exports.writeMultiRAST = co.wrap(function *(repos, rootDirectory) {
 
         // Then set up the rest of the repository.
         yield configureRepo(repo, ast, commitMaps.oldToNew, treeCache);
-        const cleanupString = `\
-git -C '${repo.path()}' -c gc.reflogExpire=0 -c gc.reflogExpireUnreachable=0 \
--c gc.rerereresolved=0 -c gc.rerereunresolved=0 \
--c gc.pruneExpire=now gc`;
-        yield exec(cleanupString);
     });
 
     // Now generate the actual repos.


### PR DESCRIPTION
This is probably not a very fulfilling fix, but it addresses the issue
that for at least one of the test cases involving a rebase, the commit
that is recorded as the starting point of the rebase exists in the
submodule's remote but not in the non-bare submodule.

Since WriteRepoASTUtil is only used from either test code or
test-oriented utilities (generate-repos and write-repo), it seems safe
to skip the GC.

Arguably, this points to a real bug somewhere if this commit is unrooted
and therefore prone to being GC'd, but I think that bug is lives
entirely within the repo AST stuff (in generating a repo that's in the
middle of a rebase), so this probably does not paper over a problem that
could impact real git-meta users.