### PR TITLE
implement git meta add verbose flag

### DIFF
--- a/node/lib/cmd/add.js
+++ b/node/lib/cmd/add.js
@@ -68,6 +68,14 @@ exports.configureParser = function (parser) {
         defaultValue:false
     });
 
+    parser.addArgument(["-v", "--verbose"], {
+        required: false,
+        action: "storeConst",
+        constant: true,
+        help: `Log which files are added to / removed from the index`,
+        defaultValue: false,
+    });
+
     parser.addArgument(["--meta"], {
         required: false,
         action: "storeConst",
@@ -77,6 +85,7 @@ Include changes to the meta-repo; disabled by default to improve performance \
 and avoid accidental changes to the meta-repo.`,
         defaultValue: false,
     });
+
     parser.addArgument(["paths"], {
         nargs: "*",
         type: "string",
@@ -131,5 +140,5 @@ exports.executeableSubcommand = co.wrap(function *(args) {
             return GitUtil.resolveRelativePath(workdir, cwd, filename);
         });
     }
-    yield Add.stagePaths(repo, userPaths, args.meta, args.update);
+    yield Add.stagePaths(repo, userPaths, args.meta, args.update, args.verbose);
 });

--- a/node/lib/util/add.js
+++ b/node/lib/util/add.js
@@ -56,7 +56,7 @@ const UserError          = require("./user_error");
  * @param {NodeGit.Repository} repo
  * @param {String []}          paths
  */
-exports.stagePaths = co.wrap(function *(repo, paths, stageMetaChanges, update) {
+exports.stagePaths = co.wrap(function *(repo, paths, stageMetaChanges, update, verbose) {
     assert.instanceOf(repo, NodeGit.Repository);
     assert.isArray(paths);
     assert.isBoolean(stageMetaChanges);
@@ -88,12 +88,21 @@ exports.stagePaths = co.wrap(function *(repo, paths, stageMetaChanges, update) {
             yield Object.keys(workdir).map(filename => {
                 // if -u flag is provided, update tracked files only.
                 if (RepoStatus.FILESTATUS.REMOVED === workdir[filename]) {
+                    if (verbose) {
+                        process.stdout.write(`${name}: remove '${filename}'\n`)
+                    }
                     return index.removeByPath(filename);
                 } else if (update) {
                     if (RepoStatus.FILESTATUS.ADDED !== workdir[filename]) {
+                        if (verbose) {
+                            process.stdout.write(`${name}: add '${filename}'\n`)
+                        }
                        return index.addByPath(filename);
                     }
                 } else {
+                    if (verbose) {
+                        process.stdout.write(`${name}: add '${filename}'\n`)
+                    }
                     return index.addByPath(filename);
                 }
             });
@@ -104,6 +113,9 @@ exports.stagePaths = co.wrap(function *(repo, paths, stageMetaChanges, update) {
             yield Object.keys(staged).map(co.wrap(function *(filename) {
                 const change = staged[filename];
                 if (change instanceof RepoStatus.Conflict) {
+                    if (verbose) {
+                        process.stdout.write(`${name}: add '${filename}'\n`)
+                    }
                     yield index.addByPath(filename);
                 }
             }));


### PR DESCRIPTION
Implement `git meta add -v ...`

Example:
```
georgeli@lhs:~/dev/test$ $HOME/dev/gitmeta/ext/public/twosigma/gitmeta2/bin/git-meta status
On branch master.
Changes not staged for commit:
  (use "git meta add <file>..." to update what will be committed)
  (commit or discard the untracked or modified content in submodules)
 
        modified:     ext/public/twosigma/gitmeta2/node/lib/patch-tree.js
        deleted:      ts/sdlc/trygit/georgeli
        modified:     ts/sdlc/trygit/gobisa
 
Untracked files:
  (use "git meta add <file>..." to include in what will be committed)
 
        ext/public/twosigma/gitmeta2/node/newfile
 
georgeli@lhs:~/dev/test$ $HOME/dev/gitmeta/ext/public/twosigma/gitmeta2/bin/git-meta add --help
usage: git-meta add [-h] [-u] [-v] [--meta] [paths [paths ...]]

 
This command updates the (logical) mono-repo index using the current content
found in the working tree, to prepare the content staged for the next commit.
If a path is specified, this command will stage all modified content in the
meta-repo and submodules rooted in that path. Note that the index of a
mono-repo is a logical construct derived from the state of the indices of its
meta-repo and open submodules. Thus, content that is staged in a submodule is
added to the index for that submodule; the index of the meta-repo is not
affected. Note also that from the perspective of the mono-repo, the status of
a submodule in the index is irrelevant: 'git meta commit' always stages
changes to submodules with new commits in their working directories.

Positional arguments:
  paths          the paths to add

Optional arguments:
  -h, --help     Show this help message and exit.
  -u, --update   Update tracked files.
  -v, --verbose  Log all files are updated / added to / removed from index
  --meta         Include changes to the meta-repo; disabled by default to
                 improve performance and avoid accidental changes to the
                 meta-repo.
georgeli@lhs:~/dev/test$ $HOME/dev/gitmeta/ext/public/twosigma/gitmeta2/bin/git-meta add . -v

ext/public/twosigma/gitmeta2: add 'node/lib/patch-tree.js'
ext/public/twosigma/gitmeta2: add 'node/newfile'
ts/sdlc/trygit: remove 'georgeli'
ts/sdlc/trygit: add 'gobisa'
georgeli@lhs:~/dev/test$ gitm status

On branch master.
Changes to be committed:
  (use "git meta reset HEAD <file>..." to unstage)

        modified:     ext/public/twosigma/gitmeta2/node/lib/patch-tree.js
        new file:     ext/public/twosigma/gitmeta2/node/newfile
        deleted:      ts/sdlc/trygit/georgeli
        modified:     ts/sdlc/trygit/gobisa
```