### PR TITLE
Elaborated on Cherry-Pick and Rebase Error Messages + Updated Tests for Cherry-Pick and Rebase

### DIFF
--- a/node/lib/util/rebase_util.js
+++ b/node/lib/util/rebase_util.js
@@ -134,7 +134,8 @@ exports.runRebase = co.wrap(function *(repo, seq) {
         const sha = nextSeq.commits[i];
         const commit = yield repo.getCommit(sha);
         SubmoduleRebaseUtil.logCommit(commit);
-        const cherryResult = yield CherryPickUtil.rewriteCommit(repo, commit);
+        const cherryResult = yield CherryPickUtil.rewriteCommit(repo, commit, 
+            "rebase");
         if (null !== cherryResult.newMetaCommit) {
             result.metaCommits[cherryResult.newMetaCommit] = sha;
         }

--- a/node/test/util/cherry_pick_util.js
+++ b/node/test/util/cherry_pick_util.js
@@ -744,7 +744,10 @@ a
 `,
             errorMessage: `\
 Submodule ${colors.red("s")} is conflicted.
-`,
+        A testCommand is in progress.
+        (after resolving conflicts mark the corrected paths
+        with 'git meta add', then run "git meta testCommand --continue")
+        (use "git meta testCommand --abort" to check out the original branch)`,
         },
         "conflict in a sub pick, success in another": {
             input: `
@@ -762,7 +765,10 @@ a
 `,
             errorMessage: `\
 Submodule ${colors.red("s")} is conflicted.
-`,
+        A testCommand is in progress.
+        (after resolving conflicts mark the corrected paths
+        with 'git meta add', then run "git meta testCommand --continue")
+        (use "git meta testCommand --abort" to check out the original branch)`,
         },
     };
     Object.keys(cases).forEach(caseName => {
@@ -773,7 +779,8 @@ Submodule ${colors.red("s")} is conflicted.
             assert.property(reverseCommitMap, "8");
             const eightCommitSha = reverseCommitMap["8"];
             const eightCommit = yield x.getCommit(eightCommitSha);
-            const result  = yield CherryPickUtil.rewriteCommit(x, eightCommit);
+            const result  = yield CherryPickUtil.rewriteCommit(x, eightCommit,
+                "testCommand");
             assert.equal(result.errorMessage, c.errorMessage || null);
             return mapCommits(maps, result);
         });
@@ -836,7 +843,10 @@ a
 `,
             errorMessage: `\
 Submodule ${colors.red("s")} is conflicted.
-`,
+        A cherry-pick is in progress.
+        (after resolving conflicts mark the corrected paths
+        with 'git meta add', then run "git meta cherry-pick --continue")
+        (use "git meta cherry-pick --abort" to check out the original branch)`,
         },
     };
 

--- a/node/test/util/rebase_util.js
+++ b/node/test/util/rebase_util.js
@@ -369,7 +369,10 @@ t
 ;`,
             errorMessage: `\
 Submodule ${colors.red("s")} is conflicted.
-`,
+        A rebase is in progress.
+        (after resolving conflicts mark the corrected paths
+        with 'git meta add', then run "git meta rebase --continue")
+        (use "git meta rebase --abort" to check out the original branch)`,
         },
         "does not close open submodules when rewinding": {
             initial: `


### PR DESCRIPTION
I elaborated on cherry-pick and rebase error messages to include next steps when running into a conflict e.g.  `git meta cherry-pick --abort` or `git meta cherry-pick --continue `. After this, I also updated particular tests relating to cherry-pick and rebase to reflect these changes.