### PR TITLE
Add no-commit option to cherry-pick

### DIFF
--- a/node/lib/cmd/cherry_pick.js
+++ b/node/lib/cmd/cherry_pick.js
@@ -71,7 +71,8 @@ exports.configureParser = function (parser) {
     parser.addArgument(["-n", "--no-commit"], {
         action: "storeConst",
         constant: true,
-        help: "applies the changes necessary without making any commits",
+        help: `cherry-picked commits are followed by a soft reset, leaving all
+         changes as staged instead of as commits.`,
     }); 
     // TODO: Note that ideally we might do something similar to
     // `git reset --merge`, but that would be (a) tricky and (b) it can fail,

--- a/node/lib/cmd/cherry_pick.js
+++ b/node/lib/cmd/cherry_pick.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Two Sigma Open Source
+ * Copyright (c) 2022, Two Sigma Open Source
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,6 +68,11 @@ exports.configureParser = function (parser) {
         constant: true,
         help: "continue an in-progress cherry-pick",
     });
+    parser.addArgument(["-n", "--no-commit"], {
+        action: "storeConst",
+        constant: true,
+        help: "applies the changes necessary without making any commits",
+    }); 
     // TODO: Note that ideally we might do something similar to
     // `git reset --merge`, but that would be (a) tricky and (b) it can fail,
     // leaving the cherry-pick still in progress.
@@ -139,6 +144,11 @@ Could not resolve ${colors.red(commitish)} to a commit.`);
  * @param {String[]} args.commit
  */
 exports.executeableSubcommand = co.wrap(function *(args) {
+    const path            = require("path");
+    const Reset           = require("../util/reset");
+    const Hook            = require("../util/hook");
+    const StatusUtil      = require("../util/status_util");
+    const PrintStatusUtil = require("../util/print_status_util");
     const CherryPickUtil  = require("../util/cherry_pick_util");
 
     const repo = yield GitUtil.getCurrentRepo();
@@ -177,5 +187,20 @@ exports.executeableSubcommand = co.wrap(function *(args) {
 
     if (null !== result.errorMessage) {
         throw new UserError(result.errorMessage);
+    }
+
+    if (args.no_commit) {
+        const commitish = `HEAD~${commits.length}`
+        const annotated = yield GitUtil.resolveCommitish(repo, commitish);
+        const commit = yield repo.getCommit(annotated.id());
+        yield Reset.reset(repo, commit, Reset.TYPE.SOFT);
+
+        const repoStatus = yield StatusUtil.getRepoStatus(repo);
+        const cwd = process.cwd();
+        const relCwd = path.relative(repo.workdir(), cwd);
+        const statusText = PrintStatusUtil.printRepoStatus(repoStatus, relCwd);
+        process.stdout.write(statusText);
+
+        yield Hook.execHook(repo, "post-reset");
     }
 });

--- a/node/lib/cmd/cherry_pick.js
+++ b/node/lib/cmd/cherry_pick.js
@@ -191,7 +191,7 @@ exports.executeableSubcommand = co.wrap(function *(args) {
     }
 
     if (args.no_commit) {
-        const commitish = `HEAD~${commits.length}`
+        const commitish = `HEAD~${commits.length}`;
         const annotated = yield GitUtil.resolveCommitish(repo, commitish);
         const commit = yield repo.getCommit(annotated.id());
         yield Reset.reset(repo, commit, Reset.TYPE.SOFT);


### PR DESCRIPTION
This PR is related to #703 

This is a hack-day contribution and is not done in an elegant way, but I believe it's functional

In order to implement `--no-commit` cleanly, I think we would need to refactor `computeChanges()` in `cherry_pick_utils.js`. It currently only supports computing changes between two commits. But if it were able to compute changes between the index and a target commit, then we could keep applying changes to the index without needing to commit them.

The way things stand in the code right now, in order to do subsequent cherry-picks, I would need each intermediate state to be fully committed and with a clean working directory. Thus, the fastest way I saw to work around this was to let cherry-pick perform all the necessary commits, but then soft reset them.

In essence, this PR's `git meta cherry-pick --no-commit` is equivalent to:
```
git meta cherry-pick sha1 sha2 ... shaN
git meta reset --soft HEAD~N
```