### PR TITLE
cherry-pick: added extra info on conflict next steps (also applies to rebase)

### DIFF
--- a/node/lib/util/rebase_util.js
+++ b/node/lib/util/rebase_util.js
@@ -134,7 +134,7 @@ exports.runRebase = co.wrap(function *(repo, seq) {
         const sha = nextSeq.commits[i];
         const commit = yield repo.getCommit(sha);
         SubmoduleRebaseUtil.logCommit(commit);
-        const cherryResult = yield CherryPickUtil.rewriteCommit(repo, commit);
+        const cherryResult = yield CherryPickUtil.rewriteCommit(repo, commit, "rebase");
         if (null !== cherryResult.newMetaCommit) {
             result.metaCommits[cherryResult.newMetaCommit] = sha;
         }


### PR DESCRIPTION
Implemented change that displayed extra information on next steps to take when facing a conflict when utilizing cherry-pick/rebase `git meta cherry-pick --continue` or `git meta cherry-pick --abort`