### PR TITLE
Force using latest node-gyp for nodegit, for Python 3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 jobs:
   Test-Git-Meta:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: sudo apt-get install libkrb5-dev

--- a/node/package.json
+++ b/node/package.json
@@ -43,6 +43,9 @@
     "rimraf": "",
     "split": ""
   },
+  "resolutions": {
+    "nodegit/node-gyp": "9.3.1"
+  },
   "devDependencies": {
     "deepcopy": "",
     "istanbul": "",


### PR DESCRIPTION
The most recent stable release of nodegit still depends on node-gyp ^4,
which doesn't have Python 3 support. More recent versions support Python
3 and even drop Python 2. Until a non-alpha release of nodegit 0.28 is
out, we can just override the dependency resolution, which seems to work
fine. (Upstream nodegit did not make any interesting code changes when
upgrading their node-gyp dependency.)